### PR TITLE
Migrate email IMAP from imap 2.4.1 to async-imap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ All notable changes to Keel.
 
 ## [Unreleased]
 
-%%TAGLINE%% update this line before releasing — one sentence summary of the release
+%%TAGLINE%% Email IMAP moved to a maintained async client, clearing a future-Rust-incompatibility warning.
+
+### Changed
+
+- **Email IMAP now uses the maintained `async-imap` client.** The runtime previously depended on `imap 2.4.1`, which transitively pinned `imap-proto 0.10.2` — a crate that emitted a future-incompatibility warning (`trailing semicolon in macro used in expression position`, [rust#79813](https://github.com/rust-lang/rust/issues/79813)) and is slated to become a hard error in a future Rust release. `Email.fetch` and `Email.archive` now run on `async-imap 0.11` (with `async-native-tls`), which tracks the current `imap-proto 0.16`, so the warning is gone. The IMAP calls now run natively on the async interpreter instead of `tokio::task::spawn_blocking`. No language-surface change: `Email.fetch`, `Email.send`, and `Email.archive` behave exactly as before.
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,10 +119,74 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayvec"
-version = "0.5.2"
+name = "async-channel"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "async-imap"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a78dceaba06f029d8f4d7df20addd4b7370a30206e3926267ecda2915b0f3f66"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-compression",
+ "base64",
+ "bytes",
+ "chrono",
+ "futures",
+ "imap-proto",
+ "log",
+ "nom 7.1.3",
+ "pin-project",
+ "pin-utils",
+ "self_cell",
+ "stop-token",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
+name = "async-native-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9343dc5acf07e79ff82d0c37899f079db3534d99f189a1837c8e549c99405bec"
+dependencies = [
+ "native-tls",
+ "thiserror 1.0.69",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "async-trait"
@@ -236,12 +300,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -272,12 +330,6 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
-
-[[package]]
-name = "bufstream"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40e38929add23cdf8a366df9b0e088953150724bcbe5fc330b0d8eb3b328eec8"
 
 [[package]]
 name = "bumpalo"
@@ -416,6 +468,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,6 +526,21 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
@@ -521,7 +613,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9298e6504d9b9e780ed3f7dfd43a61be8cd0e09eb07f7706a945b0072b6670b6"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "memchr",
 ]
 
@@ -569,6 +661,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener 5.4.1",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -602,6 +721,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -657,6 +786,7 @@ checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -678,6 +808,17 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -955,7 +1096,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1108,28 +1249,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "imap"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c617c55def8c42129e0dd503f11d7ee39d73f5c7e01eff55768b3879ff1d107d"
-dependencies = [
- "base64 0.13.1",
- "bufstream",
- "chrono",
- "imap-proto",
- "lazy_static",
- "native-tls",
- "nom 5.1.3",
- "regex",
-]
-
-[[package]]
 name = "imap-proto"
-version = "0.10.2"
+version = "0.16.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16a6def1d5ac8975d70b3fd101d57953fe3278ef2ee5d7816cba54b1d1dfc22f"
+checksum = "25f6af35c6a517aea5c72314abe90134980d2ae6a763809b50c208b3e429d71f"
 dependencies = [
- "nom 5.1.3",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -1203,7 +1328,6 @@ dependencies = [
  "colored",
  "csv",
  "glob",
- "imap",
  "keel-catalog",
  "keel-compiler",
  "keel-runtime",
@@ -1224,6 +1348,8 @@ dependencies = [
 name = "keel-runtime"
 version = "0.2.2"
 dependencies = [
+ "async-imap",
+ "async-native-tls",
  "axum",
  "chrono",
  "chrono-tz",
@@ -1231,15 +1357,14 @@ dependencies = [
  "csv",
  "fastrand",
  "fs2",
+ "futures",
  "getrandom 0.2.17",
  "glob",
- "imap",
  "keel-catalog",
  "keel-compiler",
  "keel-syntax",
  "lettre",
  "miette",
- "native-tls",
  "parking_lot",
  "regex",
  "reqwest",
@@ -1248,7 +1373,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -1280,7 +1405,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64",
  "email-encoding",
  "email_address",
  "fastrand",
@@ -1298,19 +1423,6 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "url",
-]
-
-[[package]]
-name = "lexical-core"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
-dependencies = [
- "arrayvec",
- "bitflags 1.3.2",
- "cfg-if",
- "ryu",
- "static_assertions",
 ]
 
 [[package]]
@@ -1460,12 +1572,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1519,13 +1638,12 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "5.1.3"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08959a387a676302eebf4ddbcbc611da04285579f76f88ee0506c63b1a61dd4b"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
- "lexical-core",
  "memchr",
- "version_check",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1617,6 +1735,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1688,6 +1812,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -1808,7 +1938,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1995,6 +2125,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "self_cell"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2105,6 +2241,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2152,10 +2294,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
+name = "stop-token"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+checksum = "af91f480ee899ab2d9f8435bfdfc14d08a5754bd9d3fef1f1a1c23336aad6c8b"
+dependencies = [
+ "async-channel 1.9.0",
+ "cfg-if",
+ "futures-core",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "strsim"
@@ -2277,11 +2425,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,9 @@ serde_json = "1"
 colored = "2"
 parking_lot = "0.12"
 tempfile = "3"
-imap = "2"
+async-imap = { version = "0.11", default-features = false, features = ["runtime-tokio"] }
+async-native-tls = { version = "0.5", default-features = false, features = ["runtime-tokio"] }
+futures = "0.3"
 regex = "1"
 glob = "0.3"
 csv = "1"
@@ -67,7 +69,6 @@ parking_lot = { workspace = true }
 [dev-dependencies]
 tempfile = { workspace = true }
 # Used only by the integration tests that exercise the email/csv/search namespaces.
-imap = { workspace = true }
 regex = { workspace = true }
 glob = { workspace = true }
 csv = { workspace = true }

--- a/crates/keel-runtime/Cargo.toml
+++ b/crates/keel-runtime/Cargo.toml
@@ -21,8 +21,9 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 colored = { workspace = true }
 lettre = { version = "0.11", features = ["tokio1-native-tls"] }
-imap = { workspace = true }
-native-tls = "0.2"
+async-imap = { workspace = true }
+async-native-tls = { workspace = true }
+futures = { workspace = true }
 chrono = "0.4"
 chrono-tz = "0.10"
 regex = { workspace = true }

--- a/crates/keel-runtime/src/runtime/email.rs
+++ b/crates/keel-runtime/src/runtime/email.rs
@@ -59,31 +59,49 @@ fn config_str<'a>(value: &'a Value, field: &str) -> Result<&'a str, String> {
     }
 }
 
-/// Fetch unread emails via IMAP. Returns a list of email maps.
-pub fn fetch_emails(conn: &EmailConnection) -> Result<Vec<Value>, String> {
-    let tls = native_tls::TlsConnector::builder()
-        .build()
-        .map_err(|e| format!("TLS error: {e}"))?;
-
-    let client = imap::connect((&conn.imap_host as &str, 993), &conn.imap_host, &tls)
+/// Open an authenticated IMAP session over TLS and `SELECT INBOX`.
+async fn open_inbox(conn: &EmailConnection) -> Result<ImapSession, String> {
+    let tcp = tokio::net::TcpStream::connect((conn.imap_host.as_str(), 993))
+        .await
         .map_err(|e| format!("IMAP connect failed ({}): {}", conn.imap_host, e))?;
+
+    let tls_stream = async_native_tls::TlsConnector::new()
+        .connect(conn.imap_host.as_str(), tcp)
+        .await
+        .map_err(|e| format!("IMAP TLS failed ({}): {}", conn.imap_host, e))?;
+
+    let client = async_imap::Client::new(tls_stream);
 
     let mut session = client
         .login(&conn.user, &conn.pass)
-        .map_err(|e| format!("IMAP login failed: {}", e.0))?;
+        .await
+        .map_err(|(e, _client)| format!("IMAP login failed: {e}"))?;
 
     session
         .select("INBOX")
+        .await
         .map_err(|e| format!("IMAP select INBOX: {e}"))?;
+
+    Ok(session)
+}
+
+type ImapSession = async_imap::Session<async_native_tls::TlsStream<tokio::net::TcpStream>>;
+
+/// Fetch unread emails via IMAP. Returns a list of email maps.
+pub async fn fetch_emails(conn: &EmailConnection) -> Result<Vec<Value>, String> {
+    use futures::StreamExt;
+
+    let mut session = open_inbox(conn).await?;
 
     let unseen = session
         .uid_search("UNSEEN")
+        .await
         .map_err(|e| format!("IMAP search: {e}"))?;
 
     let mut emails = Vec::new();
 
     if unseen.is_empty() {
-        session.logout().ok();
+        session.logout().await.ok();
         return Ok(emails);
     }
 
@@ -98,18 +116,23 @@ pub fn fetch_emails(conn: &EmailConnection) -> Result<Vec<Value>, String> {
         .collect::<Vec<_>>()
         .join(",");
 
-    let messages = session
-        .uid_fetch(&fetch_range, "(UID RFC822)")
-        .map_err(|e| format!("IMAP fetch: {e}"))?;
+    // The fetch stream borrows `session`; drain it inside a scope so the
+    // borrow is released before we log out.
+    {
+        let mut messages = session
+            .uid_fetch(&fetch_range, "(UID RFC822)")
+            .await
+            .map_err(|e| format!("IMAP fetch: {e}"))?;
 
-    for msg in messages.iter() {
-        if let Some(body) = msg.body() {
-            let parsed = parse_email(body, msg.uid);
-            emails.push(parsed);
+        while let Some(msg) = messages.next().await {
+            let msg = msg.map_err(|e| format!("IMAP fetch: {e}"))?;
+            if let Some(body) = msg.body() {
+                emails.push(parse_email(body, msg.uid));
+            }
         }
     }
 
-    session.logout().ok();
+    session.logout().await.ok();
 
     println!(
         "  {} Fetched {} email(s) via IMAP",
@@ -124,37 +147,44 @@ pub fn fetch_emails(conn: &EmailConnection) -> Result<Vec<Value>, String> {
 /// is read from `IMAP_ARCHIVE_FOLDER` (default `Archive`). If the server
 /// supports the IMAP MOVE extension we use it; otherwise we fall back to
 /// COPY + STORE (\\Deleted) + EXPUNGE.
-pub fn archive_email(conn: &EmailConnection, uid: u32, folder: &str) -> Result<(), String> {
-    let tls = native_tls::TlsConnector::builder()
-        .build()
-        .map_err(|e| format!("TLS error: {e}"))?;
+pub async fn archive_email(conn: &EmailConnection, uid: u32, folder: &str) -> Result<(), String> {
+    use futures::StreamExt;
 
-    let client = imap::connect((&conn.imap_host as &str, 993), &conn.imap_host, &tls)
-        .map_err(|e| format!("IMAP connect failed ({}): {}", conn.imap_host, e))?;
-
-    let mut session = client
-        .login(&conn.user, &conn.pass)
-        .map_err(|e| format!("IMAP login failed: {}", e.0))?;
-
-    session
-        .select("INBOX")
-        .map_err(|e| format!("IMAP select INBOX: {e}"))?;
+    let mut session = open_inbox(conn).await?;
 
     let uid_str = uid.to_string();
-    if session.uid_mv(&uid_str, folder).is_err() {
+    if session.uid_mv(&uid_str, folder).await.is_err() {
         // Fallback for servers without MOVE support.
         session
             .uid_copy(&uid_str, folder)
+            .await
             .map_err(|e| format!("IMAP UID COPY to `{folder}`: {e}"))?;
-        session
-            .uid_store(&uid_str, "+FLAGS (\\Deleted)")
-            .map_err(|e| format!("IMAP UID STORE: {e}"))?;
-        session
-            .expunge()
-            .map_err(|e| format!("IMAP EXPUNGE: {e}"))?;
+
+        // `uid_store` and `expunge` return response streams that are not
+        // `Unpin`; pin and drain them so the commands run to completion.
+        {
+            let store = session
+                .uid_store(&uid_str, "+FLAGS (\\Deleted)")
+                .await
+                .map_err(|e| format!("IMAP UID STORE: {e}"))?;
+            futures::pin_mut!(store);
+            while let Some(item) = store.next().await {
+                item.map_err(|e| format!("IMAP UID STORE: {e}"))?;
+            }
+        }
+        {
+            let expunge = session
+                .expunge()
+                .await
+                .map_err(|e| format!("IMAP EXPUNGE: {e}"))?;
+            futures::pin_mut!(expunge);
+            while let Some(item) = expunge.next().await {
+                item.map_err(|e| format!("IMAP EXPUNGE: {e}"))?;
+            }
+        }
     }
 
-    session.logout().ok();
+    session.logout().await.ok();
 
     println!(
         "  {} Archived email UID {} → {}",

--- a/crates/keel-runtime/src/runtime/namespaces/email.rs
+++ b/crates/keel-runtime/src/runtime/namespaces/email.rs
@@ -13,10 +13,9 @@ pub(crate) fn namespace() -> Namespace {
                 eprintln!("  ⚠ Email.fetch: IMAP_HOST/EMAIL_USER/EMAIL_PASS not set — returning empty list");
                 return Ok(Value::List(vec![]));
             };
-            match tokio::task::spawn_blocking(move || email::fetch_emails(&conn)).await {
-                Ok(Ok(emails)) => Ok(Value::List(emails)),
-                Ok(Err(msg)) => Err(email_err("email.fetch", msg)),
-                Err(e) => Err(miette::miette!("email fetch task join error: {e}")),
+            match email::fetch_emails(&conn).await {
+                Ok(emails) => Ok(Value::List(emails)),
+                Err(msg) => Err(email_err("email.fetch", msg)),
             }
         }),
         "send" => |host, args| Box::pin(async move {
@@ -76,10 +75,9 @@ pub(crate) fn namespace() -> Namespace {
             let folder = host.runtime().env.var("IMAP_ARCHIVE_FOLDER")
                 .filter(|s| !s.is_empty())
                 .unwrap_or_else(|| "Archive".to_string());
-            match tokio::task::spawn_blocking(move || email::archive_email(&conn, uid, &folder)).await {
-                Ok(Ok(())) => Ok(Value::None),
-                Ok(Err(msg)) => Err(email_err("email.archive", msg)),
-                Err(e) => Err(miette::miette!("email archive task join error: {e}")),
+            match email::archive_email(&conn, uid, &folder).await {
+                Ok(()) => Ok(Value::None),
+                Err(msg) => Err(email_err("email.archive", msg)),
             }
         }),
     })


### PR DESCRIPTION
## Why

`cargo build` emits a future-incompatibility warning:

```
warning: the following packages contain code that will be rejected by a future version of Rust: imap-proto v0.10.2
```

The lint is `trailing semicolon in macro used in expression position` (rust-lang/rust#79813), slated to become a hard error. It comes from `imap-proto 0.10.2`, pinned transitively by `imap 2.4.1` (the latest stable `imap`; the only newer `imap` is 3.0 alpha). The warning can't be cleared while staying on the `imap` crate.

## What

Move `Email.fetch` / `Email.archive` to the maintained, stable `async-imap 0.11` (with `async-native-tls`), which tracks `imap-proto 0.16.7`.

- The runtime is already async — these calls previously ran under `tokio::task::spawn_blocking`, so they now `.await` directly (a simplification of the call path).
- The fetch results and the `uid_store`/`expunge` response streams are drained explicitly; the latter two are pinned (`futures::pin_mut!`) since they are not `Unpin`.
- `Email.send` stays on `spawn_blocking` (lettre is synchronous).
- No language-surface change: `Email.fetch`/`send`/`archive` behave exactly as before.

## Verification

- `cargo build` clean — **future-incompat warning gone** (`cargo tree -i imap-proto` → `0.16.7`).
- `cargo clippy --all-targets` and `cargo fmt --check` clean.
- `KEEL_LLM=mock cargo test` — full suite green (465+).
- **Live-verified:** `Email.fetch` against a real Yahoo IMAP mailbox connected over TLS, logged in, searched `UNSEEN`, and streamed real unread mail correctly. (`Email.archive` shares the connect/login/select path; its `uid_mv`/`uid_store`/`expunge` branch is compile-verified, not exercised live, since it mutates real mail.)

Close #75