### PR TITLE
Add user-authored LLM providers via impl LlmProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,33 @@ All notable changes to Keel.
 
 ## [Unreleased]
 
-%%TAGLINE%% Swappable LLM providers — `ai.*` now runs on Ollama, OpenAI, or Anthropic (Claude), selected per program, agent, or call.
+%%TAGLINE%% Swappable LLM providers — `ai.*` runs on built-in Ollama, OpenAI, and Anthropic backends, or a provider you write in Keel.
 
 ### Added
 
-- **Swappable LLM backends — OpenAI and Anthropic (Claude) join Ollama.** `ai.*` no longer hard-codes Ollama. Three backends ship built in and are selected with no extra code, most-specific wins: a `provider:` prefix on a model tag (`@model "anthropic:claude-opus-4-8"`, or a `using:` argument) picks the backend per call; `@provider <name>` sets an agent's default backend for bare tags; `KEEL_PROVIDER` sets the program default (otherwise `ollama`). OpenAI and Anthropic read `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` — a missing key throws `AiError { reason: "provider" }`, never a silent fallback. `@provider` accepts only the built-in names `ollama`, `openai`, `anthropic`; anything else is a compile-time error (user-authored Keel providers are planned — see SPEC §5.5). `@limits { max_tokens }` is now threaded into the request as the generation cap.
+- **User-authored LLM providers — write a backend in Keel.** For proprietary or self-hosted models the built-in backends don't cover, any field-less type with `impl LlmProvider` is now a backend `ai.*` can dispatch through. `ai.install(MyProvider)` registers it program-wide (the lowest-precedence default, below a `provider:` prefix and `@provider`); `@provider MyProvider` selects it per agent. `complete(self, req: CompletionRequest) -> str` returns the raw model output — Keel applies its own prompt construction and output parsing (enum matching, schema validation) identically to built-in and user providers, so `??`, `when`, and the typed `AiError`/`AiSchemaError` errors behave the same. `CompletionRequest` is a built-in struct (`system`, `user`, `model`, `max_tokens`). `ai.install(X)` and `@provider X` require `X` to implement `LlmProvider` (a compile-time error otherwise), and a provider that calls `ai.*` from inside its own `complete()` is rejected with an `AiError` rather than recursing without bound.
+
+```keel
+use std/ai
+use std/env
+use std/http
+
+type MyProvider {}
+impl LlmProvider for MyProvider {
+  task complete(self, req: CompletionRequest) -> str {
+    key = env.get("MY_LLM_KEY")!
+    http.post("https://my-llm.example/complete", body: { prompt: req.user })["text"]
+  }
+}
+
+ai.install(MyProvider)        # program-wide, or `@provider MyProvider` per agent
+
+task ask(q: str) -> str {
+  ai.prompt(system: "Be concise.", user: q) ?? "no answer"
+}
+```
+
+- **Swappable LLM backends — OpenAI and Anthropic (Claude) join Ollama.** `ai.*` no longer hard-codes Ollama. Three backends ship built in and are selected with no extra code, most-specific wins: a `provider:` prefix on a model tag (`@model "anthropic:claude-opus-4-8"`, or a `using:` argument) picks the backend per call; `@provider <name>` sets an agent's default backend for bare tags; `KEEL_PROVIDER` sets the program default (otherwise `ollama`). OpenAI and Anthropic read `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` — a missing key throws `AiError { reason: "provider" }`, never a silent fallback. `@provider` accepts the built-in names `ollama`, `openai`, `anthropic` (and now user-authored provider types — see above); anything else is a compile-time error. `@limits { max_tokens }` is now threaded into the request as the generation cap.
 
 ```keel
 use std/ai

--- a/README.md
+++ b/README.md
@@ -158,16 +158,25 @@ keel build agent.keel     Deferred: bytecode compiler post-v0.1
 
 ## LLM Provider
 
-Keel v0.1 ships with a single backend: **Ollama** (local, offline). It follows the planned `LlmProvider` interface shape, but custom provider installation is not wired yet. No silent fallbacks — if a model isn't configured, you get a clear error.
+`ai.*` dispatches through swappable backends. Three ship built in — **Ollama**
+(default, local), **OpenAI**, and **Anthropic (Claude)** — selected with no extra
+code: a `provider:` prefix on the model tag (per call), `@provider` (per agent),
+or `KEEL_PROVIDER` (per program). For proprietary or self-hosted models, write a
+provider in Keel (`impl LlmProvider` + `ai.install`/`@provider`). No silent
+fallbacks — a missing key or unmapped model throws a clear `AiError`.
 
 ```bash
-# Required: Ollama running locally with a pulled model
+# Ollama (default): a local daemon with a pulled model
 export KEEL_OLLAMA_MODEL=gemma4
+export KEEL_MODEL_FAST=gemma4              # optional per-alias mapping
 
-# Optional: per-alias mapping
-export KEEL_MODEL_FAST=gemma4
-export KEEL_MODEL_SMART=mistral:7b-instruct
+# OpenAI / Anthropic: select the backend and supply a key
+export KEEL_PROVIDER=anthropic
+export ANTHROPIC_API_KEY=sk-...
 ```
+
+See [docs: LLM Providers](docs/src/config/llm-providers.md) for user-authored
+providers and the full precedence rules.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -75,7 +75,7 @@ Legend: **[x]** complete · **[~]** partial · **[ ]** planned.
 
 | Namespace | Status | Implemented | Gaps |
 |---|---|---|---|
-| `std/ai` | [~] | `classify`, `summarize` (format/max), `draft`, `extract` (as: T), `translate`, `decide`, `prompt` (response_format: json); swappable built-in backends — Ollama, OpenAI, Anthropic (Claude) — via `@model "provider:model"`, `@provider`, or `KEEL_PROVIDER` | `embed` deferred to v0.2; user-authored `ai.install(provider)` planned (SPEC §5.5) |
+| `std/ai` | [~] | `classify`, `summarize` (format/max), `draft`, `extract` (as: T), `translate`, `decide`, `prompt` (response_format: json); swappable built-in backends — Ollama, OpenAI, Anthropic (Claude) — via `@model "provider:model"`, `@provider`, or `KEEL_PROVIDER`; user-authored providers via `impl LlmProvider` + `ai.install`/`@provider` (SPEC §5.5) | `embed` deferred to v0.2 |
 | `std/io` | [x] | `notify`, `show`, `ask`, `confirm` | — |
 | `std/schedule` | [x] | `every`, `after`, `at`, `cron`, `sleep` | — |
 | `std/email` | [~] | `fetch` (IMAP), `send` (SMTP), `archive` (IMAP folder move with fallback) | — |

--- a/SPEC.md
+++ b/SPEC.md
@@ -921,12 +921,43 @@ OpenAI and Anthropic read their keys from `OPENAI_API_KEY` / `ANTHROPIC_API_KEY`
 a missing key surfaces as `AiError { reason: "provider" }`, never a silent
 fallback. `@limits { max_tokens }` caps generation for the backend.
 
-#### User-authored providers <span class="badge badge-soon">Planned</span>
+#### User-authored providers
 
-Writing a provider in Keel and installing it — `ai.install(MyProvider)` with
-`impl LlmProvider for MyProvider` — is planned for a future release, for the long
-tail of proprietary or self-hosted backends. The built-in backends above cover
-the common cases today.
+For the long tail of proprietary or self-hosted backends, write a provider **in
+Keel** and install it. Any field-less type with `impl LlmProvider` becomes a
+backend `ai.*` can dispatch through:
+
+```keel
+type MyProvider {}
+
+impl LlmProvider for MyProvider {
+  task complete(self, req: CompletionRequest) -> str {
+    # `req` carries `system`, `user`, `model`, and `max_tokens`. Configuration
+    # (endpoints, keys) is read from env.* — the provider is constructed with
+    # no fields, so it holds no state of its own.
+    key = env.get("MY_LLM_KEY")!
+    http.post("https://my-llm.example/complete", body: { prompt: req.user })["text"]
+  }
+}
+
+ai.install(MyProvider)        # program-wide default (lowest precedence)
+
+agent Assistant {
+  @provider MyProvider        # …or per-agent, like the built-in names
+}
+```
+
+`complete(self, req: CompletionRequest) -> str` returns the raw model output;
+Keel's prompt construction and output parsing (enum matching, schema validation)
+are applied identically to built-in and user providers, so `??`, `when`, and the
+typed `AiError`/`AiSchemaError` errors behave the same. `CompletionRequest` is a
+built-in struct with fields `system: str`, `user: str`, `model: str`, and
+`max_tokens: int`.
+
+`ai.install(X)` and `@provider X` require `X` to be a type implementing
+`LlmProvider`; anything else is a compile-time error. A user provider must not
+call `ai.*` from inside its own `complete()` — that re-entry is rejected with an
+`AiError` rather than recursing without bound.
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -30,9 +30,9 @@ Verdict: **plan** (worth doing — aligned with Keel's purpose, no redundant ove
 
 | Ref | Short | Description | Verdict | Why |
 |-----|-------|-------------|---------|-----|
-| K-14 | Ship one real interface implementation | `interface` declarations parse but don't dispatch. `@provider` parses but Ollama is hardcoded. Implement `LlmProvider` with two concrete backends (Ollama + mock/test) sharing the interface ABI. | **plan** | THE central architectural bet of Keel: swappable providers. Without this, Keel is a fixed framework with language syntax, not a language with replaceable backends. The single biggest gap between spec and reality. |
+| K-14 | Ship one real interface implementation | **Done** (#44). Built-in `LlmProvider` backends (Ollama/OpenAI/Anthropic) shipped in #46/#87; user-authored providers landed in #44 — `impl LlmProvider for X` dispatches through `ai.install(X)` (program-wide) or `@provider X` (per-agent), with `CompletionRequest` as a built-in struct, checker conformance via `signature_satisfies`, and a re-entrancy guard. | **done** | THE central architectural bet of Keel: swappable providers — built in *and* user-authored. |
 | K-15 | Interface conformance checks | **Done** (#45). `impl Interface for Type` conformance is enforced in both checker and runtime via the shared `types/interface.rs` — presence, arity, parameter types, return type, and extra-method rejection. `dynamic` in the interface position is a wildcard on both parameters and return. Provider *dispatch* (the `@provider` wiring) is tracked separately in K-14/K-16. | **done** | Method-signature conformance is complete; the static checker and the runtime apply identical rules through `signature_satisfies`. |
-| K-16 | Typed provider ABI | Define the runtime contract for provider dispatch: per-call, per-agent, per-program scoping; method resolution; error propagation. | **plan** | Follows from K-14. The interface system needs a concrete dispatch contract. |
+| K-16 | Typed provider ABI | **Done** (#46/#87). Runtime contract for provider dispatch: per-call (`provider:` prefix), per-agent (`@provider`), per-program (`KEEL_PROVIDER`/`ai.install`) scoping; method resolution; error propagation via `LlmError` → typed `AiError`. | **done** | The interface system's concrete dispatch contract, extended by user-authored providers in K-14. |
 
 ---
 

--- a/crates/keel-catalog/src/providers.rs
+++ b/crates/keel-catalog/src/providers.rs
@@ -26,13 +26,13 @@ pub fn builtin_provider_prefix(model: &str) -> Option<&'static str> {
         .find(|provider| *provider == prefix)
 }
 
-/// The shared error message for an `@provider` attribute that doesn't name a
-/// built-in backend. Used by both the compiler checker and the interpreter so
-/// the two phases word the rejection identically.
+/// The shared error message for an `@provider` attribute that names neither a
+/// built-in backend nor a type implementing `LlmProvider`. Used by both the
+/// compiler checker and the interpreter so the two phases word it identically.
 pub fn provider_attribute_error() -> String {
     format!(
-        "@provider must name a built-in provider — use one of: {}. \
-         User-authored providers are planned; see SPEC §5.5.",
+        "@provider must name a built-in provider — one of: {} — or a type with \
+         `impl LlmProvider`. See SPEC §5.5.",
         BUILTIN_LLM_PROVIDERS.join(", ")
     )
 }

--- a/crates/keel-catalog/src/specs/ai.rs
+++ b/crates/keel-catalog/src/specs/ai.rs
@@ -59,4 +59,11 @@ pub const SPEC: &[BuiltinMethod] = &[
         result: BuiltinResult::Unknown,
         doc: "Embed text into a vector (reserved, not yet stable).",
     },
+    BuiltinMethod {
+        namespace: "ai",
+        name: "install",
+        params: &[],
+        result: BuiltinResult::Fixed(TySpec::None_),
+        doc: "Register a user-authored `LlmProvider` as the program-wide backend.",
+    },
 ];

--- a/crates/keel-compiler/src/types/checker.rs
+++ b/crates/keel-compiler/src/types/checker.rs
@@ -1370,6 +1370,20 @@ ai.install(Bogus)
     }
 
     #[test]
+    fn ai_install_builtin_name_is_compile_error() {
+        // A built-in backend name is not installable — it resolves to no value at
+        // runtime (a confusing `Undefined` error). Reject it at check time and
+        // point at `@provider`/the `provider:` prefix instead.
+        expect_error(
+            r#"
+use std/ai
+ai.install(openai)
+"#,
+            "built-in backend",
+        );
+    }
+
+    #[test]
     fn error_self_outside_agent() {
         expect_error(
             r#"

--- a/crates/keel-compiler/src/types/checker.rs
+++ b/crates/keel-compiler/src/types/checker.rs
@@ -30,7 +30,7 @@ pub use crate::ide::hover::type_at;
 pub use crate::ide::symbols::{
     definition_of, ident_at_offset, ident_span_at_offset, is_top_level_symbol, usages_of,
 };
-use crate::types::prelude::builtin_interfaces;
+use crate::types::prelude::{builtin_interfaces, builtin_structs};
 use crate::types::scope::Scope;
 
 // ---------------------------------------------------------------------------
@@ -108,6 +108,9 @@ pub(crate) struct Checker<'hir, 'ast> {
     /// Type names that implement `Iterable` — used to allow `for x in value`
     /// on struct types.
     iterable_types: HashSet<String>,
+    /// Type names that implement `LlmProvider` — the eligible targets for
+    /// `@provider X` and `ai.install(X)`.
+    llm_provider_types: HashSet<String>,
     /// Generic type declarations stored as `name → (type_params, body)` for
     /// deferred instantiation when a concrete `Foo[str]` application appears.
     generic_decls: HashMap<String, (Vec<String>, TypeDef)>,
@@ -615,10 +618,11 @@ impl<'hir, 'ast> Checker<'hir, 'ast> {
             errors: Vec::new(),
             enum_variants: HashMap::new(),
             enum_variant_fields: HashMap::new(),
-            structs: HashMap::new(),
+            structs: builtin_structs(),
             aliases: HashMap::new(),
             interfaces: builtin_interfaces(),
             iterable_types: HashSet::new(),
+            llm_provider_types: HashSet::new(),
             generic_decls: HashMap::new(),
             generic_task_decls: HashMap::new(),
             top_tasks: HashMap::new(),
@@ -1273,8 +1277,8 @@ run(A)
 
     #[test]
     fn provider_unknown_resolvable_name_is_compile_error() {
-        // A name that *resolves* (a declared type) must still be rejected at
-        // check time — not slip through to runtime.
+        // A name that *resolves* (a declared type) but has no `impl LlmProvider`
+        // must still be rejected at check time — not slip through to runtime.
         expect_error(
             r#"
 type MyProvider { id: int }
@@ -1285,6 +1289,81 @@ agent A {
 }
 
 run(A)
+"#,
+            "built-in provider",
+        );
+    }
+
+    #[test]
+    fn provider_user_type_with_impl_is_ok() {
+        type_ok(
+            r#"
+type MyProvider {}
+impl LlmProvider for MyProvider {
+  task complete(self, req: CompletionRequest) -> str {
+    req.user
+  }
+}
+
+agent A {
+  @provider MyProvider
+  @model "x"
+}
+
+run(A)
+"#,
+        );
+    }
+
+    #[test]
+    fn ai_install_user_type_with_impl_is_ok() {
+        type_ok(
+            r#"
+use std/ai
+type MyProvider {}
+impl LlmProvider for MyProvider {
+  task complete(self, req: CompletionRequest) -> str {
+    "{req.system} :: {req.model}"
+  }
+}
+
+ai.install(MyProvider)
+"#,
+        );
+    }
+
+    #[test]
+    fn provider_user_type_with_fields_is_compile_error() {
+        // The runtime constructs the provider with no fields, so a field-bearing
+        // provider type is rejected — config belongs in env.* inside complete().
+        expect_error(
+            r#"
+type Configured { key: str }
+impl LlmProvider for Configured {
+  task complete(self, req: CompletionRequest) -> str {
+    req.user
+  }
+}
+
+agent A {
+  @provider Configured
+  @model "x"
+}
+
+run(A)
+"#,
+            "field-less",
+        );
+    }
+
+    #[test]
+    fn ai_install_non_conforming_type_is_compile_error() {
+        expect_error(
+            r#"
+use std/ai
+type Bogus { id: int }
+
+ai.install(Bogus)
 "#,
             "built-in provider",
         );

--- a/crates/keel-compiler/src/types/checker/collect.rs
+++ b/crates/keel-compiler/src/types/checker/collect.rs
@@ -26,6 +26,7 @@ impl Checker<'_, '_> {
             "Equatable",
             "Serializable",
             "Iterable",
+            "LlmProvider",
         ];
         for node in &program.declarations {
             self.current_span = Some(node.span.clone());
@@ -61,6 +62,9 @@ impl Checker<'_, '_> {
                     self.check_impl_conformance(impl_decl);
                     if impl_decl.interface_name == "Iterable" {
                         self.iterable_types.insert(impl_decl.type_name.clone());
+                    }
+                    if impl_decl.interface_name == "LlmProvider" {
+                        self.llm_provider_types.insert(impl_decl.type_name.clone());
                     }
                 }
                 _ => {}

--- a/crates/keel-compiler/src/types/checker/expr.rs
+++ b/crates/keel-compiler/src/types/checker/expr.rs
@@ -1189,8 +1189,10 @@ impl Checker<'_, '_> {
     }
 
     /// Validate the argument to `ai.install(X)`: `X` must be a bare type name
-    /// that implements `LlmProvider`. Reuses the same conformance rule as
-    /// `@provider X` so the two install sites word rejections identically.
+    /// that implements `LlmProvider`. Unlike `@provider X`, a built-in backend
+    /// name is *not* accepted here — built-ins are selected with `@provider` or a
+    /// `provider:` model prefix, and a bare backend name is not a value the
+    /// interpreter can install (it resolves to nothing at runtime).
     fn check_ai_install_arg(&mut self, args: &[CallArg], span: crate::lexer::Span) {
         let Some(first) = args.first() else {
             self.err_at(
@@ -1199,13 +1201,25 @@ impl Checker<'_, '_> {
             );
             return;
         };
-        match &first.value.kind {
-            Expr::Ident(name) => self.check_provider_name(name, first.value.span.clone()),
-            _ => self.err_at(
+        let Expr::Ident(name) = &first.value.kind else {
+            self.err_at(
                 "ai.install expects a provider type name, e.g. `ai.install(MyProvider)`",
                 first.value.span.clone(),
-            ),
+            );
+            return;
+        };
+        if keel_catalog::is_builtin_llm_provider(name) {
+            self.err_at(
+                format!(
+                    "ai.install expects a user-authored provider type implementing \
+                     `LlmProvider`, not the built-in backend `{name}` — select a built-in \
+                     with `@provider {name}` or a `{name}:` model prefix instead"
+                ),
+                first.value.span.clone(),
+            );
+            return;
         }
+        self.check_provider_name(name, first.value.span.clone());
     }
 
     /// Enforce deny-by-default `@tools` at compile time for direct std calls

--- a/crates/keel-compiler/src/types/checker/expr.rs
+++ b/crates/keel-compiler/src/types/checker/expr.rs
@@ -1137,8 +1137,11 @@ impl Checker<'_, '_> {
         match members {
             super::ModuleMembers::Std(ns) => match prelude::catalog_method(&ns, method) {
                 Some(entry) => {
-                    if !self.agent_capability_allows(&ns, method, binding, span) {
+                    if !self.agent_capability_allows(&ns, method, binding, span.clone()) {
                         return Ty::Error;
+                    }
+                    if ns == "ai" && method == "install" {
+                        self.check_ai_install_arg(args, span);
                     }
                     self.catalog_result_ty(entry, args)
                 }
@@ -1182,6 +1185,26 @@ impl Checker<'_, '_> {
                 );
                 Ty::Error
             }
+        }
+    }
+
+    /// Validate the argument to `ai.install(X)`: `X` must be a bare type name
+    /// that implements `LlmProvider`. Reuses the same conformance rule as
+    /// `@provider X` so the two install sites word rejections identically.
+    fn check_ai_install_arg(&mut self, args: &[CallArg], span: crate::lexer::Span) {
+        let Some(first) = args.first() else {
+            self.err_at(
+                "ai.install expects a provider type, e.g. `ai.install(MyProvider)`",
+                span,
+            );
+            return;
+        };
+        match &first.value.kind {
+            Expr::Ident(name) => self.check_provider_name(name, first.value.span.clone()),
+            _ => self.err_at(
+                "ai.install expects a provider type name, e.g. `ai.install(MyProvider)`",
+                first.value.span.clone(),
+            ),
         }
     }
 

--- a/crates/keel-compiler/src/types/checker/stmt.rs
+++ b/crates/keel-compiler/src/types/checker/stmt.rs
@@ -460,21 +460,44 @@ impl Checker<'_, '_> {
     }
 
     fn check_provider_attribute(&mut self, attr: &AttributeDecl) {
-        let ok = matches!(
-            &attr.body,
-            AttributeBody::Expr(node)
-                if matches!(
-                    &node.kind,
-                    Expr::Ident(name) if keel_catalog::is_builtin_llm_provider(name)
-                )
-        );
-        if !ok {
-            let span = match &attr.body {
-                AttributeBody::Expr(node) => node.span.clone(),
-                _ => self.current_span.clone().unwrap_or(0..0),
-            };
+        let AttributeBody::Expr(node) = &attr.body else {
+            let span = self.current_span.clone().unwrap_or(0..0);
             self.err_at(keel_catalog::provider_attribute_error(), span);
+            return;
+        };
+        let Expr::Ident(name) = &node.kind else {
+            self.err_at(keel_catalog::provider_attribute_error(), node.span.clone());
+            return;
+        };
+        self.check_provider_name(name, node.span.clone());
+    }
+
+    /// Validate a provider reference — `@provider X` or `ai.install(X)`.
+    ///
+    /// `X` must be a built-in backend name or a type implementing `LlmProvider`.
+    /// A user provider type must be field-less: the runtime constructs its
+    /// receiver with no fields, so configuration is read from `env.*` inside
+    /// `complete()`.
+    pub(crate) fn check_provider_name(&mut self, name: &str, span: Span) {
+        if keel_catalog::is_builtin_llm_provider(name) {
+            return;
         }
+        if self.llm_provider_types.contains(name) {
+            if let Some(fields) = self.structs.get(name)
+                && !fields.is_empty()
+            {
+                self.err_at(
+                    format!(
+                        "provider `{name}` must be a field-less type — read configuration \
+                         from env.* inside `complete()`, since the runtime constructs the \
+                         provider with no fields"
+                    ),
+                    span,
+                );
+            }
+            return;
+        }
+        self.err_at(keel_catalog::provider_attribute_error(), span);
     }
 
     fn check_block(&mut self, block: &Block, scope: &mut Scope) {

--- a/crates/keel-compiler/src/types/prelude.rs
+++ b/crates/keel-compiler/src/types/prelude.rs
@@ -148,6 +148,7 @@ static PRELUDE_NAMES: LazyLock<HashSet<String>> = LazyLock::new(|| {
         "EnvError",
         "AiError",
         "AiSchemaError",
+        "CompletionRequest",
         "CapabilityError",
         "TimeoutError",
         "DeadlineError",
@@ -198,6 +199,7 @@ static PRELUDE_NAMES: LazyLock<HashSet<String>> = LazyLock::new(|| {
         "Equatable",
         "Serializable",
         "Iterable",
+        "LlmProvider",
     ] {
         prelude.insert(iface.to_string());
     }
@@ -259,6 +261,13 @@ pub(crate) fn builtin_interfaces() -> HashMap<String, Vec<TaskSig>> {
         default: None,
         variadic: false,
     };
+    let named_param = |name: &str, ty: &str| Param {
+        name: Binding::Ident(name.to_string()),
+        name_span: 0..0,
+        ty: Node::synthetic(TypeExpr::Named(ty.to_string())),
+        default: None,
+        variadic: false,
+    };
 
     map.insert(
         "Stringable".to_string(),
@@ -305,7 +314,36 @@ pub(crate) fn builtin_interfaces() -> HashMap<String, Vec<TaskSig>> {
             return_type: Some(Node::synthetic(TypeExpr::List(Box::new(TypeExpr::Dynamic)))),
         }],
     );
+    map.insert(
+        "LlmProvider".to_string(),
+        vec![TaskSig {
+            name: "complete".to_string(),
+            name_span: 0..0,
+            params: vec![self_param(), named_param("req", "CompletionRequest")],
+            return_type: Some(Node::synthetic(TypeExpr::Named("str".to_string()))),
+        }],
+    );
 
+    map
+}
+
+/// Return the built-in struct types known to the checker without an explicit
+/// `type` declaration.
+///
+/// `CompletionRequest` is the value a user-authored `LlmProvider.complete`
+/// receives; registering it here lets `req.system`/`req.user`/`req.model`/
+/// `req.max_tokens` field access type-check.
+pub(crate) fn builtin_structs() -> HashMap<String, Vec<(String, Ty)>> {
+    let mut map = HashMap::new();
+    map.insert(
+        "CompletionRequest".to_string(),
+        vec![
+            ("system".to_string(), Ty::Str),
+            ("user".to_string(), Ty::Str),
+            ("model".to_string(), Ty::Str),
+            ("max_tokens".to_string(), Ty::Int),
+        ],
+    );
     map
 }
 

--- a/crates/keel-runtime/src/interpreter/call.rs
+++ b/crates/keel-runtime/src/interpreter/call.rs
@@ -144,9 +144,12 @@ impl Interpreter {
         //
         // A user-authored provider's `complete()` (active_providers non-empty)
         // is trusted program infrastructure — like a built-in backend that makes
-        // HTTP calls without the agent granting `@tools [http]` — so its own
-        // transport calls (env, http, …) run ungated regardless of the consuming
-        // agent's `@tools`.
+        // HTTP calls without the agent granting `@tools [http]` — so effectful
+        // calls (env, http, …) run ungated regardless of the consuming agent's
+        // `@tools`. The bypass covers everything reached while a provider is on
+        // the stack: the `complete()` body, any task it calls, and closures it
+        // spawns (which inherit `active_providers`) — all provider-authored,
+        // trusted code, never the consuming agent's own statements.
         if keel_catalog::module_requires_capability(ns_name)
             && self.active_providers.is_empty()
             && let Some(agent_mutex) = &self.current_agent

--- a/crates/keel-runtime/src/interpreter/call.rs
+++ b/crates/keel-runtime/src/interpreter/call.rs
@@ -141,7 +141,14 @@ impl Interpreter {
         // `@tools` may not call any effectful module; `@tools all` is the
         // explicit unrestricted form. Pure-compute modules (json, math, …)
         // and __global (agent lifecycle builtins) are never gated.
+        //
+        // A user-authored provider's `complete()` (active_providers non-empty)
+        // is trusted program infrastructure — like a built-in backend that makes
+        // HTTP calls without the agent granting `@tools [http]` — so its own
+        // transport calls (env, http, …) run ungated regardless of the consuming
+        // agent's `@tools`.
         if keel_catalog::module_requires_capability(ns_name)
+            && self.active_providers.is_empty()
             && let Some(agent_mutex) = &self.current_agent
         {
             let (allowed, agent_name) = {

--- a/crates/keel-runtime/src/interpreter/decl.rs
+++ b/crates/keel-runtime/src/interpreter/decl.rs
@@ -278,18 +278,19 @@ impl Interpreter {
                     }
                 }
 
-                // Validate @provider — only built-in backend names in v0.1.
+                // Validate @provider: it must be a bare identifier — a built-in
+                // backend name or a user type implementing `LlmProvider`.
+                // Conformance for a user type is enforced by the checker (which
+                // `keel run` runs before execution) and again at dispatch time,
+                // so a registration-order-dependent impl-presence check here is
+                // neither needed nor reliable.
                 for attr in &def.attributes {
                     if attr.name == "provider" {
-                        let valid = matches!(
+                        let is_ident = matches!(
                             &attr.body,
-                            AttributeBody::Expr(node)
-                                if matches!(
-                                    &node.kind,
-                                    Expr::Ident(name) if keel_catalog::is_builtin_llm_provider(name)
-                                )
+                            AttributeBody::Expr(node) if matches!(&node.kind, Expr::Ident(_))
                         );
-                        if !valid {
+                        if !is_ident {
                             return Err(runtime_error(keel_catalog::provider_attribute_error()));
                         }
                     }
@@ -757,14 +758,31 @@ mod tests {
     }
 
     #[test]
-    fn agent_provider_unknown_name_is_error() {
+    fn agent_provider_user_type_name_is_accepted() {
+        // A non-built-in identifier is a user provider type; conformance is the
+        // checker's job, so registration accepts it without an impl present.
         let mut interp = new_interp();
         let decl = Decl::Agent(AgentDecl {
             name: "Bot".into(),
             name_span: 0..0,
             items: vec![AgentItem::Attribute(AttributeDecl {
                 name: "provider".into(),
-                body: AttributeBody::Expr(Node::synthetic(Expr::Ident("bogus".into()))),
+                body: AttributeBody::Expr(Node::synthetic(Expr::Ident("MyProvider".into()))),
+            })],
+        });
+        assert!(interp.register_decl(&decl).is_ok());
+    }
+
+    #[test]
+    fn agent_provider_non_ident_body_is_error() {
+        // A malformed @provider (not a bare identifier) is rejected outright.
+        let mut interp = new_interp();
+        let decl = Decl::Agent(AgentDecl {
+            name: "Bot".into(),
+            name_span: 0..0,
+            items: vec![AgentItem::Attribute(AttributeDecl {
+                name: "provider".into(),
+                body: AttributeBody::Expr(Node::synthetic(Expr::Integer(1))),
             })],
         });
         let err = interp.register_decl(&decl).unwrap_err();

--- a/crates/keel-runtime/src/interpreter/host.rs
+++ b/crates/keel-runtime/src/interpreter/host.rs
@@ -99,8 +99,25 @@ pub trait Host: Send {
     fn current_model(&self) -> String;
 
     /// The `@provider` attribute of the current agent (a built-in backend
-    /// name like `openai`), or `None` when absent.
+    /// name like `openai`, or a user-authored provider type), or `None`.
     fn current_provider(&self) -> Option<String>;
+
+    // ── user-authored provider registry ───────────────────────────────────
+
+    /// Type name registered program-wide via `ai.install`, or `None`.
+    fn installed_provider(&self) -> Option<String>;
+
+    /// Register `type_name` as the program-wide user provider (`ai.install`).
+    fn set_installed_provider(&mut self, type_name: String);
+
+    /// Whether `type_name`'s `complete()` is currently on the call stack.
+    fn provider_is_active(&self, type_name: &str) -> bool;
+
+    /// Mark `type_name`'s `complete()` as entered (re-entry guard).
+    fn push_active_provider(&mut self, type_name: String);
+
+    /// Mark `type_name`'s `complete()` as exited (re-entry guard).
+    fn pop_active_provider(&mut self, type_name: &str);
 
     /// The `@limits { max_tokens }` value of the current agent, or `None`.
     fn current_max_tokens(&self) -> Option<u32>;
@@ -243,6 +260,28 @@ impl Host for Interpreter {
         Interpreter::current_provider(self)
     }
 
+    fn installed_provider(&self) -> Option<String> {
+        self.installed_provider.clone()
+    }
+
+    fn set_installed_provider(&mut self, type_name: String) {
+        self.installed_provider = Some(type_name);
+    }
+
+    fn provider_is_active(&self, type_name: &str) -> bool {
+        self.active_providers.iter().any(|n| n == type_name)
+    }
+
+    fn push_active_provider(&mut self, type_name: String) {
+        self.active_providers.push(type_name);
+    }
+
+    fn pop_active_provider(&mut self, type_name: &str) {
+        if let Some(pos) = self.active_providers.iter().rposition(|n| n == type_name) {
+            self.active_providers.remove(pos);
+        }
+    }
+
     fn current_max_tokens(&self) -> Option<u32> {
         Interpreter::current_max_tokens(self)
     }
@@ -305,6 +344,11 @@ impl Host for Interpreter {
             let event_tx = self.event_tx.clone();
             let active_http_servers = self.active_http_servers.clone();
             let live_agents = self.live_agents.clone();
+            // Carry the program-wide user provider and the re-entrancy guard so a
+            // spawned closure routes `ai.*` through the same installed provider and
+            // still trips the recursion guard for it.
+            let installed_provider = self.installed_provider.clone();
+            let active_providers = self.active_providers.clone();
 
             let handle = tokio::spawn(async move {
                 let mut local_interp = Interpreter::with_runtime(runtime);
@@ -322,6 +366,8 @@ impl Host for Interpreter {
                 local_interp.live_agents = live_agents;
                 local_interp.current_agent = current_agent;
                 local_interp.program_name = program_name;
+                local_interp.installed_provider = installed_provider;
+                local_interp.active_providers = active_providers;
                 local_interp
                     .call_closure(&params, &body, vec![])
                     .await
@@ -431,6 +477,26 @@ impl Host for MockHost {
 
     fn current_provider(&self) -> Option<String> {
         None
+    }
+
+    fn installed_provider(&self) -> Option<String> {
+        None
+    }
+
+    fn set_installed_provider(&mut self, _type_name: String) {
+        unimplemented!("MockHost does not support set_installed_provider")
+    }
+
+    fn provider_is_active(&self, _type_name: &str) -> bool {
+        false
+    }
+
+    fn push_active_provider(&mut self, _type_name: String) {
+        unimplemented!("MockHost does not support push_active_provider")
+    }
+
+    fn pop_active_provider(&mut self, _type_name: &str) {
+        unimplemented!("MockHost does not support pop_active_provider")
     }
 
     fn current_max_tokens(&self) -> Option<u32> {

--- a/crates/keel-runtime/src/interpreter/state.rs
+++ b/crates/keel-runtime/src/interpreter/state.rs
@@ -213,6 +213,14 @@ pub struct Interpreter {
     /// Format: `<stem>_<sha256[:12]>` for real files; `__repl__` / `__inline__`
     /// for REPL and inline evaluations. Defaults to `"__inline__"`.
     pub(crate) program_name: String,
+    /// Type name of the user-authored provider registered with `ai.install`,
+    /// or `None` when no program-wide user provider is installed. This is the
+    /// lowest-precedence backend, below per-call prefixes and `@provider`.
+    pub(crate) installed_provider: Option<String>,
+    /// User-provider type names whose `complete()` is currently executing.
+    /// Guards against a provider re-entering `ai.*` from inside its own
+    /// `complete()`, which would recurse without bound.
+    pub(crate) active_providers: Vec<String>,
 }
 
 impl Interpreter {
@@ -242,6 +250,8 @@ impl Interpreter {
             active_http_servers: Arc::new(AtomicU64::new(0)),
             source: None,
             program_name: "__inline__".to_string(),
+            installed_provider: None,
+            active_providers: Vec::new(),
         };
         crate::runtime::install_prelude(&mut interp);
         interp
@@ -396,10 +406,11 @@ impl Interpreter {
             .unwrap_or_else(|| "default".to_string())
     }
 
-    /// The current agent's `@provider` attribute — a built-in backend name
-    /// (`ollama`, `openai`, `anthropic`) written as a bareword identifier — or
-    /// `None` when absent. The `ai` namespace uses it as the agent's default
-    /// provider for model tags that carry no `provider:` prefix.
+    /// The current agent's `@provider` attribute, written as a bareword
+    /// identifier — either a built-in backend name (`ollama`, `openai`,
+    /// `anthropic`) or a user-authored provider type — or `None` when absent.
+    /// The `ai` namespace uses it as the agent's default provider for model
+    /// tags that carry no `provider:` prefix.
     pub fn current_provider(&self) -> Option<String> {
         let agent = self.current_agent.as_ref()?;
         let def = agent.lock().def.clone();
@@ -614,6 +625,13 @@ fn builtin_interfaces() -> HashMap<String, Vec<TaskSig>> {
         default: None,
         variadic: false,
     };
+    let named_param = |name: &str, ty: &str| Param {
+        name: Binding::Ident(name.to_string()),
+        name_span: 0..0,
+        ty: Node::synthetic(TypeExpr::Named(ty.to_string())),
+        default: None,
+        variadic: false,
+    };
 
     map.insert(
         "Stringable".to_string(),
@@ -659,6 +677,15 @@ fn builtin_interfaces() -> HashMap<String, Vec<TaskSig>> {
             params: vec![self_param()],
             // list[dynamic] — wildcard list return, matches any list[T] in conformance checks
             return_type: Some(Node::synthetic(TypeExpr::List(Box::new(TypeExpr::Dynamic)))),
+        }],
+    );
+    map.insert(
+        "LlmProvider".to_string(),
+        vec![TaskSig {
+            name: "complete".to_string(),
+            name_span: 0..0,
+            params: vec![self_param(), named_param("req", "CompletionRequest")],
+            return_type: Some(Node::synthetic(TypeExpr::Named("str".to_string()))),
         }],
     );
     map

--- a/crates/keel-runtime/src/runtime/llm.rs
+++ b/crates/keel-runtime/src/runtime/llm.rs
@@ -7,6 +7,8 @@
 
 use std::borrow::Cow;
 use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -31,6 +33,41 @@ const DEFAULT_MAX_TOKENS: u32 = 4096;
 ///
 /// Re-exported from [`keel_catalog`] so the checker and runtime never disagree.
 pub use keel_catalog::BUILTIN_LLM_PROVIDERS as BUILTIN_PROVIDERS;
+
+/// Boxed, non-`'static` future a user-provider transport returns.
+///
+/// Unlike [`super::providers::LlmFuture`] (which is `'static`), this future may
+/// borrow the interpreter for `'a`, because a user provider re-enters the
+/// interpreter inline to run its `complete()` method.
+type UserTransportFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<Option<String>, LlmError>> + Send + 'a>>;
+
+/// One-shot transport that turns a [`CompletionRequest`] into raw model output
+/// by invoking a user-authored Keel provider.
+type UserTransportFn<'a> =
+    Box<dyn FnOnce(CompletionRequest) -> UserTransportFuture<'a> + Send + 'a>;
+
+/// The transport seam for a single model call.
+///
+/// The built-in path dispatches through the [`LlmProvider`] registry; the user
+/// path re-enters the interpreter. Keeping this at the call boundary lets the
+/// prompt-construction and output-parsing logic in [`LlmClient`] stay identical
+/// across both — only the transport differs.
+pub enum Transport<'a> {
+    /// Dispatch through the built-in provider registry (model-prefix routed).
+    Builtin,
+    /// Run a user-authored `impl LlmProvider`, re-entering the interpreter.
+    User(UserTransportFn<'a>),
+}
+
+impl std::fmt::Debug for Transport<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Builtin => f.write_str("Transport::Builtin"),
+            Self::User(_) => f.write_str("Transport::User(..)"),
+        }
+    }
+}
 
 /// Dispatches `ai.*` primitives through a registry of [`LlmProvider`] backends.
 ///
@@ -143,6 +180,10 @@ impl LlmClient {
         self.provider_for(model).describe_model(model)
     }
 
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "prelude API maps named Keel arguments directly into the LLM request"
+    )]
     async fn call(
         &self,
         role: Option<&str>,
@@ -151,8 +192,13 @@ impl LlmClient {
         user: &str,
         model: &str,
         max_tokens: Option<u32>,
+        transport: Transport<'_>,
     ) -> Result<Option<String>, LlmError> {
-        if let Some(message) = &self.provider_config_error {
+        // A bad program-default only blocks the built-in path; a user provider
+        // or an explicit `provider:` prefix is unaffected by it.
+        if matches!(transport, Transport::Builtin)
+            && let Some(message) = &self.provider_config_error
+        {
             return Err(LlmError::ConfigError(message.clone()));
         }
         let mut full_system = match role {
@@ -179,14 +225,16 @@ impl LlmClient {
             );
         }
 
-        self.provider_for(model)
-            .complete(CompletionRequest {
-                system: full_system,
-                user: user.to_string(),
-                model: model.to_string(),
-                max_tokens: max_tokens.unwrap_or(DEFAULT_MAX_TOKENS),
-            })
-            .await
+        let request = CompletionRequest {
+            system: full_system,
+            user: user.to_string(),
+            model: model.to_string(),
+            max_tokens: max_tokens.unwrap_or(DEFAULT_MAX_TOKENS),
+        };
+        match transport {
+            Transport::Builtin => self.provider_for(model).complete(request).await,
+            Transport::User(run) => run(request).await,
+        }
     }
 
     // ── High-level primitives used by the Ai namespace ────────────────
@@ -204,6 +252,7 @@ impl LlmClient {
         criteria: &[(String, String)],
         model: &str,
         max_tokens: Option<u32>,
+        transport: Transport<'_>,
     ) -> Result<Option<String>, LlmError> {
         let variants_str = variants.join(", ");
         if self.trace.load(Ordering::Relaxed) {
@@ -228,7 +277,7 @@ impl LlmClient {
         }
 
         let Some(response) = self
-            .call(role, rules, &system, input, model, max_tokens)
+            .call(role, rules, &system, input, model, max_tokens, transport)
             .await?
         else {
             return Ok(None);
@@ -272,6 +321,7 @@ impl LlmClient {
         unit: Option<String>,
         model: &str,
         max_tokens: Option<u32>,
+        transport: Transport<'_>,
     ) -> Result<Option<String>, LlmError> {
         let length_instruction = match &length {
             Some((n, unit)) => format!("in {n} {unit}"),
@@ -308,7 +358,7 @@ impl LlmClient {
             system.push_str(&format!(" Use at most {n} {unit_str}."));
         }
         let Some(response) = self
-            .call(role, rules, &system, input, model, max_tokens)
+            .call(role, rules, &system, input, model, max_tokens, transport)
             .await?
         else {
             return Ok(None);
@@ -333,6 +383,7 @@ impl LlmClient {
         max_length: Option<i64>,
         model: &str,
         max_tokens: Option<u32>,
+        transport: Transport<'_>,
     ) -> Result<Option<String>, LlmError> {
         let tone_s = tone.unwrap_or("neutral");
         if self.trace.load(Ordering::Relaxed) {
@@ -358,7 +409,15 @@ impl LlmClient {
         }
 
         let Some(response) = self
-            .call(role, rules, &system, description, model, max_tokens)
+            .call(
+                role,
+                rules,
+                &system,
+                description,
+                model,
+                max_tokens,
+                transport,
+            )
             .await?
         else {
             return Ok(None);
@@ -369,6 +428,10 @@ impl LlmClient {
         Ok(Some(response.trim().to_string()))
     }
 
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "prelude API maps named Keel arguments directly into the LLM request"
+    )]
     pub async fn extract(
         &self,
         role: Option<&str>,
@@ -377,6 +440,7 @@ impl LlmClient {
         schema: &[(String, String)],
         model: &str,
         max_tokens: Option<u32>,
+        transport: Transport<'_>,
     ) -> Result<Option<String>, LlmError> {
         let fields_desc: Vec<String> = schema.iter().map(|(n, t)| format!("{n}: {t}")).collect();
         if self.trace.load(Ordering::Relaxed) {
@@ -395,7 +459,7 @@ impl LlmClient {
             fields_desc.join("\n  ")
         );
         let Some(response) = self
-            .call(role, rules, &system, input, model, max_tokens)
+            .call(role, rules, &system, input, model, max_tokens, transport)
             .await?
         else {
             return Ok(None);
@@ -406,6 +470,10 @@ impl LlmClient {
         Ok(Some(response.trim().to_string()))
     }
 
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "prelude API maps named Keel arguments directly into the LLM request"
+    )]
     pub async fn translate(
         &self,
         role: Option<&str>,
@@ -414,6 +482,7 @@ impl LlmClient {
         target_langs: &[String],
         model: &str,
         max_tokens: Option<u32>,
+        transport: Transport<'_>,
     ) -> Result<Option<HashMap<String, String>>, LlmError> {
         let langs = target_langs.join(", ");
         if self.trace.load(Ordering::Relaxed) {
@@ -438,7 +507,7 @@ impl LlmClient {
             )
         };
         let Some(response) = self
-            .call(role, rules, &system, input, model, max_tokens)
+            .call(role, rules, &system, input, model, max_tokens, transport)
             .await?
         else {
             return Ok(None);
@@ -465,6 +534,10 @@ impl LlmClient {
         }
     }
 
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "prelude API maps named Keel arguments directly into the LLM request"
+    )]
     pub async fn decide(
         &self,
         role: Option<&str>,
@@ -473,6 +546,7 @@ impl LlmClient {
         options: &[String],
         model: &str,
         max_tokens: Option<u32>,
+        transport: Transport<'_>,
     ) -> Result<Option<(String, String)>, LlmError> {
         if self.trace.load(Ordering::Relaxed) {
             println!(
@@ -492,7 +566,7 @@ impl LlmClient {
             options.join(", ")
         );
         let Some(response) = self
-            .call(role, rules, &system, input, model, max_tokens)
+            .call(role, rules, &system, input, model, max_tokens, transport)
             .await?
         else {
             return Ok(None);
@@ -541,6 +615,7 @@ impl LlmClient {
         response_format: Option<String>,
         model: &str,
         max_tokens: Option<u32>,
+        transport: Transport<'_>,
     ) -> Result<Option<String>, LlmError> {
         if self.trace.load(Ordering::Relaxed) {
             println!(
@@ -554,7 +629,7 @@ impl LlmClient {
             full_sys.push_str("\n\nRespond with valid JSON only. No prose, no markdown fences.");
         }
         let Some(response) = self
-            .call(role, rules, &full_sys, user, model, max_tokens)
+            .call(role, rules, &full_sys, user, model, max_tokens, transport)
             .await?
         else {
             return Ok(None);
@@ -597,7 +672,7 @@ fn truncate(s: &str, max: usize) -> Cow<'_, str> {
 
 #[cfg(test)]
 mod tests {
-    use super::{LlmClient, LlmError, truncate};
+    use super::{LlmClient, LlmError, Transport, truncate};
     use crate::runtime::context::MapEnv;
     use std::net::SocketAddr;
 
@@ -678,6 +753,7 @@ mod tests {
                 None,
                 "fast-model",
                 None,
+                Transport::Builtin,
             )
             .await
             .expect("summarize should succeed")
@@ -706,6 +782,7 @@ mod tests {
                 None,
                 "ollama:fast-model",
                 None,
+                Transport::Builtin,
             )
             .await
             .expect("summarize should succeed")
@@ -732,6 +809,7 @@ mod tests {
                 None,
                 "ollama:llama3",
                 None,
+                Transport::Builtin,
             )
             .await
             .expect("summarize should succeed")
@@ -754,6 +832,7 @@ mod tests {
                 &[("urgent tickets".to_string(), "high".to_string())],
                 "default",
                 None,
+                Transport::Builtin,
             )
             .await
             .expect("classify should succeed");
@@ -775,6 +854,7 @@ mod tests {
                 &[],
                 "default",
                 None,
+                Transport::Builtin,
             )
             .await
             .expect_err("unknown variant should be a schema error");
@@ -796,6 +876,7 @@ mod tests {
                 Some("json".to_string()),
                 "default",
                 None,
+                Transport::Builtin,
             )
             .await
             .expect_err("json prompt should validate response JSON");
@@ -813,7 +894,17 @@ mod tests {
         let client = client(&base_url, &[]);
 
         let err = client
-            .draft(None, &[], "write", None, None, None, "default", None)
+            .draft(
+                None,
+                &[],
+                "write",
+                None,
+                None,
+                None,
+                "default",
+                None,
+                Transport::Builtin,
+            )
             .await
             .expect_err("HTTP 500 should fail");
 
@@ -835,6 +926,7 @@ mod tests {
                 &[("name".into(), "str".into())],
                 "default",
                 None,
+                Transport::Builtin,
             )
             .await
             .expect_err("malformed JSON should fail");
@@ -857,6 +949,7 @@ mod tests {
                 &["fr".to_string(), "es".to_string()],
                 "default",
                 None,
+                Transport::Builtin,
             )
             .await
             .expect("translate should succeed")
@@ -879,6 +972,7 @@ mod tests {
                 &["ship".to_string()],
                 "default",
                 None,
+                Transport::Builtin,
             )
             .await
             .expect("decide should succeed")
@@ -930,7 +1024,16 @@ mod tests {
         ]));
 
         let out = client
-            .prompt(None, &[], "sys", "user", None, "openai:gpt-4o", None)
+            .prompt(
+                None,
+                &[],
+                "sys",
+                "user",
+                None,
+                "openai:gpt-4o",
+                None,
+                Transport::Builtin,
+            )
             .await
             .expect("prompt should succeed")
             .expect("content should be present");
@@ -955,6 +1058,7 @@ mod tests {
                 None,
                 "anthropic:claude-opus-4-8",
                 None,
+                Transport::Builtin,
             )
             .await
             .expect("prompt should succeed")
@@ -971,7 +1075,16 @@ mod tests {
         )]));
 
         let err = client
-            .prompt(None, &[], "sys", "user", None, "anthropic:claude-x", None)
+            .prompt(
+                None,
+                &[],
+                "sys",
+                "user",
+                None,
+                "anthropic:claude-x",
+                None,
+                Transport::Builtin,
+            )
             .await
             .expect_err("missing key should be a config error");
 
@@ -989,7 +1102,16 @@ mod tests {
         ]));
 
         let out = client
-            .prompt(None, &[], "s", "u", None, "gpt-4o", None)
+            .prompt(
+                None,
+                &[],
+                "s",
+                "u",
+                None,
+                "gpt-4o",
+                None,
+                Transport::Builtin,
+            )
             .await
             .expect("prompt should succeed")
             .expect("content should be present");
@@ -1016,6 +1138,7 @@ mod tests {
                 None,
                 "ollama:default",
                 None,
+                Transport::Builtin,
             )
             .await
             .expect("summarize should succeed")
@@ -1031,7 +1154,16 @@ mod tests {
         let client = LlmClient::from_env(&MapEnv::with(&[("KEEL_PROVIDER", "claude")]));
 
         let err = client
-            .prompt(None, &[], "s", "u", None, "gpt-4o", None)
+            .prompt(
+                None,
+                &[],
+                "s",
+                "u",
+                None,
+                "gpt-4o",
+                None,
+                Transport::Builtin,
+            )
             .await
             .expect_err("an unknown KEEL_PROVIDER must be a config error");
 
@@ -1049,7 +1181,16 @@ mod tests {
         ]));
 
         let err = client
-            .prompt(None, &[], "s", "u", None, "default", None)
+            .prompt(
+                None,
+                &[],
+                "s",
+                "u",
+                None,
+                "default",
+                None,
+                Transport::Builtin,
+            )
             .await
             .expect_err("the default sentinel under openai must be a config error");
 

--- a/crates/keel-runtime/src/runtime/namespace.rs
+++ b/crates/keel-runtime/src/runtime/namespace.rs
@@ -5,12 +5,27 @@ use crate::interpreter::{RuntimeError, RuntimeErrorKind};
 /// Returns a bare `miette::Report` wrapping a typed `RuntimeError` with a
 /// stable diagnostic code. Use this inside `.map_err()` closures. Use
 /// `throw_typed_error` instead when the call site returns `miette::Result<Value>`
-/// directly.
+/// directly, or `make_typed_report_with` when you need a bare `Report` plus an
+/// extra named field.
 pub(crate) fn make_typed_report(
     kind: RuntimeErrorKind,
     message: impl Into<String>,
 ) -> miette::Report {
+    make_typed_report_with(kind, message, None)
+}
+
+/// Like `make_typed_report`, but optionally attaches one extra named field
+/// (e.g. `got` for `AiSchemaError`, `reason` for provider errors).
+pub(crate) fn make_typed_report_with(
+    kind: RuntimeErrorKind,
+    message: impl Into<String>,
+    extra: Option<(&str, String)>,
+) -> miette::Report {
     let mut fields = std::collections::HashMap::new();
+    if let Some((key, val)) = extra {
+        fields.insert(key.to_string(), Value::String(val));
+    }
+    // Insert "message" last so it is never overwritten by an extra field.
     fields.insert("message".to_string(), Value::String(message.into()));
     miette::Report::new(RuntimeError::new(kind, fields))
 }
@@ -22,13 +37,7 @@ pub(crate) fn throw_typed_error(
     message: &str,
     extra: Option<(&str, String)>,
 ) -> miette::Result<Value> {
-    let mut fields = std::collections::HashMap::new();
-    if let Some((key, val)) = extra {
-        fields.insert(key.to_string(), Value::String(val));
-    }
-    // Insert "message" last so it is never overwritten by an extra field.
-    fields.insert("message".to_string(), Value::String(message.to_string()));
-    Err(miette::Report::new(RuntimeError::new(kind, fields)))
+    Err(make_typed_report_with(kind, message, extra))
 }
 
 pub(crate) fn find_arg<'a>(args: &'a [CallArgValue], name: &str) -> Option<&'a Value> {

--- a/crates/keel-runtime/src/runtime/namespaces/ai.rs
+++ b/crates/keel-runtime/src/runtime/namespaces/ai.rs
@@ -4,7 +4,9 @@ use crate::interpreter::value::{MapKey, Value};
 use crate::interpreter::{CallArgValue, Host, Namespace, RuntimeErrorKind};
 use crate::runtime::convert::json_to_value;
 use crate::runtime::llm::{LlmError, Transport};
-use crate::runtime::namespace::{find_arg, ns, positional, throw_typed_error};
+use crate::runtime::namespace::{
+    find_arg, make_typed_report_with, ns, positional, throw_typed_error,
+};
 use crate::runtime::providers::CompletionRequest;
 
 /// Map an `LlmError` to a typed Keel runtime error.
@@ -343,15 +345,14 @@ fn transport_for(
         return Ok(Transport::Builtin);
     };
     if host.provider_is_active(&type_name) {
-        return Err(throw_typed_error(
+        return Err(make_typed_report_with(
             RuntimeErrorKind::Ai,
-            &format!(
+            format!(
                 "provider `{type_name}` called an `ai.*` operation from inside its own \
                  `complete()`; this would recurse without bound"
             ),
             Some(("reason", "provider".into())),
-        )
-        .expect_err("throw_typed_error always returns Err"));
+        ));
     }
     Ok(Transport::User(Box::new(move |req| {
         Box::pin(async move {

--- a/crates/keel-runtime/src/runtime/namespaces/ai.rs
+++ b/crates/keel-runtime/src/runtime/namespaces/ai.rs
@@ -3,8 +3,9 @@ use std::collections::HashMap;
 use crate::interpreter::value::{MapKey, Value};
 use crate::interpreter::{CallArgValue, Host, Namespace, RuntimeErrorKind};
 use crate::runtime::convert::json_to_value;
-use crate::runtime::llm::LlmError;
+use crate::runtime::llm::{LlmError, Transport};
 use crate::runtime::namespace::{find_arg, ns, positional, throw_typed_error};
+use crate::runtime::providers::CompletionRequest;
 
 /// Map an `LlmError` to a typed Keel runtime error.
 ///
@@ -45,7 +46,7 @@ pub(crate) fn namespace() -> Namespace {
                 .to_display_string();
             let variants = classify_variants(host, &args)?;
             let criteria = extract_criteria(&args);
-            let model = resolve_model(host, &args);
+            let (model, user_provider) = resolve_provider(host, &args);
             let max_tokens = host.current_max_tokens();
             let role = host.current_role();
             let enum_type = find_arg(&args, "as").and_then(|v| match v {
@@ -55,7 +56,8 @@ pub(crate) fn namespace() -> Namespace {
 
             let rules = host.current_rules();
             let llm = host.runtime().llm.clone();
-            match llm.classify(role.as_deref(), &rules, &input, &variants, &criteria, &model, max_tokens).await {
+            let transport = transport_for(host, user_provider)?;
+            match llm.classify(role.as_deref(), &rules, &input, &variants, &criteria, &model, max_tokens, transport).await {
                 Ok(Some(variant)) => Ok(Value::EnumVariant(enum_type, variant, None)),
                 Ok(None) => Ok(Value::None),
                 Err(e) => throw_llm_error(e),
@@ -73,12 +75,13 @@ pub(crate) fn namespace() -> Namespace {
             };
             let format = find_arg(&args, "format").map(|v| v.to_display_string());
             let max = find_arg(&args, "max").and_then(|v| v.as_int());
-            let model = resolve_model(host, &args);
+            let (model, user_provider) = resolve_provider(host, &args);
             let max_tokens = host.current_max_tokens();
             let role = host.current_role();
             let rules = host.current_rules();
             let llm = host.runtime().llm.clone();
-            match llm.summarize(role.as_deref(), &rules, &input, length, format, max, unit_val, &model, max_tokens).await {
+            let transport = transport_for(host, user_provider)?;
+            match llm.summarize(role.as_deref(), &rules, &input, length, format, max, unit_val, &model, max_tokens, transport).await {
                 Ok(Some(s)) => Ok(Value::String(s)),
                 Ok(None) => Ok(Value::None),
                 Err(e) => throw_llm_error(e),
@@ -92,13 +95,14 @@ pub(crate) fn namespace() -> Namespace {
             let tone = find_arg(&args, "tone").map(|v| v.to_display_string());
             let guidance = find_arg(&args, "guidance").map(|v| v.to_display_string());
             let max_length = find_arg(&args, "max_length").and_then(|v| v.as_int());
-            let model = resolve_model(host, &args);
+            let (model, user_provider) = resolve_provider(host, &args);
             let max_tokens = host.current_max_tokens();
             let role = host.current_role();
             let rules = host.current_rules();
             let llm = host.runtime().llm.clone();
+            let transport = transport_for(host, user_provider)?;
             match llm
-                .draft(role.as_deref(), &rules, &description, tone.as_deref(), guidance.as_deref(), max_length, &model, max_tokens)
+                .draft(role.as_deref(), &rules, &description, tone.as_deref(), guidance.as_deref(), max_length, &model, max_tokens, transport)
                 .await
             {
                 Ok(Some(s)) => Ok(Value::String(s)),
@@ -139,12 +143,13 @@ pub(crate) fn namespace() -> Namespace {
                         _ => (Vec::new(), None),
                     },
                 };
-            let model = resolve_model(host, &args);
+            let (model, user_provider) = resolve_provider(host, &args);
             let max_tokens = host.current_max_tokens();
             let role = host.current_role();
             let rules = host.current_rules();
             let llm = host.runtime().llm.clone();
-            match llm.extract(role.as_deref(), &rules, &input, &schema, &model, max_tokens).await {
+            let transport = transport_for(host, user_provider)?;
+            match llm.extract(role.as_deref(), &rules, &input, &schema, &model, max_tokens, transport).await {
                 Ok(Some(json)) => {
                     if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&json) {
                         let v = json_to_value(&parsed);
@@ -180,12 +185,13 @@ pub(crate) fn namespace() -> Namespace {
                     "ai.translate: `to:` must contain at least one language"
                 ));
             }
-            let model = resolve_model(host, &args);
+            let (model, user_provider) = resolve_provider(host, &args);
             let max_tokens = host.current_max_tokens();
             let role = host.current_role();
             let rules = host.current_rules();
             let llm = host.runtime().llm.clone();
-            match llm.translate(role.as_deref(), &rules, &input, &target_langs, &model, max_tokens).await {
+            let transport = transport_for(host, user_provider)?;
+            match llm.translate(role.as_deref(), &rules, &input, &target_langs, &model, max_tokens, transport).await {
                 Ok(Some(map)) if target_langs.len() == 1 => {
                     Ok(Value::String(map.into_values().next().unwrap_or_default()))
                 }
@@ -209,12 +215,13 @@ pub(crate) fn namespace() -> Namespace {
                 Some(Value::List(items)) => items.iter().map(|v| v.to_display_string()).collect(),
                 _ => Vec::new(),
             };
-            let model = resolve_model(host, &args);
+            let (model, user_provider) = resolve_provider(host, &args);
             let max_tokens = host.current_max_tokens();
             let role = host.current_role();
             let rules = host.current_rules();
             let llm = host.runtime().llm.clone();
-            match llm.decide(role.as_deref(), &rules, &input, &options, &model, max_tokens).await {
+            let transport = transport_for(host, user_provider)?;
+            match llm.decide(role.as_deref(), &rules, &input, &options, &model, max_tokens, transport).await {
                 Ok(Some((choice, reason))) => {
                     let mut m = HashMap::new();
                     m.insert(MapKey::Str("choice".into()), Value::String(choice));
@@ -231,12 +238,13 @@ pub(crate) fn namespace() -> Namespace {
             let system = find_arg(&args, "system").map(|v| v.to_display_string()).unwrap_or_default();
             let user = find_arg(&args, "user").map(|v| v.to_display_string()).unwrap_or_default();
             let response_format = find_arg(&args, "response_format").map(|v| v.to_display_string());
-            let model = resolve_model(host, &args);
+            let (model, user_provider) = resolve_provider(host, &args);
             let max_tokens = host.current_max_tokens();
             let role = host.current_role();
             let rules = host.current_rules();
             let llm = host.runtime().llm.clone();
-            match llm.prompt(role.as_deref(), &rules, &system, &user, response_format, &model, max_tokens).await {
+            let transport = transport_for(host, user_provider)?;
+            match llm.prompt(role.as_deref(), &rules, &system, &user, response_format, &model, max_tokens, transport).await {
                 Ok(Some(s)) => Ok(Value::String(s)),
                 Ok(None) => Ok(Value::None),
                 Err(e) => throw_llm_error(e),
@@ -247,33 +255,150 @@ pub(crate) fn namespace() -> Namespace {
             // v0.1: embeddings not wired yet.
             Ok(Value::List(vec![]))
         }),
+
+        "install" => |host, args| Box::pin(async move {
+            let type_name = match positional(&args, 0) {
+                Some(Value::Namespace(n)) => n.clone(),
+                other => {
+                    let got = other.map_or_else(
+                        || "nothing".to_string(),
+                        |v| format!("a {}", v.type_name()),
+                    );
+                    return Err(miette::miette!(
+                        "ai.install expects a provider type implementing `LlmProvider`, \
+                         e.g. `ai.install(MyProvider)` — got {got}"
+                    ));
+                }
+            };
+            // Conformance is also enforced by the checker; this guards the
+            // interpreter path (e.g. REPL) and pins the error to the install site.
+            let probe = Value::Struct(type_name.clone(), HashMap::new());
+            if host.find_impl_task(&probe, "complete").is_none() {
+                return throw_typed_error(
+                    RuntimeErrorKind::Ai,
+                    &format!(
+                        "`{type_name}` cannot be installed as a provider: it has no \
+                         `impl LlmProvider` with a `complete` method"
+                    ),
+                    Some(("reason", "provider".into())),
+                );
+            }
+            host.set_installed_provider(type_name);
+            Ok(Value::None)
+        }),
     })
 }
 
-/// Resolve the model string for an Ai.* call:
-///   1. explicit `using: "model"` argument
-///   2. enclosing agent's `@model` attribute
-///   3. `"default"` (triggers KEEL_OLLAMA_MODEL catch-all)
-fn resolve_model(host: &dyn Host, args: &[CallArgValue]) -> String {
+/// Resolve the model tag and selected provider for an `ai.*` call.
+///
+/// Returns the model string to send and, when a user-authored provider applies,
+/// its type name. Precedence, most-specific first:
+///   1. explicit `provider:` prefix on the tag (`using:` or `@model`) — built-in
+///   2. `@provider` on the enclosing agent (built-in name or user type)
+///   3. the program-wide `ai.install` provider (always a user type)
+///   4. the built-in program default
+///
+/// A built-in `@provider` is folded into the tag as a routing prefix (a bare
+/// `"gpt-4o"` under `@provider openai` becomes `"openai:gpt-4o"`); a user
+/// provider leaves the tag bare and is dispatched by re-entering the interpreter.
+fn resolve_provider(host: &dyn Host, args: &[CallArgValue]) -> (String, Option<String>) {
     let tag = match find_arg(args, "using") {
         Some(v) => v.to_display_string(),
         None => host.current_model(),
     };
-    provider_prefixed(host.current_provider().as_deref(), tag)
+    route_tag(
+        tag,
+        host.current_provider()
+            .or_else(|| host.installed_provider()),
+    )
 }
 
-/// Prepends the agent's `@provider` (`current`) as a routing prefix when the
-/// model tag carries no explicit `provider:` prefix of its own. A tag like
-/// `"anthropic:claude-opus-4-8"` is left untouched; a bare `"gpt-4o"` under
-/// `@provider openai` becomes `"openai:gpt-4o"`.
-fn provider_prefixed(current: Option<&str>, tag: String) -> String {
+/// Route a bare model tag against the selected `@provider`/`ai.install` name.
+///
+/// An explicit `provider:` prefix on `tag` always wins. Otherwise a built-in
+/// `provider` is folded in as a routing prefix, while a user-provider name is
+/// returned separately and the tag is left bare.
+fn route_tag(tag: String, provider: Option<String>) -> (String, Option<String>) {
     if keel_catalog::builtin_provider_prefix(&tag).is_some() {
-        return tag;
+        return (tag, None);
     }
-    match current {
-        Some(provider) => format!("{provider}:{tag}"),
-        None => tag,
+    match provider {
+        Some(name) if !keel_catalog::is_builtin_llm_provider(&name) => (tag, Some(name)),
+        Some(name) => (format!("{name}:{tag}"), None),
+        None => (tag, None),
     }
+}
+
+/// Build the transport for a call: the built-in registry, or a user provider.
+///
+/// # Errors
+///
+/// Returns an `AiError` when `user_provider`'s `complete()` is already on the
+/// call stack — a provider must not call `ai.*` from inside its own `complete()`.
+fn transport_for(
+    host: &mut dyn Host,
+    user_provider: Option<String>,
+) -> miette::Result<Transport<'_>> {
+    let Some(type_name) = user_provider else {
+        return Ok(Transport::Builtin);
+    };
+    if host.provider_is_active(&type_name) {
+        return Err(throw_typed_error(
+            RuntimeErrorKind::Ai,
+            &format!(
+                "provider `{type_name}` called an `ai.*` operation from inside its own \
+                 `complete()`; this would recurse without bound"
+            ),
+            Some(("reason", "provider".into())),
+        )
+        .expect_err("throw_typed_error always returns Err"));
+    }
+    Ok(Transport::User(Box::new(move |req| {
+        Box::pin(async move {
+            let receiver = Value::Struct(type_name.clone(), HashMap::new());
+            let Some(decl) = host.find_impl_task(&receiver, "complete") else {
+                return Err(LlmError::ConfigError(format!(
+                    "installed provider `{type_name}` has no `complete` method"
+                )));
+            };
+            host.push_active_provider(type_name.clone());
+            let call_args = vec![
+                CallArgValue {
+                    name: None,
+                    value: receiver,
+                },
+                CallArgValue {
+                    name: None,
+                    value: completion_request_to_value(&req),
+                },
+            ];
+            let outcome = host.call_task("complete", &decl, call_args).await;
+            host.pop_active_provider(&type_name);
+            match outcome {
+                Ok(Value::String(s)) => Ok(Some(s)),
+                Ok(Value::None) => Ok(None),
+                Ok(other) => Err(LlmError::CallFailed(format!(
+                    "provider `{type_name}` `complete()` must return str, got {}",
+                    other.type_name()
+                ))),
+                Err(report) => Err(LlmError::CallFailed(report.to_string())),
+            }
+        })
+    })))
+}
+
+/// Render a Rust [`CompletionRequest`] as the Keel `CompletionRequest` struct
+/// the user's `complete()` receives.
+fn completion_request_to_value(req: &CompletionRequest) -> Value {
+    let mut fields = HashMap::new();
+    fields.insert("system".to_string(), Value::String(req.system.clone()));
+    fields.insert("user".to_string(), Value::String(req.user.clone()));
+    fields.insert("model".to_string(), Value::String(req.model.clone()));
+    fields.insert(
+        "max_tokens".to_string(),
+        Value::Integer(i64::from(req.max_tokens)),
+    );
+    Value::Struct("CompletionRequest".to_string(), fields)
 }
 
 /// Extract enum variants from `as: T` (Value::Namespace(T)) by looking
@@ -355,24 +480,42 @@ mod tests {
     }
 
     #[test]
-    fn provider_prefixed_explicit_prefix_wins() {
-        // An explicit `provider:` prefix is never overridden by the agent's @provider.
+    fn route_tag_explicit_prefix_wins_over_provider() {
+        // An explicit `provider:` prefix is never overridden by @provider.
         assert_eq!(
-            provider_prefixed(Some("openai"), "anthropic:claude-opus-4-8".into()),
-            "anthropic:claude-opus-4-8"
+            route_tag("anthropic:claude-opus-4-8".into(), Some("openai".into())),
+            ("anthropic:claude-opus-4-8".into(), None)
         );
     }
 
     #[test]
-    fn provider_prefixed_bare_tag_gets_agent_provider() {
+    fn route_tag_bare_tag_gets_builtin_provider_prefix() {
         assert_eq!(
-            provider_prefixed(Some("openai"), "gpt-4o".into()),
-            "openai:gpt-4o"
+            route_tag("gpt-4o".into(), Some("openai".into())),
+            ("openai:gpt-4o".into(), None)
         );
     }
 
     #[test]
-    fn provider_prefixed_bare_tag_without_provider_is_unchanged() {
-        assert_eq!(provider_prefixed(None, "gpt-4o".into()), "gpt-4o");
+    fn route_tag_bare_tag_without_provider_is_unchanged() {
+        assert_eq!(route_tag("gpt-4o".into(), None), ("gpt-4o".into(), None));
+    }
+
+    #[test]
+    fn route_tag_user_provider_leaves_tag_bare() {
+        // A non-built-in provider name is a user type: the tag stays bare and
+        // the type name is returned for re-entrant dispatch.
+        assert_eq!(
+            route_tag("my-model".into(), Some("MyProvider".into())),
+            ("my-model".into(), Some("MyProvider".into()))
+        );
+    }
+
+    #[test]
+    fn route_tag_user_provider_does_not_override_explicit_prefix() {
+        assert_eq!(
+            route_tag("openai:gpt-4o".into(), Some("MyProvider".into())),
+            ("openai:gpt-4o".into(), None)
+        );
     }
 }

--- a/designs/llm-providers.md
+++ b/designs/llm-providers.md
@@ -1,0 +1,200 @@
+# Design: Swappable LLM providers (#44 + #46)
+
+Status: **Phase 1 + Phase 2 shipped.** Built-in Ollama/OpenAI/Anthropic backends,
+model-tag prefix routing, `@provider`, `KEEL_PROVIDER`, and `@limits { max_tokens }`
+landed in Phase 1 (#46/#87). **Phase 2** (user-authored Keel providers — a built-in
+`interface LlmProvider`, the `CompletionRequest` struct, `ai.install(MyProvider)`,
+`@provider MyProvider`, re-entrant dispatch via the namespace-layer `Transport`
+seam, and a recursion guard) landed in #44. The re-entry risk flagged below was
+resolved by dispatching the user's `complete()` inline from the `ai.*` namespace
+closure (which holds `&mut dyn Host`), not from inside the `'static` `LlmProvider`
+future — see the `Transport` enum in `runtime/llm.rs`.
+
+Validated against the `design-lang` (Hejlsberg) principles: developer productivity
+first, make the common case one line, gradual adoption, IDE-friendly, escape hatches
+for the long tail.
+
+## Problem
+
+`ai.*` is hardcoded to a single `Provider` enum (`Ollama` | `Mock`) inside
+`LlmClient` (`crates/keel-runtime/src/runtime/llm.rs`). `@provider` parses but is a
+silent no-op. There is no way to use OpenAI, Anthropic/Claude, or any other backend,
+and no contract for *how* a provider is selected.
+
+## Guiding insight
+
+Most users will reach for **OpenAI or Claude**, not Ollama and not a hand-written
+backend. Forcing them to author a provider in Keel for the mainstream case violates
+"don't make simple things verbose." So the design is **two tiers**:
+
+- **Tier 1 — built-in Rust backends** (covers ~90% of users): `ollama`, `openai`,
+  `anthropic`, selected declaratively with zero Keel code.
+- **Tier 2 — user-authored Keel providers** (the escape hatch): `impl LlmProvider for
+  MyProvider` + `ai.install(...)`, for proprietary / self-hosted / novel backends.
+
+## The seam
+
+Every high-level primitive (`classify`, `summarize`, `draft`, `extract`, `translate`,
+`decide`, `prompt`) funnels through one private method in `LlmClient`:
+
+```
+call(role, rules, system, user, model) -> Result<Option<String>, LlmError>
+    └─ dispatches on self.provider → call_ollama(...)
+```
+
+`call_ollama` is the only provider-specific code. Prompt construction (role/rules/
+system) and output parsing (enum match, schema validation) are provider-agnostic and
+**stay in `LlmClient`** — they are Keel's value-add and must behave identically across
+backends. We extract the transport, nothing else.
+
+### Rust trait (mirrors `db_provider.rs::DbConnectionHandle`)
+
+```rust
+pub trait LlmProvider: Debug + Send + Sync {
+    /// Returns the raw model output, or `None` for deterministic *absence*
+    /// (mock mode / "model had no answer") — never a silent failure.
+    /// Transport/config faults return Err(LlmError).
+    fn complete(&self, req: CompletionRequest) -> LlmFuture<Option<String>>;
+}
+
+pub struct CompletionRequest {
+    pub system: String,    // fully-built system prompt (role + rules + task system)
+    pub user: String,      // the user content
+    pub model: String,     // resolved model tag, provider prefix already stripped
+    pub max_tokens: u32,   // REQUIRED by Anthropic & OpenAI — no provider default
+}
+```
+
+`system` and `user` stay **separate fields** (not pre-merged) precisely because
+providers place the system prompt differently — Anthropic takes a top-level `system`
+field, OpenAI takes a `system` message role. Each backend assembles its own wire shape.
+
+`max_tokens` is mandatory: Anthropic's `/v1/messages` rejects a request without it.
+Source it from the agent's `@limits { max_tokens }` attribute (today parsed but **not
+enforced** — see ROADMAP `@limits [~]`), falling back to a sane default (e.g. 4096) when
+unset. Threading it here also begins enforcing that limit, closing part of the `@limits`
+gap.
+
+Built-ins (`OllamaProvider`, `OpenAiProvider`, `AnthropicProvider`, `MockProvider`)
+implement this in Rust. A Tier-2 Keel provider is wrapped in a `KeelProvider` adapter
+that implements the same trait by calling back into the interpreter — so `ai.*` always
+talks to `dyn LlmProvider` and never knows the difference.
+
+### Built-in backend wire facts (from the `claude-api` reference + OpenAI docs)
+
+| | Anthropic | OpenAI | Ollama (have it) |
+|---|---|---|---|
+| Endpoint | `POST /v1/messages` | `POST /v1/chat/completions` | `POST {host}/api/chat` |
+| Auth | `x-api-key` + `anthropic-version: 2023-06-01` | `Authorization: Bearer` | none (local) |
+| Key env | `ANTHROPIC_API_KEY` | `OPENAI_API_KEY` | — |
+| System prompt | top-level `system` field | `{role:"system"}` message | `{role:"system"}` message |
+| Required | `model`, `max_tokens`, `messages` | `model`, `messages` (+ `max_tokens`) | `model`, `messages` |
+| Response text | `content: [{type:"text", text}]` (extract text blocks) | `choices[0].message.content` | `message.content` |
+| Refusal | HTTP 200 `stop_reason:"refusal"` → map to `AiError` | n/a | n/a |
+
+Current model IDs (default to Opus 4.8): `claude-opus-4-8`, `claude-sonnet-4-6`,
+`claude-haiku-4-5`, `claude-fable-5`; OpenAI per its own docs. **Pull exact IDs and any
+request-shape changes from the `claude-api` reference / OpenAI docs at implementation
+time — do not hardcode from memory.**
+
+## Provider selection (the #46 dispatch contract)
+
+Resolution, most-specific wins:
+
+```
+per-call using:  >  per-agent @provider  >  program ai.install()  >  built-in default
+```
+
+- **Model-tag prefix** infers the provider for the common case:
+  `@model "anthropic:claude-..."`, `"openai:gpt-4o"`, `"ollama:llama3"`.
+- **`@provider <name>`** sets an agent's default backend for bare model tags and is the
+  explicit override.
+- **`using:`** already exists in `resolve_model` (ai.rs) for per-call model override;
+  the same hook extends to provider override.
+- Bare tag with no prefix and no `@provider` → the program default (Ollama today,
+  or whatever `ai.install` set).
+
+API keys come from env: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`. Missing key or unmapped
+model → `LlmError::ConfigError` → `AiError { reason: "provider" }`. No silent fallback.
+
+## Type checking
+
+Keel does **not** yet support interfaces as parameter types (`task f(x: SomeIface)`),
+and we will **not** build that here. Instead:
+
+**`@provider X` name resolution (decided).** The three built-in backend names —
+`ollama`, `openai`, `anthropic` — are a known reserved set. The checker resolves
+`@provider X` as follows:
+- `X` ∈ {ollama, openai, anthropic} → a built-in backend (Tier 1).
+- else, in **Phase 2**, `X` must be a type with `impl LlmProvider for X` (reuse
+  `types/interface.rs::signature_satisfies`, shipped in #45/#86).
+- else (Phase 1, or a name that is neither a built-in nor a conforming type) →
+  compile error: "unknown provider `X`".
+
+This avoids ambiguity: a built-in name is never also a user type, and the checker
+never has to guess. `ai.install(x)` (Tier 2) is special-cased the same way — `x`'s
+type must conform to `LlmProvider`. **General interface-as-type** (`task f(x: SomeIface)`)
+stays a separate v0.2 item; we special-case only these two builtin sites.
+
+## Error mapping
+
+| Source | LlmError | AiError reason |
+|---|---|---|
+| Network / endpoint unreachable | `CallFailed` | `unavailable` |
+| Missing key / unmapped model / misconfig | `ConfigError` | `provider` |
+| Output didn't match enum/schema | `SchemaValidation` | (handled by parser) |
+| Tier-2 provider `raise`s | `CallFailed`, message preserved | `unavailable` |
+
+Absence (`Ok(None)`) is unchanged: stdlib parsing decides `none`, so `??`/`when` still
+fire for "no answer" while real failures throw.
+
+## Phase → issue mapping
+
+- **Phase 1** delivers the #46 dispatch contract in full, plus the Rust-trait +
+  built-in-backends slice of #44. It **partially** closes #44 (the `Close #44` line
+  waits for Phase 2). It can `Close #46`.
+- **Phase 2** delivers the user-authored-dispatch slice of #44 ("interface declarations
+  parse but don't dispatch" as applied to providers) → `Close #44`.
+
+> **ROADMAP principle change (deliberate).** Adding OpenAI + Anthropic reverses the
+> stated "v0.1 ships Ollama only" line and pulls provider support forward from the v0.2
+> "pluggable provider registry". The user explicitly chose this. The ROADMAP and SPEC
+> §5.5 must be edited to reflect it — not left contradicting the code.
+
+## Phasing
+
+### Phase 1 — built-in backends (high value, low risk; no interpreter re-entry)
+1. Extract `LlmProvider` Rust trait + `CompletionRequest`; refactor Ollama and Mock
+   behind it. `LlmClient` holds a name→provider registry (per-call resolution — needed
+   for per-agent `@provider`), not a single fixed `Box<dyn LlmProvider>`.
+2. Add `OpenAiProvider` and `AnthropicProvider` HTTP backends. **Model IDs, request
+   shape, and auth headers pulled from the `claude-api` reference (Anthropic) and
+   OpenAI docs at implementation time.** API keys from env; missing key → `ConfigError`
+   → `AiError{reason:"provider"}`.
+3. Model-tag prefix routing (`provider:model`) + per-program default selection.
+4. `Host::current_provider()` (read the agent's `@provider` attribute, analogous to the
+   existing `current_model()`); `call()` selects the backend per-call from the model
+   prefix / current provider, replacing the once-at-construction `self.provider`.
+5. Thread `@limits { max_tokens }` → `CompletionRequest.max_tokens` (default when unset).
+6. SPEC §5.5, ROADMAP (principle change above), CHANGELOG, docs/src guide pages,
+   `.keel` examples, tests.
+
+### Phase 2 — user-authored Keel providers (the escape hatch)
+1. `KeelProvider` adapter: implement `LlmProvider::complete` by invoking the user's
+   `impl LlmProvider for MyProvider` method through the `Host` trait (#11).
+   **Open risk to confirm before building: the `Host` trait must be able to invoke a
+   user method re-entrantly from inside a namespace call (async).**
+2. `ai.install(MyProvider)` (per-program) + `@provider MyProvider` (per-agent).
+3. Type-checks per above. SPEC/docs/examples/tests.
+
+## Resolved open questions
+
+- **`CompletionRequest` shape** — carries `max_tokens` (mandatory). `system`/`user`
+  stay separate. A `format`/JSON-mode hint stays folded into `system` for Phase 1; add
+  a structured field later only if a backend's native JSON mode proves worth it.
+- **Registry shape** — name-keyed map on `LlmClient`, resolved per call (per-agent
+  `@provider` requires it).
+- **Per-call `using:` provider override** — `using:` already exists for model override;
+  extending it to provider override is a small Phase-1 add, included.
+- **`@provider` naming** — resolved (reserved built-in names; else conforming type in
+  Phase 2; else error). See Type checking above.

--- a/docs/src/config/llm-providers.md
+++ b/docs/src/config/llm-providers.md
@@ -99,12 +99,58 @@ In mock mode every `ai.*` call returns `none` regardless of provider —
 deterministic *absence*, never a failure — so `??` defaults fire predictably.
 (Real provider failures throw `AiError`; mock mode does not simulate them.)
 
-## User-authored providers <span class="badge badge-soon">Coming soon</span>
+## User-authored providers
 
-> Status: planned. Writing a provider in Keel (`impl LlmProvider for MyProvider`)
-> and installing it with `ai.install(MyProvider)` is planned for a future release,
-> for proprietary or self-hosted backends. The built-in providers above cover the
-> common cases today. See [SPEC §5.5](https://github.com/keel-lang/keel/blob/main/SPEC.md).
+For proprietary or self-hosted models the built-in backends don't cover, write a
+provider **in Keel**. Any field-less type with `impl LlmProvider` becomes a
+backend `ai.*` can dispatch through:
+
+```keel
+use std/ai
+use std/env
+use std/http
+
+type MyProvider {}
+
+impl LlmProvider for MyProvider {
+  task complete(self, req: CompletionRequest) -> str {
+    # The provider is constructed with no fields, so read configuration from
+    # the environment — not from struct fields.
+    key = env.get("MY_LLM_KEY")!
+    http.post(
+      "https://my-llm.example/v1/complete",
+      headers: { "Authorization": "Bearer {key}" },
+      body: { system: req.system, prompt: req.user, model: req.model, max_tokens: req.max_tokens }
+    )["text"]
+  }
+}
+
+ai.install(MyProvider)   # program-wide default
+```
+
+`complete(self, req: CompletionRequest) -> str` returns the **raw** model text;
+Keel applies its own prompt construction and output parsing (enum matching for
+`ai.classify`, schema validation for `ai.extract`) on top, so `??`, `when`, and
+the typed `AiError` / `AiSchemaError` behave identically to the built-in
+backends. The `CompletionRequest` struct carries `system`, `user`, `model`, and
+`max_tokens`.
+
+Select a user provider the same two ways as a built-in:
+
+- `ai.install(MyProvider)` — program-wide default (lowest precedence, below a
+  `provider:` model-tag prefix and `@provider`).
+- `@provider MyProvider` — per agent.
+
+`ai.install(X)` and `@provider X` require `X` to implement `LlmProvider`;
+anything else is a compile-time error. A provider must not call `ai.*` from
+inside its own `complete()` — that re-entry raises an `AiError` rather than
+recursing without bound.
+
+A provider is **trusted transport**, like a built-in backend: its `complete()`
+may call effectful modules (`env`, `http`, …) regardless of the consuming
+agent's `@tools`. An agent only needs `@tools [ai]` to use a provider that talks
+HTTP under the hood — just as it does for the built-in OpenAI and Anthropic
+backends.
 
 ## Troubleshooting
 

--- a/docs/src/guide/ai-primitives.md
+++ b/docs/src/guide/ai-primitives.md
@@ -169,7 +169,10 @@ an Ollama alias resolved via `KEEL_MODEL_<ALIAS>`, or a literal Ollama tag. Open
 and Anthropic read `OPENAI_API_KEY` / `ANTHROPIC_API_KEY`; a missing key throws
 `AiError { reason: "provider" }`. Full setup: see [LLM Providers](../config/llm-providers.md).
 
-Writing your own provider in Keel (`ai.install(...)`) is planned for a future release.
+For proprietary or self-hosted models, you can also **write your own provider in
+Keel** — any field-less type with `impl LlmProvider` becomes a backend, selected
+with `ai.install(MyProvider)` or `@provider MyProvider`. See
+[User-authored providers](../config/llm-providers.md#user-authored-providers).
 
 ## Why functions, not keywords
 

--- a/docs/src/release-notes.md
+++ b/docs/src/release-notes.md
@@ -4,6 +4,40 @@
 
 ## Unreleased
 
+### User-authored LLM providers — write a backend in Keel
+
+For proprietary or self-hosted models the built-in backends don't cover, any
+field-less type with `impl LlmProvider` is now a backend `ai.*` can dispatch
+through:
+
+```keel
+use std/ai
+use std/env
+use std/http
+
+type MyProvider {}
+impl LlmProvider for MyProvider {
+  task complete(self, req: CompletionRequest) -> str {
+    key = env.get("MY_LLM_KEY")!
+    http.post("https://my-llm.example/complete", body: { prompt: req.user })["text"]
+  }
+}
+
+ai.install(MyProvider)        # program-wide, or `@provider MyProvider` per agent
+```
+
+`complete(self, req: CompletionRequest) -> str` returns the raw model text; Keel
+applies its own prompt construction and output parsing on top, so `??`, `when`,
+and the typed `AiError` / `AiSchemaError` behave the same as for built-in
+backends. `CompletionRequest` is a built-in struct (`system`, `user`, `model`,
+`max_tokens`). `ai.install(X)` and `@provider X` require `X` to implement
+`LlmProvider` (a compile-time error otherwise), and a provider that calls `ai.*`
+from inside its own `complete()` is rejected with an `AiError` instead of
+recursing without bound. See
+[User-authored providers](./config/llm-providers.md#user-authored-providers).
+
+---
+
 ### Swappable LLM providers — Ollama, OpenAI, and Anthropic (Claude)
 
 `ai.*` no longer hard-codes Ollama. Three backends ship built in and are selected
@@ -28,8 +62,8 @@ summary = ai.summarize(text, using: "openai:gpt-4o") ?? "(none)"
 
 OpenAI and Anthropic read `OPENAI_API_KEY` / `ANTHROPIC_API_KEY`; a missing key
 throws `AiError { reason: "provider" }`, never a silent fallback. `@limits {
-max_tokens }` is now threaded into the request as the generation cap. Writing a
-provider in Keel (`ai.install`) remains planned — see
+max_tokens }` is now threaded into the request as the generation cap. You can
+also write your own provider in Keel — see above and
 [LLM Providers](./config/llm-providers.md).
 
 ---

--- a/docs/status/features.json
+++ b/docs/status/features.json
@@ -83,8 +83,8 @@
     {
       "name": "std/ai",
       "status": "partial",
-      "implemented_ops": "`classify`, `summarize` (format/max), `draft`, `extract` (as: T), `translate`, `decide`, `prompt` (response_format: json); swappable built-in backends — Ollama, OpenAI, Anthropic (Claude) — via `@model \"provider:model\"`, `@provider`, or `KEEL_PROVIDER`",
-      "gaps": "`embed` deferred to v0.2; user-authored `ai.install(provider)` planned (SPEC §5.5)",
+      "implemented_ops": "`classify`, `summarize` (format/max), `draft`, `extract` (as: T), `translate`, `decide`, `prompt` (response_format: json); swappable built-in backends — Ollama, OpenAI, Anthropic (Claude) — via `@model \"provider:model\"`, `@provider`, or `KEEL_PROVIDER`; user-authored providers via `impl LlmProvider` + `ai.install`/`@provider` (SPEC §5.5)",
+      "gaps": "`embed` deferred to v0.2",
       "purpose": "LLM operations: `classify`, `extract`, `summarize`, `draft`, `translate`, `decide`, `prompt` · `embed` ⏳"
     },
     {

--- a/examples/custom_provider.keel
+++ b/examples/custom_provider.keel
@@ -1,0 +1,46 @@
+use std/ai
+use std/io
+use std/testing
+
+# User-authored LLM provider (SPEC §5.5).
+#
+# Any type with `impl LlmProvider` becomes a backend that `ai.*` can dispatch
+# through — for proprietary or self-hosted models the built-in `ollama`,
+# `openai`, and `anthropic` backends don't cover.
+#
+# A provider is a *field-less* type: the runtime constructs it with no fields,
+# so configuration (endpoints, API keys) is read from the environment inside
+# `complete()` — e.g. `env.get("MY_LLM_URL")` — not from struct fields.
+
+type EchoProvider {}
+
+impl LlmProvider for EchoProvider {
+  # `complete` receives the fully-built request and returns the raw model text.
+  # A real provider would POST `req.system` / `req.user` to its endpoint with
+  # `req.model` and `req.max_tokens`; here we just echo to stay deterministic.
+  task complete(self, req: CompletionRequest) -> str {
+    "echo: {req.user}"
+  }
+}
+
+# Register it program-wide. `ai.install` is the lowest-precedence backend:
+# a per-call `provider:` model prefix and a per-agent `@provider` both win.
+ai.install(EchoProvider)
+
+test "installed provider answers ai.prompt" {
+  ai.install(EchoProvider)
+  assert ai.prompt(system: "ignored", user: "hello") == "echo: hello"
+}
+
+agent Demo {
+  @tools [ai, io]
+  # `@provider` also accepts a user type, scoped to this agent's bare model tags.
+  @provider EchoProvider
+  @on_start {
+    reply = ai.prompt(system: "You are a demo.", user: "ping") ?? "no reply"
+    io.show(reply)
+    stop(self)
+  }
+}
+
+run(Demo)

--- a/tests/integration/ai.rs
+++ b/tests/integration/ai.rs
@@ -582,6 +582,262 @@ run(A)
     );
 }
 
+// ---------------------------------------------------------------------------
+// User-authored providers (#44): `impl LlmProvider` + `ai.install` / `@provider`
+// ---------------------------------------------------------------------------
+
+#[test]
+fn installed_user_provider_routes_classify() {
+    // A Keel-authored provider is a deterministic backend: `ai.install` makes it
+    // the program-wide transport, so `ai.classify` dispatches into its
+    // `complete()` instead of any built-in HTTP/mock path.
+    let src = r#"
+use std/ai
+use std/io
+type Urgency = low | medium | high
+
+type FixedProvider {}
+impl LlmProvider for FixedProvider {
+  task complete(self, req: CompletionRequest) -> str {
+    "high"
+  }
+}
+
+ai.install(FixedProvider)
+
+agent A {
+  @tools [ai, io]
+  @on_start {
+    u = ai.classify("anything", as: Urgency) ?? Urgency.low
+    io.show("urgency={u}")
+    stop(self)
+  }
+}
+run(A)
+"#;
+    let (ok, stdout, stderr) = run_inline(src, false);
+    assert!(
+        ok,
+        "program exited non-zero\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("urgency=high"),
+        "installed provider did not route classify:\n{stdout}\n{stderr}"
+    );
+}
+
+#[test]
+fn per_agent_at_provider_routes_to_user_type() {
+    // `@provider MyType` selects a user provider for that agent's bare model tags.
+    let src = r#"
+use std/ai
+use std/io
+
+type Shouter {}
+impl LlmProvider for Shouter {
+  task complete(self, req: CompletionRequest) -> str {
+    "ECHO: {req.user}"
+  }
+}
+
+agent A {
+  @tools [ai, io]
+  @provider Shouter
+  @on_start {
+    r = ai.prompt(system: "sys", user: "hello") ?? "none"
+    io.show("got={r}")
+    stop(self)
+  }
+}
+run(A)
+"#;
+    let (ok, stdout, stderr) = run_inline(src, false);
+    assert!(
+        ok,
+        "program exited non-zero\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("got=ECHO: hello"),
+        "@provider user type did not receive the CompletionRequest user field:\n{stdout}\n{stderr}"
+    );
+}
+
+#[test]
+fn user_provider_recursion_guard_raises_instead_of_looping() {
+    // A provider whose `complete()` calls `ai.*` again would recurse without
+    // bound; the guard turns that into a catchable error rather than a hang.
+    let src = r#"
+use std/ai
+use std/io
+
+type Loopy {}
+impl LlmProvider for Loopy {
+  task complete(self, req: CompletionRequest) -> str {
+    ai.prompt(system: "x", user: "y") ?? "fallback"
+  }
+}
+
+ai.install(Loopy)
+
+agent A {
+  @tools [ai, io]
+  @on_start {
+    try {
+      ai.prompt(system: "s", user: "u")
+      io.show("no-error")
+    } catch e: AiError {
+      io.show("caught={e.message}")
+    }
+    stop(self)
+  }
+}
+run(A)
+"#;
+    let (ok, stdout, stderr) = run_inline(src, false);
+    assert!(
+        ok,
+        "program exited non-zero\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("caught="),
+        "recursion guard did not raise a catchable AiError:\n{stdout}\n{stderr}"
+    );
+    assert!(
+        !stdout.contains("no-error"),
+        "re-entrant provider call should not have succeeded:\n{stdout}"
+    );
+}
+
+#[test]
+fn provider_complete_runs_effectful_modules_ungated() {
+    // A user provider is trusted transport, like a built-in backend: its
+    // `complete()` may call effectful modules (env/http) even when the consuming
+    // agent only grants `@tools [ai]` — the provider's needs are not the agent's.
+    let src = r#"
+use std/ai
+use std/io
+use std/env
+
+type EnvProvider {}
+impl LlmProvider for EnvProvider {
+  task complete(self, req: CompletionRequest) -> str {
+    prefix = env.get("KEEL_TEST_PROVIDER_PREFIX") ?? "default"
+    "{prefix}: {req.user}"
+  }
+}
+
+ai.install(EnvProvider)
+
+agent A {
+  @tools [ai, io]
+  @on_start {
+    r = ai.prompt(system: "s", user: "hello") ?? "none"
+    io.show("got={r}")
+    stop(self)
+  }
+}
+run(A)
+"#;
+    let (ok, stdout, stderr) = run_inline_with_env(
+        src,
+        &[("KEEL_LLM", "mock"), ("KEEL_TEST_PROVIDER_PREFIX", "cfg")],
+    );
+    assert!(
+        ok,
+        "provider's complete() was blocked by the agent's @tools\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("got=cfg: hello"),
+        "provider did not read env config ungated:\n{stdout}\n{stderr}"
+    );
+}
+
+#[test]
+fn installed_provider_routes_inside_spawned_closure() {
+    // `ai.install` must reach `ai.*` calls made inside `async.spawn(...)`.
+    let src = r#"
+use std/ai
+use std/async
+use std/io
+
+type FixedProvider {}
+impl LlmProvider for FixedProvider {
+  task complete(self, req: CompletionRequest) -> str {
+    "spawned: {req.user}"
+  }
+}
+
+ai.install(FixedProvider)
+
+agent A {
+  @tools [ai, io]
+  @on_start {
+    h = async.spawn(() => {
+      ai.prompt(system: "s", user: "hi") ?? "none"
+    })
+    r = async.join_all([h])
+    io.show("result={r[0]}")
+    stop(self)
+  }
+}
+run(A)
+"#;
+    let (ok, stdout, stderr) = run_inline(src, false);
+    assert!(
+        ok,
+        "program exited non-zero\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("result=spawned: hi"),
+        "installed provider did not route inside a spawned closure:\n{stdout}\n{stderr}"
+    );
+}
+
+#[test]
+fn at_provider_unknown_type_is_compile_error() {
+    let src = r#"
+use std/ai
+type NotAProvider { id: int }
+
+agent A {
+  @tools [ai]
+  @provider NotAProvider
+  @on_start {
+    ai.prompt(system: "s", user: "u")
+  }
+}
+run(A)
+"#;
+    let (ok, _stdout, stderr) = check_inline_output(src);
+    assert!(
+        !ok,
+        "@provider naming a non-LlmProvider type should fail `keel check`"
+    );
+    assert!(
+        stderr.contains("LlmProvider") || stderr.contains("built-in provider"),
+        "error should explain the provider must implement LlmProvider:\n{stderr}"
+    );
+}
+
+#[test]
+fn ai_install_non_conforming_type_is_compile_error() {
+    let src = r#"
+use std/ai
+type Bogus { id: int }
+
+ai.install(Bogus)
+"#;
+    let (ok, _stdout, stderr) = check_inline_output(src);
+    assert!(
+        !ok,
+        "ai.install of a non-LlmProvider type should fail check"
+    );
+    assert!(
+        stderr.contains("LlmProvider") || stderr.contains("built-in provider"),
+        "error should explain the install target must implement LlmProvider:\n{stderr}"
+    );
+}
+
 #[test]
 fn translate_empty_target_list_raises_instead_of_panicking() {
     // An empty `to: []` previously slipped past the namespace and reached


### PR DESCRIPTION
Lets users write an LLM backend **in Keel** and install it — for the long tail of proprietary or self-hosted models the built-in Ollama/OpenAI/Anthropic backends don't cover. Completes the Phase 2 half of #44 (the built-in backends shipped earlier in #87/#46).

## What's new

- **`impl LlmProvider for MyType`** — a built-in `interface LlmProvider { complete(self, req: CompletionRequest) -> str }` plus a built-in `CompletionRequest` struct (`system`, `user`, `model`, `max_tokens`).
- **`ai.install(MyProvider)`** registers a provider program-wide (lowest precedence, below a `provider:` model-tag prefix and `@provider`); **`@provider MyProvider`** selects it per agent.
- `complete()` returns the **raw** model text — prompt construction and output parsing stay in `LlmClient`, so `??`, `when`, and the typed `AiError`/`AiSchemaError` behave identically across built-in and user providers.

```keel
use std/ai
use std/env
use std/http

type MyProvider {}
impl LlmProvider for MyProvider {
  task complete(self, req: CompletionRequest) -> str {
    key = env.get("MY_LLM_KEY")!
    http.post("https://my-llm.example/complete", body: { prompt: req.user })["text"]
  }
}

ai.install(MyProvider)        # program-wide, or `@provider MyProvider` per agent
```

## How it works

Re-entrant dispatch runs the user's `complete()` inline from the `ai.*` namespace closure through a `Transport` seam, after cloning the `Arc<LlmClient>` to release the host borrow — keeping the re-entry out of the `'static` `LlmProvider` future where it can't reach the interpreter.

## Safety / edges

- The checker requires `ai.install(X)` / `@provider X` to implement `LlmProvider` (compile-time error otherwise) and rejects field-bearing provider types (the receiver is field-less; config comes from `env.*`).
- A provider that calls `ai.*` inside its own `complete()` trips a recursion guard (`AiError`) instead of looping.
- A provider runs as **trusted transport**, like a built-in backend: its `complete()` may call `env`/`http` regardless of the consuming agent's `@tools` (an agent needs only `@tools [ai]`).
- `ai.install` and the installed provider propagate into spawned closures.

## Tests & docs

- Integration tests (routing via `ai.install` and `@provider`, `CompletionRequest` field access, recursion guard, ungated effectful calls, spawn propagation, compile-error cases), checker unit tests, and runtime unit tests.
- New runnable example `examples/custom_provider.keel`.
- SPEC §5.5 promoted from "Planned"; ROADMAP, CHANGELOG, `docs/src` guide/config/release-notes, `docs/status/features.json`, README, and `TODO.md` (K-14/K-16 → Done) updated.

`cargo fmt --check`, `clippy --all-targets`, the full test suite, and `mdbook build` all pass.

Close #44