### PR TITLE
Add community health files and MIT LICENSE

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: [keel-lang]

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,72 @@
+name: 🐛 Bug report
+description: Report something that doesn't work the way it should
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug! Keel is alpha software, so bugs are expected —
+        a clear, minimal reproduction is the single most useful thing you can give us.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, what you expected instead, and the impact.
+      placeholder: Running `keel run x.keel` panics instead of reporting a type error.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal reproduction
+      description: The smallest `.keel` program that triggers the bug. Smaller is better.
+      render: rust
+      placeholder: |
+        use std/ai
+
+        task main() {
+          ai.classify("hi", as: Nope)
+        }
+    validations:
+      required: true
+
+  - type: textarea
+    id: command
+    attributes:
+      label: Command and output
+      description: The exact command you ran and its full output (paste the error verbatim).
+      render: shell
+      placeholder: |
+        $ keel run repro.keel
+        <full output here>
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Keel version
+      description: Output of `keel --version` (or the commit SHA if built from source).
+      placeholder: keel 0.2.4
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: OS / platform
+      placeholder: macOS 15.5 (arm64)
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and this isn't a duplicate.
+          required: true
+        - label: My reproduction is minimal and runs with `KEEL_LLM=mock` where applicable.
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Questions & discussion
+    url: https://github.com/keel-lang/keel/discussions
+    about: Ask questions, share ideas, or discuss the language design here.
+  - name: 🔒 Report a security vulnerability
+    url: https://github.com/keel-lang/keel/security/advisories/new
+    about: Please report security issues privately, not as a public issue. See SECURITY.md.
+  - name: 📐 Language specification
+    url: https://github.com/keel-lang/keel/blob/main/SPEC.md
+    about: The source of truth for the language surface — check here before filing.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,53 @@
+name: 💡 Feature request
+description: Propose a language feature, stdlib addition, or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea! Keel's surface is still soft enough that a good proposal can change
+        the language. To save everyone time, please describe the **problem** first, not just the
+        solution — and check it isn't already covered.
+
+  - type: checkboxes
+    id: prechecks
+    attributes:
+      label: Before proposing
+      options:
+        - label: I checked [NON-GOALS.md](https://github.com/keel-lang/keel/blob/main/NON-GOALS.md) and this isn't a deliberately declined idea (or I explain below why it should be reconsidered).
+          required: true
+        - label: I searched existing issues and discussions for prior art.
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: The use case and the pain today. Why should the language / stdlib own this rather than user code?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed surface
+      description: Sketch the syntax or API. Show a `.keel` snippet of how it would be used.
+      render: rust
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other designs, workarounds, or how other languages handle this.
+    validations:
+      required: false
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional context
+      description: Anything else — links, related issues, design trade-offs.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,39 @@
+<!--
+Thanks for contributing to Keel! Keep the description focused on WHAT changed and WHY.
+Delete sections that don't apply.
+-->
+
+## Summary
+
+<!-- What does this PR do, and why? -->
+
+## Related issue
+
+<!-- e.g. Close #123 — GitHub auto-closes the issue on merge. -->
+Close #
+
+## Type of change
+
+- [ ] Bug fix (non-breaking)
+- [ ] New feature (non-breaking)
+- [ ] Breaking change (alters existing `.keel` behavior or the language surface)
+- [ ] Docs / examples only
+- [ ] Internal / refactor (no surface change)
+
+## Checklist
+
+- [ ] `just check` passes (`fmt --check` · `clippy -D warnings` · `doc` · build · tests)
+- [ ] Added/updated **tests** (integration tests for new behavior; a regression test for a fix)
+- [ ] Added/updated a runnable **`examples/*.keel`** program (for user-facing features)
+- [ ] Updated **`CHANGELOG.md`** under `## [Unreleased]` (no hand-written version/date)
+- [ ] Updated **`docs/src/`** — release notes **and** every affected guide page (`mdbook build` clean)
+
+### Language-surface changes only
+
+- [ ] Validated the design against the project's principles (`design-lang`)
+- [ ] Updated **`SPEC.md`** (the source of truth) in this PR
+- [ ] Confirmed the idea isn't in [`NON-GOALS.md`](https://github.com/keel-lang/keel/blob/main/NON-GOALS.md)
+
+## Notes for reviewers
+
+<!-- Anything that needs extra eyes: trade-offs, follow-ups, things you're unsure about. -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  # Rust dependencies (root workspace + member crates share one lockfile).
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "deps"
+    groups:
+      # Batch low-risk patch/minor bumps into a single PR to cut review noise.
+      cargo-minor:
+        update-types:
+          - minor
+          - patch
+
+  # GitHub Actions used by the CI / release workflows.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: "ci"
+    groups:
+      actions:
+        update-types:
+          - minor
+          - patch

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,21 @@
+cff-version: 1.2.0
+title: "Keel: a programming language where AI agents are first-class citizens"
+message: "If you use Keel in your research or writing, please cite it as below."
+type: software
+authors:
+  - given-names: Zied
+    family-names: Maktouf
+repository-code: "https://github.com/keel-lang/keel"
+url: "https://github.com/keel-lang/keel"
+abstract: >-
+  Keel is a statically typed, inference-first programming language built in Rust in which AI
+  agents are first-class citizens. Its core concurrency primitive is the actor model; AI,
+  scheduling, HTTP, email, memory, and human I/O are provided by a standard library.
+keywords:
+  - programming-language
+  - ai-agents
+  - actor-model
+  - rust
+  - llm
+license: MIT
+version: 0.2.4

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,115 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a
+harassment-free experience for everyone, regardless of age, body size, visible or invisible
+disability, ethnicity, sex characteristics, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race, caste, color, religion,
+or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive,
+and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from
+  the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+- Critiquing ideas, not people — keep discussion technical
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their
+  explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable
+behavior and will take appropriate and fair corrective action in response to any behavior that
+they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits,
+code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct,
+and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is
+officially representing the community in public spaces. Examples of representing our community
+include using an official email address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the
+community leaders responsible for enforcement at **`maktouf.zied@gmail.com`**. All complaints will
+be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any
+incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for
+any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or
+unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the
+nature of the violation and an explanation of why the behavior was inappropriate. A public apology
+may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the
+people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a
+specified period of time. This includes avoiding interactions in community spaces as well as
+external channels like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate
+behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the
+community for a specified period of time. No public or private interaction with the people
+involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed
+during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including
+sustained inappropriate behavior, harassment of an individual, or aggression toward or
+disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available
+at <https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][mozilla].
+
+For answers to common questions about this code of conduct, see the FAQ at
+<https://www.contributor-covenant.org/faq>. Translations are available at
+<https://www.contributor-covenant.org/translations>.
+
+[homepage]: https://www.contributor-covenant.org
+[mozilla]: https://github.com/mozilla/diversity

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,305 @@
+# Contributing to Keel
+
+Thanks for being here. **Keel** is a programming language where AI agents are first-class
+citizens — a small actor-model core with AI, scheduling, HTTP, email, memory, and human I/O
+in the standard library. It's built in Rust and it's **alpha (v0.2)**: no production users, no
+stable API, breaking changes expected between `0.x` releases.
+
+That status is an invitation, not a warning. The surface is still soft enough that a good idea
+can change the language. This guide tells you how to land one.
+
+- 📐 **Spec:** [`SPEC.md`](SPEC.md) — the source of truth for the language surface
+- 📓 **Changelog:** [`CHANGELOG.md`](CHANGELOG.md) — shipped history
+- 🚫 **Non-goals:** [`NON-GOALS.md`](NON-GOALS.md) — deliberately declined ideas (check before proposing)
+- 🎯 **Vision:** [`VISION.md`](VISION.md) — where this is going and why
+- 🗺️ **Roadmap & issues:** [GitHub Issues](https://github.com/keel-lang/keel/issues) · [project board](https://github.com/orgs/keel-lang/projects/1)
+
+---
+
+## Table of contents
+
+- [Code of conduct](#code-of-conduct)
+- [Ways to contribute](#ways-to-contribute)
+- [Quick start](#quick-start)
+- [Project layout](#project-layout)
+- [Development workflow](#development-workflow)
+- [Adding or changing a language feature](#adding-or-changing-a-language-feature)
+- [Testing](#testing)
+- [Coding standards](#coding-standards)
+- [Commits & pull requests](#commits--pull-requests)
+- [Reporting bugs & proposing features](#reporting-bugs--proposing-features)
+- [Releases](#releases)
+- [License](#license)
+
+---
+
+## Code of conduct
+
+Be decent. Assume good faith, critique ideas not people, and keep discussion technical.
+Maintainers may remove comments, commits, and contributors that don't meet that bar.
+
+---
+
+## Ways to contribute
+
+You don't need to write Rust to help.
+
+| Contribution | Where it lands |
+| --- | --- |
+| 🐛 **Report a bug** | [open an issue](https://github.com/keel-lang/keel/issues/new) with a minimal `.keel` repro |
+| 💡 **Propose a feature** | open a discussion/issue — run it past [`NON-GOALS.md`](NON-GOALS.md) first |
+| 📝 **Improve docs** | `docs/src/` (mdBook) — guides, examples, CLI/config reference |
+| ✨ **Write an example** | `examples/*.keel` — small, focused, runnable programs |
+| 🔧 **Fix a bug / build a feature** | `src/` + `crates/` — see below |
+| 🧪 **Add test coverage** | `tests/` — the parts of the surface that aren't pinned yet |
+
+Good first issues are tagged on the [board](https://github.com/orgs/keel-lang/projects/1). If
+you're unsure whether an idea fits, open an issue *before* writing code — it's cheaper to align
+on direction than to rework a PR.
+
+---
+
+## Quick start
+
+**Prerequisites**
+
+- **Rust** — current stable toolchain (`rustup default stable`). The workspace targets Rust
+  **edition 2024**, so you need a recent stable (1.85+). CI runs on `dtolnay/rust-toolchain@stable`.
+- **[`just`](https://github.com/casey/just)** *(recommended)* — task runner for the recipes below.
+- **[`mdbook`](https://rust-lang.github.io/mdBook/)** *(docs only)* — `cargo install mdbook`.
+
+```bash
+git clone https://github.com/keel-lang/keel.git
+cd keel
+
+# Build the toolchain
+cargo build                 # or: just build debug
+
+# Run an example (mock LLM — no API keys, no network)
+KEEL_LLM=mock KEEL_ONESHOT=1 cargo run -- run examples/hello_world.keel
+just hello                  # shorthand for the line above
+
+# Everything CI checks, in one command
+just check                  # fmt --check · clippy -D warnings · doc · build · test
+```
+
+`just` with no arguments lists every recipe.
+
+---
+
+## Project layout
+
+Keel is a Cargo **workspace**. The root binary (`keel-lang`) wires together four library crates
+plus the CLI, REPL, and LSP.
+
+```
+src/
+  main.rs / cli/      # CLI entry (clap): run · check · fmt · init · repl · lsp
+  pipeline.rs         # source → tokens → AST → HIR → typed program → execution
+  repl.rs             # interactive REPL
+  lsp/                # Language Server (diagnostics, completion, hover, go-to-def)
+  catalog.rs          # stdlib namespace surface
+  vm/                 # placeholder — `keel build` is deferred post-v0.1
+
+crates/
+  keel-syntax/        # front-end: lexer (logos), AST, parser (chumsky), formatter, linter
+  keel-compiler/      # middle-end: HIR, type checker, module graph, IDE queries
+  keel-runtime/       # execution engine: tree-walking async interpreter + stdlib runtime
+  keel-catalog/       # neutral stdlib method descriptors + capability metadata
+
+examples/             # .keel programs (every feature ships with one)
+tests/                # integration + pipeline coverage tests
+docs/src/             # mdBook documentation (guides, CLI, config, release notes)
+brand/                # logo, color tokens, mdBook theme (single source of truth)
+SPEC.md               # language spec — source of truth for the surface
+```
+
+**Architectural anchors** (from `AGENTS.md`):
+
+- **BoxedParser everywhere** — chumsky parsers are boxed to avoid a macOS linker crash on
+  deeply nested types. Keep new parser combinators boxed.
+- **Async recursion via `Pin<Box<dyn Future>>`** — the interpreter's recursive async functions
+  follow this pattern; match it.
+- **No silent fallbacks** — an unmapped LLM model, a malformed input, a contract violation: all
+  fail with an actionable error. Never mock, truncate, or silently drop data to make something
+  "work."
+- **Newlines are statement separators** — the lexer normalizes them; the parser uses them for
+  statement boundaries.
+
+---
+
+## Development workflow
+
+All recipes are in the `justfile`. The raw `cargo` equivalent is shown for reference.
+
+| Task | `just` | `cargo` |
+| --- | --- | --- |
+| Build (release) | `just build` | `cargo build --release` |
+| Build (debug) | `just build debug` | `cargo build` |
+| Format | `just fmt` | `cargo fmt` |
+| Format check | `just fmt check` | `cargo fmt --check` |
+| Lint | `just lint` | `cargo clippy --all-targets --all-features -- -D warnings` |
+| Test (all) | `just test` | `cargo test` |
+| Test (unit / integration) | `just test unit` · `just test integration` | `cargo test --lib` · `cargo test --test '*'` |
+| Filter tests | `just test-filter <name>` | `cargo test <name>` |
+| Coverage | `just cov` / `just cov html` | `cargo llvm-cov` |
+| Run a file | `just run path.keel` | `cargo run -- run path.keel` |
+| Run an example | `just run-example hello_world` | — |
+| Run all examples | `just run-all-examples` | — |
+| REPL | `just repl` | `cargo run -- repl` |
+| Docs (serve / build) | `just docs` / `just docs build` | `cd docs && mdbook serve` |
+| **Everything CI runs** | `just check` | — |
+
+> **Before you push:** `just check` must pass clean. It mirrors CI exactly —
+> `fmt --check`, `clippy -D warnings`, `cargo doc`, build, and the full test suite.
+
+### Useful environment variables
+
+Keel reads a number of env vars; these are the ones you'll want while hacking:
+
+- `KEEL_LLM=mock` — deterministic mock LLM. **Use this for tests and local runs** — no keys, no network.
+- `KEEL_ONESHOT=1` — exit after the first idle window (so examples terminate).
+- `KEEL_REPL=1` — suppress agent boilerplate (REPL mode).
+- `KEEL_TRACE=1` (`--trace`) — verbose narration of every LLM call.
+- `KEEL_LOG_LEVEL=debug|info|warn|error` (`--log-level`) — threshold for `Log.*`.
+- `KEEL_PROVIDER=ollama|openai|anthropic` — program-default LLM backend (default `ollama`).
+
+The full list lives in [`AGENTS.md`](AGENTS.md).
+
+---
+
+## Adding or changing a language feature
+
+Keel is a language, so changes to its surface go through more gates than a typical app. Follow
+this order — it's the same one maintainers use.
+
+1. **Validate the design first.** *Before touching `SPEC.md` or any source*, validate the idea
+   against the project's design principles (gradual typing, IDE-driven design, pragmatic type
+   systems, developer productivity). Contributors using Claude Code should invoke the
+   `design-lang` skill; everyone should be able to articulate *why* the feature earns its
+   complexity. Check it isn't already in [`NON-GOALS.md`](NON-GOALS.md).
+2. **Update `SPEC.md`.** The spec is the source of truth. Write the surface before you implement it.
+3. **Implement** across the relevant crate(s):
+   - new syntax → `keel-syntax` (lexer/parser/AST)
+   - type rules → `keel-compiler` (HIR + type checker)
+   - runtime behavior → `keel-runtime` (interpreter + stdlib)
+4. **Add tests and an example.** Every feature ships with integration tests **and** a runnable
+   `examples/*.keel` program. This is non-negotiable — see [Testing](#testing).
+5. **Update `CHANGELOG.md`** under `## [Unreleased]`, with a `.keel` example for features and an
+   explanation of what broke for fixes. Never hand-write a version number or date — the release
+   process stamps those. Keep the `%%TAGLINE%%` one-liner current.
+6. **Update `docs/src/`.** Touch `release-notes.md` *and* every guide page a user would land on
+   from search. A change isn't done until `mdbook build` runs clean. Tag partial features with
+   `<span class="badge badge-soon">Coming soon</span>` and a `> Status:` callout.
+
+### Runtime type-dispatch checklist
+
+When you write or modify code that dispatches on `TypeExpr` or `Value`, the project enforces a
+few rules that have bitten before (full text in [`AGENTS.md`](AGENTS.md)):
+
+- **Enumerate every variant** of the matched enum; justify every `_ =>` fallback in a comment.
+  `TypeExpr` variants: `Named`, `List`, `Set`, `Map`, `Tuple`, `Nullable`, `Struct`, `Func`, `Generic`.
+- **Audit every exit path** in param/arg loops — variadic `break` and named-arg `continue` skip
+  fall-through logic.
+- **Validate all structural preconditions** on stdlib inputs (uniqueness, non-empty, width
+  consistency). Match types strictly (`Value::String`), don't lean on `to_display_string()` as a
+  coercive catch-all. Never silently drop, truncate, or overwrite data — raise an error.
+
+---
+
+## Testing
+
+> **Every new feature must include integration tests and a `.keel` example before it ships.**
+> Bug fixes need a regression test that fails before the fix and passes after.
+
+- **Unit tests** live alongside the code they test (`cargo test --lib`).
+- **Integration tests** live in `tests/` (`cargo test --test '*'`).
+- **Run tests with `KEEL_LLM=mock`** so they're deterministic and offline.
+- **Examples are tested too** — `just run-all-examples` runs every `examples/*.keel`; a broken
+  example breaks CI.
+
+What makes a good test here: assert on **observable behavior** (program output, diagnostics,
+emitted errors), not on internal mechanism. A test that survives an implementation rewrite which
+preserves behavior is a good test; one that pins a private call order is not. Don't write
+tautological tests that can't fail given the code under test.
+
+---
+
+## Coding standards
+
+This is idiomatic, modern Rust. The bar:
+
+- **`cargo fmt`** — run it after every edit. `rustfmt.toml` pins edition 2024 + Unix newlines so
+  formatting is deterministic across contributors.
+- **`cargo clippy --all-targets --all-features -- -D warnings`** — zero warnings. The workspace
+  denies `clippy::correctness` and warns on `suspicious`, `perf`, `style`, and `complexity`.
+- **`cargo doc --no-deps --document-private-items`** — must build clean; doc links are checked.
+- **API boundaries validate input.** At any public boundary that accepts user data through a
+  permissive mechanism (flexible parsers, `HashMap::insert`, `to_string()` coercions), confirm
+  the input round-trips into the declared output. If it can't — duplicate keys, out-of-bounds
+  indices, wrong element types — return an error. Never let a permissive default silently drop
+  data.
+- **Private helpers use generic error messages** — don't hardcode a public function name in a
+  shared helper's error string; pass `caller: &str` if the identity matters.
+
+The shortcut for all of the above: **`just check` must be green before you open a PR.**
+
+---
+
+## Commits & pull requests
+
+**Commits**
+
+- Write clear, imperative commit subjects that describe *what the change does*:
+  `Fix race condition in file watcher initialization`, not `wip` or `fixes`.
+- Keep history clean: squash noisy intermediate commits before opening the PR (aim for one
+  logical change per commit). Only rewrite history on **unpushed** commits.
+- If your change closes an issue, include `Close #N` in the commit message so GitHub links and
+  closes it on merge.
+
+**Pull requests**
+
+1. Branch off `main` (don't commit directly to `main`).
+2. Make the change, with tests, docs, changelog, and an example as applicable.
+3. Run `just check` — it must pass.
+4. Open the PR with a description of *what* changed and *why*. Link the issue it addresses.
+5. CI runs on every PR (`fmt`, `clippy`, `doc`, release-profile check, full test suite). Green CI
+   is required to merge.
+
+PRs that touch the language surface should reference the `SPEC.md` change in the same PR.
+
+---
+
+## Reporting bugs & proposing features
+
+**Bugs** — open an issue with:
+
+- A **minimal `.keel` reproduction** (smaller is better).
+- The command you ran (e.g. `keel run repro.keel`) and the full output.
+- What you expected vs. what happened.
+- `keel --version` and your OS.
+
+**Features** — open an issue describing the problem first, not just the solution. State the use
+case, sketch the surface, and explain why the standard library / language should own it rather
+than user code. Check [`NON-GOALS.md`](NON-GOALS.md) so you're not re-proposing something that's
+been deliberately declined — and if you think a non-goal should be reconsidered, say so explicitly.
+
+---
+
+## Releases
+
+Releases are run by maintainers through a gated checklist and CI — contributors don't need to cut
+them. Notably: **never hand-write version numbers or dates** into `CHANGELOG.md` or docs; the
+release tooling stamps those automatically. Just keep `## [Unreleased]` accurate and the tagline
+current, and your change will be released correctly.
+
+---
+
+## License
+
+Keel is licensed under the **MIT License**. By contributing, you agree that your contributions
+will be licensed under the same terms.
+
+---
+
+Questions that aren't a bug report? Open a discussion or an issue. Welcome aboard. ⚓

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Zied Maktouf
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@
   <em>v0.2 — alpha. Not production-ready. Breaking changes expected between 0.x releases.</em>
 </p>
 
+<p align="center">
+  <a href="https://github.com/keel-lang/keel/actions/workflows/ci.yml"><img src="https://github.com/keel-lang/keel/actions/workflows/ci.yml/badge.svg" alt="CI"/></a>
+  <a href="https://github.com/keel-lang/keel/releases"><img src="https://img.shields.io/github/v/release/keel-lang/keel?include_prereleases&sort=semver" alt="Latest release"/></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/keel-lang/keel" alt="License: MIT"/></a>
+  <img src="https://img.shields.io/badge/rust-edition%202024-orange.svg" alt="Rust edition 2024"/>
+  <img src="https://img.shields.io/badge/status-alpha-yellow.svg" alt="Status: alpha"/>
+</p>
+
 ---
 
 ## Status: Alpha (v0.2)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,53 @@
+# Security Policy
+
+Keel is **alpha software (v0.2)** with no production users and no stable API. We still take
+security seriously — especially because the standard library touches LLM providers, email
+(IMAP/SMTP), the filesystem, and the network, and programs may handle API keys and credentials.
+
+## Supported versions
+
+Keel ships frequent breaking `0.x` releases. Only the **latest released version** on the `main`
+branch receives security fixes. There are no long-term support branches during the `0.x` series.
+
+| Version | Supported |
+| --- | --- |
+| Latest `0.x` release | ✅ |
+| Older `0.x` releases | ❌ |
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for security vulnerabilities.**
+
+Report privately through either of:
+
+- **GitHub Security Advisories** — [open a private report](https://github.com/keel-lang/keel/security/advisories/new)
+  (Security → Advisories → *Report a vulnerability*). This is the preferred channel.
+- **Email** — `maktouf.zied@gmail.com` with the subject line `SECURITY: <short summary>`.
+
+Please include:
+
+- A description of the vulnerability and its impact.
+- A minimal reproduction (a `.keel` program and/or commands) where possible.
+- The Keel version (`keel --version`), OS, and toolchain.
+- Any suggested remediation, if you have one.
+
+## What to expect
+
+- **Acknowledgement** within **5 business days**.
+- An initial assessment and severity rating shortly after.
+- We'll keep you updated on progress toward a fix and coordinate a disclosure timeline with you.
+- With your permission, we'll credit you in the advisory and release notes once a fix ships.
+
+## Scope
+
+Examples of issues we want to hear about:
+
+- Sandbox or capability escapes (a program reaching resources it wasn't granted).
+- Credential or API-key leakage (e.g. keys surfacing in logs, traces, or error messages).
+- Injection through LLM prompts/responses that leads to unintended file, network, or email actions.
+- Memory-safety or panics reachable from untrusted `.keel` input that lead to DoS.
+
+Out of scope: vulnerabilities in third-party LLM providers, mail servers, or dependencies (report
+those upstream), and theoretical issues without a practical attack path.
+
+Thank you for helping keep Keel and its users safe. ⚓


### PR DESCRIPTION
Brings the repo up to GitHub's community-profile standard. All additions are docs/metadata — no source or build changes.

## What's added

- **`LICENSE`** — MIT license text. `Cargo.toml` declared `MIT` but no license file existed, so the project wasn't actually licensed for reuse. This is the one real gap; the rest is completeness.
- **`CONTRIBUTING.md`** — contributor guide: setup, `just`-based workflow, the spec → tests → changelog → docs gates for language-surface changes, coding standards, and the bug/feature reporting flow.
- **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1.
- **`SECURITY.md`** — private vulnerability reporting (GitHub advisories + email), supported versions, and a scope tuned to Keel's risks (credential leakage, sandbox escape, LLM-driven injection).
- **Issue forms** — `bug_report.yml` (requires a minimal `.keel` repro), `feature_request.yml` (problem-first, NON-GOALS check), and `config.yml` routing to Discussions / security / SPEC.
- **`PULL_REQUEST_TEMPLATE.md`** — checklist mirroring the contributor gates (`just check`, tests + example, changelog, docs; SPEC/design-lang for surface changes).
- **`dependabot.yml`** — weekly grouped `cargo` + `github-actions` updates.
- **`FUNDING.yml`** — Sponsor button for the `keel-lang` org.
- **`CITATION.cff`** — citable project metadata.
- **`README.md`** — CI, release, license, Rust-edition, and status badges.

## Notes

- The **release** badge reads "no release" until a GitHub release is published; the **license** badge resolves once GitHub indexes the new `LICENSE`.
- The Sponsor button requires GitHub Sponsors to be enabled on the `keel-lang` org.