### PR TITLE
Run example programs in a temp dir so tests don't litter the repo

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -17,31 +17,31 @@ pub fn keel_binary() -> PathBuf {
 }
 
 pub fn run_example(name: &str) -> (bool, String, String) {
-    let bin = keel_binary();
-    let example = project_root().join("examples").join(format!("{name}.keel"));
-    let output = Command::new(&bin)
-        .env("KEEL_ONESHOT", "1")
-        .env("KEEL_LLM", "mock")
-        .arg("run")
-        .arg(&example)
-        .output()
-        .expect("failed to run keel binary");
-    let ok = output.status.success();
-    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
-    (ok, stdout, stderr)
+    run_example_subcommand("run", name)
 }
 
 pub fn test_example(name: &str) -> (bool, String, String) {
+    run_example_subcommand("test", name)
+}
+
+/// Run a shipped example through `keel <subcommand>` in a throwaway working
+/// directory. Examples like `file_processing.keel` write relative paths
+/// (`test.txt`, `data/output.txt`); running them in a temp dir keeps those
+/// artifacts out of the repo and isolates concurrently-running examples from
+/// each other. The `TempDir` is dropped at the end of the call, deleting the
+/// directory and everything the example wrote into it.
+fn run_example_subcommand(subcommand: &str, name: &str) -> (bool, String, String) {
     let bin = keel_binary();
     let example = project_root().join("examples").join(format!("{name}.keel"));
+    let workdir = tempfile::tempdir().expect("create example workdir");
     let output = Command::new(&bin)
+        .current_dir(workdir.path())
         .env("KEEL_ONESHOT", "1")
         .env("KEEL_LLM", "mock")
-        .arg("test")
+        .arg(subcommand)
         .arg(&example)
         .output()
-        .expect("failed to run keel test");
+        .expect("failed to run keel binary");
     let ok = output.status.success();
     let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();

--- a/tests/integration/tools.rs
+++ b/tests/integration/tools.rs
@@ -234,8 +234,14 @@ fn examples_run_capability_clean_under_mock() {
         files.len()
     );
 
+    // Some examples (file_processing, capability_gating) write relative paths.
+    // Run the corpus in a throwaway dir so those artifacts never land in the
+    // repo; the TempDir is dropped at the end of the test, cleaning everything.
+    let workdir = tempfile::tempdir().expect("create example workdir");
+
     for file in files {
         let output = Command::new(keel_binary())
+            .current_dir(workdir.path())
             .env("KEEL_ONESHOT", "1")
             .env("KEEL_LLM", "mock")
             .arg("run")


### PR DESCRIPTION
## What

The example-corpus test runner in `tests/integration/tools.rs` and the shared `run_example` / `test_example` helpers in `tests/common/mod.rs` spawned the `keel` binary with the test runner's working directory — the repo root. Examples that write relative paths (`file_processing.keel` → `test.txt`, `data/output.txt`; `capability_gating.keel` → `allowed.txt`) therefore dropped those files into the project directory and left them behind after every `cargo test` run.

## Fix

Run each example with `current_dir` set to a throwaway `tempfile::tempdir()`, which is deleted when the test finishes. Artifacts never reach the repo, and concurrently-running examples no longer clobber each other's `test.txt`. Also folds the two near-identical `run_example` / `test_example` bodies into a single `run_example_subcommand` helper.

## Verification

- Full integration suite passes (468 tests).
- After running the entire example corpus, the repo is clean — no `test.txt`, `allowed.txt`, or `data/` reappear.