### PR TITLE
Guard ai.classify against AiSchemaError in triage examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,22 @@ All notable changes to Keel.
 
 - **Email IMAP now uses the maintained `async-imap` client.** The runtime previously depended on `imap 2.4.1`, which transitively pinned `imap-proto 0.10.2` — a crate that emitted a future-incompatibility warning (`trailing semicolon in macro used in expression position`, [rust#79813](https://github.com/rust-lang/rust/issues/79813)) and is slated to become a hard error in a future Rust release. `Email.fetch` and `Email.archive` now run on `async-imap 0.11` (with `async-native-tls`), which tracks the current `imap-proto 0.16`, so the warning is gone. The IMAP calls now run natively on the async interpreter instead of `tokio::task::spawn_blocking`. No language-surface change: `Email.fetch`, `Email.send`, and `Email.archive` behave exactly as before.
 
+### Fixed
+
+- **`examples/email_agent.keel` and the README triage snippet no longer crash on real models.** Both guarded `ai.classify` with `??` alone — but `ai.classify` (and `ai.extract`) *raise* `AiSchemaError` when the model's output matches no enum variant, and `??` only rescues a `none` result. So the `?? Urgency.medium` fallback fired only in mock/no-model mode; against a real model an HTML-heavy newsletter (reproduced on both `gemma4` and `gpt-oss:20b`) raised `AiSchemaError` and aborted the whole agent run — the opposite of what the example implied. The `triage` task now wraps the call in `try/catch AiSchemaError`, so a single non-conforming email falls back and the batch continues:
+
+```keel
+task triage(email: { body: str, from: str, subject: str }) -> Urgency {
+  try {
+    ai.classify(email.body, as: Urgency) ?? Urgency.medium
+  } catch err: AiSchemaError {
+    Urgency.medium
+  }
+}
+```
+
+  The README hero example was additionally rewritten to valid v0.1 syntax (the removed PascalCase prelude `Ai.`/`Io.`/`Email.`, an unimplemented `fallback:` argument, and missing `use std/…` imports), and `docs/src/guide/ai-primitives.md` now documents that `??` does not catch `AiSchemaError`. Runtime behaviour is unchanged — schema mismatch still throws by design (see `SPEC.md §11.1`).
+
 ---
 
 ## [0.2.2] — 2026-06-17

--- a/README.md
+++ b/README.md
@@ -28,35 +28,52 @@ If you're here, you're either curious or contributing. Both are welcome. Neither
 
 ## The Idea
 
-Building an AI agent today means stitching together frameworks on top of languages that were never designed for autonomous systems. Keel is a small language where the actor model is the only concurrency primitive, and everything else — AI, scheduling, HTTP, email, memory, human I/O — lives in a **standard library that is auto-imported**. You never write `use keel/ai`. You just write `Ai.classify(...)` and it works.
+Building an AI agent today means stitching together frameworks on top of languages that were never designed for autonomous systems. Keel is a small language where the actor model is the only concurrency primitive, and everything else — AI, scheduling, HTTP, email, memory, human I/O — lives in a **standard library**. Import what you need with `use std/ai`, `use std/email`, … and call it directly — `ai.classify(...)`, `ai.draft(...)`.
 
 ```keel
+use std/ai
+use std/email
+use std/io
+use std/schedule
+
 type Urgency = low | medium | high | critical
 
+task triage(email: { body: str, from: str, subject: str }) -> Urgency {
+  # `??` covers a `none` result (model unavailable). A real model can return
+  # text that matches no variant, which raises AiSchemaError — caught here so
+  # one bad email can't abort the batch. `??` alone does not catch it.
+  try {
+    ai.classify(email.body, as: Urgency) ?? Urgency.medium
+  } catch err: AiSchemaError {
+    Urgency.medium
+  }
+}
+
 agent EmailBot {
+  @tools [ai, email, io]
   @role "Professional email triage"
 
-  on message(msg: Message) {
-    urgency = Ai.classify(msg.body, as: Urgency, fallback: Urgency.medium)
-
+  task handle(email: { body: str, from: str, subject: str }) {
+    urgency = triage(email)
     when urgency {
       low, medium => {
-        reply = Ai.draft("response to {msg.body}", tone: "friendly")
-        if Io.confirm(reply) { Email.send(reply, to: msg.from) }
+        reply = ai.draft("response to {email.body}", tone: "friendly") ?? "(draft failed)"
+        if io.confirm(reply) { email.send(reply, to: email.from) }
       }
       high, critical => {
-        Io.notify("{urgency}: {msg.subject}")
-        guidance = Io.ask("How should I respond?")
-        reply = Ai.draft("response to {msg.body}", guidance: guidance)
-        if Io.confirm(reply) { Email.send(reply, to: msg.from) }
+        io.notify("{urgency}: {email.subject}")
+        guidance = io.ask("How should I respond?")
+        reply = ai.draft("response to {email.body}", guidance: guidance) ?? "(draft failed)"
+        if io.confirm(reply) { email.send(reply, to: email.from) }
       }
     }
   }
 
   @on_start {
-    Schedule.every(5.minutes, () => {
-      for email in Email.fetch(unread: true) {
-        Agent.send(self, email.as_message())
+    schedule.every(5.minutes, () => {
+      emails = email.fetch(unread: true)
+      for email in emails {
+        self.handle(email)
       }
     })
   }

--- a/docs/src/guide/ai-primitives.md
+++ b/docs/src/guide/ai-primitives.md
@@ -26,6 +26,23 @@ urgency = ai.classify(email.body,
 
 **Returns:** `T?` (where `T` is the enum). Use `?? T.variant` to supply a default inline.
 
+> **`??` does not catch schema mismatch.** `??` only fires on a `none` result —
+> model unavailable, mock mode, or a timeout. If the model returns text that
+> matches **no** variant of `T`, `ai.classify` *raises* `AiSchemaError`, which
+> `??` does **not** rescue. HTML-heavy or chatty inputs trigger this against real
+> models. In production, wrap the call in `try/catch AiSchemaError` so one bad
+> input can't abort a batch:
+>
+> ```keel
+> try {
+>   urgency = ai.classify(email.body, as: Urgency) ?? Urgency.medium
+> } catch err: AiSchemaError {
+>   urgency = Urgency.medium   # err.got holds the raw output
+> }
+> ```
+>
+> See [Error Handling](./error-handling.md).
+
 ## `ai.extract` — pull structured data from text
 
 ```keel
@@ -45,6 +62,11 @@ result = ai.extract("Invoice from ACME $99.99 on 2026-01-10", as: Invoice)
 Both forms are fully wired as of v0.1.3:
 - `schema: { field: "type" }` — inline map of field names to type strings.
 - `as: T` — derives the schema from a declared `type T { ... }` struct; raises a runtime error if `T` is not a known struct type. As of v0.1.19 the type checker resolves `T` from the `as:` argument, so field accesses on the result are statically checked.
+
+> Like `ai.classify`, `ai.extract` **raises `AiSchemaError`** when the model's
+> output can't be coerced to the requested shape — `??` only covers the `none`
+> (model-unavailable) case. Wrap it in `try/catch AiSchemaError` when the input
+> isn't trusted to produce clean structured data.
 
 ## `ai.summarize` — condense content
 

--- a/docs/src/guide/tasks.md
+++ b/docs/src/guide/tasks.md
@@ -33,6 +33,8 @@ task compose(body: str, tone: str = "friendly") -> str {
 
 # Struct parameters (inline type)
 task triage(msg: {body: str, from: str}) -> Urgency {
+  # `??` covers a none result; in production wrap classify in try/catch to also
+  # handle AiSchemaError — see the Error Handling guide.
   ai.classify(msg.body, as: Urgency) ?? Urgency.medium
 }
 ```
@@ -90,6 +92,8 @@ use std/email
 
 # Top-level: shared, testable
 task triage(email: {body: str}) -> Urgency {
+  # In production, wrap classify in try/catch to handle AiSchemaError
+  # (non-conforming model output) — `??` only covers a none result.
   ai.classify(email.body, as: Urgency) ?? Urgency.medium
 }
 

--- a/examples/email_agent.keel
+++ b/examples/email_agent.keel
@@ -10,7 +10,15 @@ use std/testing
 type Urgency = low | medium | high | critical
 
 task triage(email: { body: str, from: str, subject: str }) -> Urgency {
-  ai.classify(email.body, as: Urgency, considering: { "from a known VIP or executive": Urgency.critical, "mentions a deadline within 24h": Urgency.high, "asks a direct question": Urgency.medium, "newsletter or automated message": Urgency.low }) ?? Urgency.medium
+  # `??` only rescues a `none` result (model unavailable / mock mode). A real
+  # model can emit output that matches no `Urgency` variant, which raises
+  # `AiSchemaError` — caught here so one HTML-heavy newsletter can't abort the
+  # whole batch. `??` alone would let that error propagate and kill the run.
+  try {
+    ai.classify(email.body, as: Urgency, considering: { "from a known VIP or executive": Urgency.critical, "mentions a deadline within 24h": Urgency.high, "asks a direct question": Urgency.medium, "newsletter or automated message": Urgency.low }) ?? Urgency.medium
+  } catch err: AiSchemaError {
+    Urgency.medium
+  }
 }
 
 task brief(email: { body: str }) -> str {

--- a/tests/integration/ai.rs
+++ b/tests/integration/ai.rs
@@ -471,3 +471,60 @@ run(A)
     );
     assert!(stdout.contains("neutral"), "?? default not used:\n{stdout}");
 }
+
+#[test]
+fn triage_try_catch_supplies_fallback_on_schema_error() {
+    // Regression for #76: against a real model, `ai.classify` *raises*
+    // `AiSchemaError` when the output matches no variant — `??` only rescues
+    // `none`, so `?? Urgency.medium` alone would let the error abort the run.
+    // The shipped triage pattern (examples/email_agent.keel, README) wraps the
+    // call in try/catch so a non-conforming email falls back instead of crashing.
+    //
+    // Mock mode can't exercise this (it yields `none`, not a raise), so we drive
+    // a real schema mismatch through the HTTP path with a body that contains no
+    // Urgency variant — mirroring the HTML-newsletter failure from the issue.
+    let server = start_repeated_json_response_server(
+        r#"{"message":{"content":"<html>weekly newsletter, nothing to see here</html>"}}"#,
+        1,
+    );
+    let src = r#"
+use std/ai
+use std/io
+type Urgency = low | medium | high | critical
+
+task triage(body: str) -> Urgency {
+  try {
+    ai.classify(body, as: Urgency) ?? Urgency.medium
+  } catch err: AiSchemaError {
+    Urgency.medium
+  }
+}
+
+agent A {
+  @tools [ai, io]
+  @role "tester"
+  @on_start {
+    u = triage("buy now")
+    io.show("urgency={u}")
+    stop(self)
+  }
+}
+run(A)
+"#;
+    let (ok, stdout, stderr) = run_inline_with_env(
+        src,
+        &[
+            ("KEEL_LLM", ""),
+            ("OLLAMA_HOST", server.as_str()),
+            ("KEEL_OLLAMA_MODEL", "test-model"),
+        ],
+    );
+    assert!(
+        ok,
+        "triage aborted on AiSchemaError instead of falling back\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("urgency=medium"),
+        "try/catch fallback variant not used:\n{stdout}"
+    );
+}


### PR DESCRIPTION
## Summary

`ai.classify` (and `ai.extract`) **raise** `AiSchemaError` when the model's output matches no enum variant, but the shipped `examples/email_agent.keel` and the README hero snippet guarded the call with `??` alone. `??` only rescues a `none` result (mock mode / network failure), so against a real model a non-conforming reply raised `AiSchemaError` and aborted the whole agent run — the fallback only ever fired in mock mode. This is the inconsistency from #76: `examples/ai_error.keel` already demonstrates the correct `try/catch` pattern, while the triage example and docs disagreed.

Kept the existing two-tier failure model (schema mismatch throws by design — SPEC §11.1); fixed the unsafe examples/docs rather than collapsing the failure into `none`, which `SPEC.md` (#20, "no silent fallbacks") and #38 explicitly rule out.

## Changes

- **`examples/email_agent.keel`** — `triage` wraps `ai.classify` in `try/catch AiSchemaError` so one non-conforming email falls back instead of killing the batch. (`brief`/`compose` keep `??` — `ai.summarize`/`ai.draft` never schema-validate, so they only ever return `none`.)
- **`README.md`** — rewrote the hero snippet to valid v0.1 syntax (it used the removed PascalCase prelude `Ai.`/`Io.`/`Email.`, an unimplemented `fallback:` argument, and had no `use std/…` imports) and corrected the "you just write `Ai.classify(...)`" line.
- **`docs/src/guide/ai-primitives.md`** — callouts under `ai.classify`/`ai.extract` documenting that `??` does not catch `AiSchemaError`.
- **`docs/src/guide/tasks.md`** — cross-reference comments on the two `triage` syntax demos.
- **`tests/integration/ai.rs`** — `triage_try_catch_supplies_fallback_on_schema_error` drives a real schema mismatch (mock HTTP server) through the triage pattern and asserts the fallback fires. Non-tautological: `??`-only would abort and fail the test.
- **`CHANGELOG.md`** — `[Unreleased] → Fixed` entry.

## Verification

- README snippet + `examples/email_agent.keel` → `keel check` ✓; example `.keel` tests ✓
- Full suite: **466 integration + lib tests pass**; new regression test passes
- `cargo fmt --check` clean · `cargo clippy --all-targets -D warnings` clean · `mdbook build` clean

Closes #76