### PR TITLE
Enforce subject-only release commits in the release docs

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -170,7 +170,11 @@ git commit -m "Release v0.1.X — <short theme>"
 git push origin main
 ```
 
-Commit message rules: describe what the code change does — no AI attribution, no model names, no `Co-Authored-By`.
+Commit message rules:
+
+- **Subject line only — never add a body.** The release commit is a single `-m` line and nothing else. The CHANGELOG is the canonical record of what shipped; do not duplicate or paraphrase it in the commit. Never pass a second `-m`, a heredoc, or bullet points. A body is a blocking mistake.
+- **The `<short theme>` must come from the actual release.** Derive it from the `%%TAGLINE%%`/CHANGELOG entry for this version — never invent feature names. If the subject doesn't match what the CHANGELOG says shipped, stop and fix it.
+- Describe what the code change does — no AI attribution, no model names, no `Co-Authored-By`.
 
 ## Step 10 — Confirmation Gate for Tag (REQUIRED)
 

--- a/.claude/agents/release-engineer.md
+++ b/.claude/agents/release-engineer.md
@@ -8,3 +8,5 @@ tools: Bash, Read, Edit, Write, AskUserQuestion
 Follow the release checklist in `.agents/skills/release/SKILL.md` exactly.
 
 For the confirmation gates in Steps 9 and 10, use the `AskUserQuestion` tool — do not print the question as prose and continue. Wait for an explicit "yes" before proceeding.
+
+The release commit is a **subject line only — never add a body.** Commit with a single `git commit -m "Release vX.Y.Z — <theme>"` and nothing more: no second `-m`, no heredoc, no bullet points. The CHANGELOG is the only record of what shipped. Derive `<theme>` from the actual `%%TAGLINE%%`/CHANGELOG entry for this version — never invent feature names, and never paraphrase the changelog into the commit.


### PR DESCRIPTION
Tightens the release commit guidance in both the shared release skill and the release-engineer agent so the release commit is always a single subject line.

## What changed
- **`.agents/skills/release/SKILL.md`** — the commit-message section now spells out the rules: subject line only (no body, no second `-m`, no heredoc, no bullet points), and the `<short theme>` must be derived from the actual `%%TAGLINE%%`/CHANGELOG entry for the version rather than invented.
- **`.claude/agents/release-engineer.md`** — mirrors the same rule so the agent gates on it directly.

## Why
The CHANGELOG is the canonical record of what shipped. Duplicating or paraphrasing it into a multi-line commit body is redundant and drifts from the changelog; pinning the release commit to a single themed subject keeps the history clean and the source of truth singular.