### PR TITLE
Speed up CI: cache build artifacts and lighten the PR release step

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,4 +2,3 @@
 coverage = "llvm-cov --workspace --all-targets --summary-only"
 coverage-html = "llvm-cov --workspace --all-targets --html --output-dir target/llvm-cov/html"
 coverage-lcov = "llvm-cov --workspace --all-targets --lcov --output-path target/llvm-cov/lcov.info"
-test = "test --features test-util"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,18 @@ jobs:
       - name: Check documentation
         run: cargo doc --no-deps --document-private-items
 
+      # On PRs, only verify the release profile still type/borrow-checks — a few
+      # seconds, vs. ~2 min for the full opt-3 + fat-LTO build. The optimized
+      # binary feeds nothing else in CI (tests use the debug binary), and there
+      # is no release-divergent code, so this catches the same compile errors.
+      - name: Check release profile compiles
+        if: github.event_name == 'pull_request'
+        run: cargo check --release
+
+      # On push to main (and manual dispatch), do the full optimized build so a
+      # release-only link/codegen failure surfaces before it reaches a release.
       - name: Build release binary
+        if: github.event_name != 'pull_request'
         run: cargo build --release
 
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,17 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      # Cache the cargo registry and the target/ directory across runs. The
+      # expensive part of CI is compiling the dependency graph (tokio, hyper,
+      # reqwest, axum, lettre, …) in both the debug and release profiles; on a
+      # warm cache those artifacts are restored instead of rebuilt, so only the
+      # workspace crates recompile. rust-cache keys on the lockfile and rustc
+      # version and evicts the (cheap) workspace artifacts to keep the cache lean.
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
 
       - name: Check formatting
         run: cargo fmt --check


### PR DESCRIPTION
## What

Two changes to `ci.yml` to cut CI wall-time:

1. **Cache build artifacts** — add [`Swatinem/rust-cache`](https://github.com/Swatinem/rust-cache) so the cargo registry and `target/` are restored across runs; on a warm cache only the workspace crates recompile. Toolchain now pins `clippy` + `rustfmt` explicitly.
2. **`cargo check --release` on PRs, full `build --release` on main** — the full opt-3 + fat-LTO release build takes ~2 min and feeds nothing else in CI (tests use the debug binary). On PRs we now only verify the release profile compiles; the full optimized build still runs on push to main (and manual dispatch).

## Why

After caching, a warm run was still ~4m, and the log showed the time going to two steps caching can't help — rust-cache deliberately evicts the workspace crates, so they recompile every run:

| Step | Warm time | Note |
|---|---|---|
| clippy | 18s | deps restored from cache |
| cargo doc | 16s | deps restored from cache |
| **cargo build --release** | **2m02s** | workspace crates, opt-3 + fat LTO |
| cargo test (compile + 468 tests) | 1m22s | workspace + test harness |

The release build only proves "does it compile under the release profile." There are **no `[features]` and zero `debug_assertions`/release-only `cfg`** in the crates, and no `build.rs`/FFI/`asm!`, so `cargo check --release` catches the same compile errors in seconds. The full optimized build — whose real remaining value is proving the fat-LTO/panic=abort binary *links* — is kept on `main`, where a release-only failure still surfaces before it can reach a release.

## Expected effect

- Warm **PR** runs: ~4m → ~2m (the 2-min release build becomes a few-second `check`).
- **main**: unchanged gate (full optimized build still runs).
- First run on a branch (or after a `Cargo.lock`/rustc change) still pays full cost to reseed the cache; the win is on subsequent warm runs.

## Verified

Re-running the same commit showed `Cache hit … full match: true` / `Cache restored successfully`, and clippy's first-compile dropped from ~4½ min (cold) to ~18s (warm).

Follow-up (not in this PR): `docs.yml` has the same no-cache issue and runs `cargo install mdbook` every push.

3. **Remove a dead `cargo test` alias** — `.cargo/config.toml` defined `test = "test --features test-util"`, which shadowed the built-in `test` subcommand (so cargo ignored it and warned every run) and referenced a `test-util` feature that does not exist. Removed; the `coverage*` aliases stay.