### PR TITLE
Finish migration off Value::to_display_string

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,8 +94,8 @@ When writing a new stdlib namespace method:
   looked up by name), and width consistency (row vs. header column count). Never silently
   drop, truncate, or overwrite data that violates the declared contract — raise an error.
 - **Strict type matching over coercive display.** If the declared contract says `list[str]`,
-  match on `Value::String` explicitly. `to_display_string()` as a catch-all silently accepts
-  wrong types and produces un-round-trippable output.
+  match on `Value::String` explicitly. `.to_string()` (via `Display`) as a catch-all silently
+  accepts wrong types and produces un-round-trippable output.
 - **Private helpers use generic error messages.** Never hardcode a specific public function
   name in a shared helper's error string. If the caller identity matters for diagnostics,
   accept `caller: &str` as a parameter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to Keel.
 ### Changed
 
 - **Dependency upgrades.** `rustyline` 15→18, `logos` 0.14→0.16, `colored` 2→3, `rusqlite` 0.32→0.40, `sha2` 0.10→0.11, `getrandom` 0.2→0.4, `async-native-tls` 0.5→0.6, plus a routine `cargo update` of compatible transitive versions. No user-facing behavior change; internal call sites (`getrandom::fill`, digest-to-hex formatting, a logos comment-token lint annotation) were updated to match each library's new API surface.
+- **Removed `Value::to_display_string`.** All call sites now go through the `Display` impl on `Value` directly (`.to_string()`), which was already functionally identical. No user-facing behavior change.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,8 +202,9 @@ few rules that have bitten before (full text in [`AGENTS.md`](AGENTS.md)):
 - **Audit every exit path** in param/arg loops — variadic `break` and named-arg `continue` skip
   fall-through logic.
 - **Validate all structural preconditions** on stdlib inputs (uniqueness, non-empty, width
-  consistency). Match types strictly (`Value::String`), don't lean on `to_display_string()` as a
-  coercive catch-all. Never silently drop, truncate, or overwrite data — raise an error.
+  consistency). Match types strictly (`Value::String`), don't lean on `.to_string()` (via
+  `Display`) as a coercive catch-all. Never silently drop, truncate, or overwrite data — raise
+  an error.
 
 ---
 

--- a/crates/keel-runtime/src/interpreter/error.rs
+++ b/crates/keel-runtime/src/interpreter/error.rs
@@ -89,7 +89,7 @@ impl fmt::Display for RuntimeError {
         let msg = self
             .fields
             .get("message")
-            .map(|v| v.to_display_string())
+            .map(|v| v.to_string())
             .unwrap_or_default();
         write!(f, "{}: {}", self.type_name(), msg)
     }

--- a/crates/keel-runtime/src/interpreter/expr.rs
+++ b/crates/keel-runtime/src/interpreter/expr.rs
@@ -181,7 +181,7 @@ impl Interpreter {
                                     .await
                                 {
                                     Ok(Value::String(s)) => s,
-                                    _ => v.to_display_string(),
+                                    _ => v.to_string(),
                                 };
                                 let s = if let Some(raw_spec) = spec {
                                     apply_format_spec(&v, base, raw_spec)?

--- a/crates/keel-runtime/src/interpreter/methods.rs
+++ b/crates/keel-runtime/src/interpreter/methods.rs
@@ -540,9 +540,9 @@ impl Interpreter {
             (Value::List(items), "join") => {
                 let sep = args
                     .first()
-                    .map(|a| a.value.to_display_string())
+                    .map(|a| a.value.to_string())
                     .unwrap_or_default();
-                let parts: Vec<String> = items.iter().map(|v| v.to_display_string()).collect();
+                let parts: Vec<String> = items.iter().map(|v| v.to_string()).collect();
                 Ok(Value::String(parts.join(&sep)))
             }
             (Value::List(items), "sort") => {

--- a/crates/keel-runtime/src/interpreter/stmt.rs
+++ b/crates/keel-runtime/src/interpreter/stmt.rs
@@ -265,7 +265,7 @@ impl Interpreter {
                     };
                     let message = match &v {
                         Value::String(s) => s.clone(),
-                        other => other.to_display_string(),
+                        other => other.to_string(),
                     };
                     Err(make_typed_report(RuntimeErrorKind::UserRaised, message))
                 }

--- a/crates/keel-runtime/src/interpreter/value.rs
+++ b/crates/keel-runtime/src/interpreter/value.rs
@@ -175,17 +175,6 @@ impl Value {
         }
     }
 
-    /// Format this value for display-oriented APIs only.
-    ///
-    /// Data APIs must decode their declared input types explicitly instead of
-    /// silently coercing values through this helper.
-    pub fn to_display_string(&self) -> String {
-        match self {
-            Value::String(s) => s.clone(),
-            other => format!("{other}"),
-        }
-    }
-
     pub fn as_int(&self) -> Option<i64> {
         match self {
             Value::Integer(n) => Some(*n),
@@ -488,15 +477,11 @@ mod tests {
     }
 
     #[test]
-    fn to_display_string_passthrough() {
-        assert_eq!(Value::String("hello".into()).to_display_string(), "hello");
-    }
-
-    #[test]
-    fn to_display_string_formats_other() {
-        assert_eq!(Value::Integer(42).to_display_string(), "42");
-        assert_eq!(Value::Bool(true).to_display_string(), "true");
-        assert_eq!(Value::None.to_display_string(), "none");
+    fn display_scalars() {
+        assert_eq!(format!("{}", Value::String("hello".into())), "hello");
+        assert_eq!(format!("{}", Value::Integer(42)), "42");
+        assert_eq!(format!("{}", Value::Bool(true)), "true");
+        assert_eq!(format!("{}", Value::None), "none");
     }
 
     #[test]

--- a/crates/keel-runtime/src/runtime/human.rs
+++ b/crates/keel-runtime/src/runtime/human.rs
@@ -89,10 +89,7 @@ fn show_table(items: &[Value]) {
     for item in items {
         if let Value::Map(fields) = item {
             for (i, col) in columns.iter().enumerate() {
-                let val_len = fields
-                    .get(col)
-                    .map(|v| v.to_display_string().len())
-                    .unwrap_or(0);
+                let val_len = fields.get(col).map(|v| v.to_string().len()).unwrap_or(0);
                 if val_len > widths[i] {
                     widths[i] = val_len;
                 }
@@ -125,10 +122,7 @@ fn show_table(items: &[Value]) {
                 .iter()
                 .enumerate()
                 .map(|(i, col)| {
-                    let val = fields
-                        .get(col)
-                        .map(|v| v.to_display_string())
-                        .unwrap_or_default();
+                    let val = fields.get(col).map(|v| v.to_string()).unwrap_or_default();
                     let truncated = if val.len() > widths[i] {
                         format!("{}…", &val[..widths[i] - 1])
                     } else {

--- a/crates/keel-runtime/src/runtime/namespace.rs
+++ b/crates/keel-runtime/src/runtime/namespace.rs
@@ -185,7 +185,7 @@ mod tests {
             .expect("typed payload should be preserved");
         assert_eq!(typed.type_name(), "AiError");
         assert_eq!(
-            typed.fields.get("message").map(|v| v.to_display_string()),
+            typed.fields.get("message").map(|v| v.to_string()),
             Some("something failed".into())
         );
         assert_eq!(
@@ -214,7 +214,7 @@ mod tests {
             .expect("typed payload should be preserved");
         assert_eq!(typed.type_name(), "AiSchemaError");
         assert_eq!(
-            typed.fields.get("got").map(|v| v.to_display_string()),
+            typed.fields.get("got").map(|v| v.to_string()),
             Some("{\"x\":1}".into())
         );
         assert_eq!(

--- a/crates/keel-runtime/src/runtime/namespaces/ai.rs
+++ b/crates/keel-runtime/src/runtime/namespaces/ai.rs
@@ -45,7 +45,7 @@ pub(crate) fn namespace() -> Namespace {
         "classify" => |host, args| Box::pin(async move {
             let input = positional(&args, 0)
                 .ok_or_else(|| miette::miette!("ai.classify: missing input"))?
-                .to_display_string();
+                .to_string();
             let variants = classify_variants(host, &args)?;
             let criteria = extract_criteria(&args);
             let (model, user_provider) = resolve_provider(host, &args);
@@ -69,13 +69,13 @@ pub(crate) fn namespace() -> Namespace {
         "summarize" => |host, args| Box::pin(async move {
             let input = positional(&args, 0)
                 .ok_or_else(|| miette::miette!("ai.summarize: missing input"))?
-                .to_display_string();
-            let unit_val = find_arg(&args, "unit").map(|v| v.to_display_string());
+                .to_string();
+            let unit_val = find_arg(&args, "unit").map(|v| v.to_string());
             let length = match (find_arg(&args, "in"), &unit_val) {
                 (Some(Value::Integer(n)), Some(u)) => Some((*n, u.clone())),
                 _ => None,
             };
-            let format = find_arg(&args, "format").map(|v| v.to_display_string());
+            let format = find_arg(&args, "format").map(|v| v.to_string());
             let max = find_arg(&args, "max").and_then(|v| v.as_int());
             let (model, user_provider) = resolve_provider(host, &args);
             let max_tokens = host.current_max_tokens();
@@ -93,9 +93,9 @@ pub(crate) fn namespace() -> Namespace {
         "draft" => |host, args| Box::pin(async move {
             let description = positional(&args, 0)
                 .ok_or_else(|| miette::miette!("ai.draft: missing description"))?
-                .to_display_string();
-            let tone = find_arg(&args, "tone").map(|v| v.to_display_string());
-            let guidance = find_arg(&args, "guidance").map(|v| v.to_display_string());
+                .to_string();
+            let tone = find_arg(&args, "tone").map(|v| v.to_string());
+            let guidance = find_arg(&args, "guidance").map(|v| v.to_string());
             let max_length = find_arg(&args, "max_length").and_then(|v| v.as_int());
             let (model, user_provider) = resolve_provider(host, &args);
             let max_tokens = host.current_max_tokens();
@@ -115,10 +115,10 @@ pub(crate) fn namespace() -> Namespace {
 
         "extract" => |host, args| Box::pin(async move {
             let input = match find_arg(&args, "from") {
-                Some(v) => v.to_display_string(),
+                Some(v) => v.to_string(),
                 None => positional(&args, 0)
                     .ok_or_else(|| miette::miette!("ai.extract: missing input"))?
-                    .to_display_string(),
+                    .to_string(),
             };
             // Schema from `schema: { field: "type" }` map, or derived from `as: T` struct type.
             // target_type records the struct name when using `as: T` so the result can be tagged.
@@ -126,7 +126,7 @@ pub(crate) fn namespace() -> Namespace {
                 match find_arg(&args, "schema") {
                     Some(Value::Map(m)) => (
                         m.iter()
-                            .map(|(k, v)| (k.to_string(), v.to_display_string()))
+                            .map(|(k, v)| (k.to_string(), v.to_string()))
                             .collect(),
                         None,
                     ),
@@ -176,10 +176,10 @@ pub(crate) fn namespace() -> Namespace {
         "translate" => |host, args| Box::pin(async move {
             let input = positional(&args, 0)
                 .ok_or_else(|| miette::miette!("ai.translate: missing input"))?
-                .to_display_string();
+                .to_string();
             let target_langs: Vec<String> = match find_arg(&args, "to") {
-                Some(Value::List(items)) => items.iter().map(|v| v.to_display_string()).collect(),
-                Some(other) => vec![other.to_display_string()],
+                Some(Value::List(items)) => items.iter().map(|v| v.to_string()).collect(),
+                Some(other) => vec![other.to_string()],
                 None => return Err(miette::miette!("ai.translate: missing `to:` argument")),
             };
             if target_langs.is_empty() {
@@ -212,9 +212,9 @@ pub(crate) fn namespace() -> Namespace {
         "decide" => |host, args| Box::pin(async move {
             let input = positional(&args, 0)
                 .ok_or_else(|| miette::miette!("ai.decide: missing input"))?
-                .to_display_string();
+                .to_string();
             let options: Vec<String> = match find_arg(&args, "options") {
-                Some(Value::List(items)) => items.iter().map(|v| v.to_display_string()).collect(),
+                Some(Value::List(items)) => items.iter().map(|v| v.to_string()).collect(),
                 _ => Vec::new(),
             };
             let (model, user_provider) = resolve_provider(host, &args);
@@ -237,9 +237,9 @@ pub(crate) fn namespace() -> Namespace {
         }),
 
         "prompt" => |host, args| Box::pin(async move {
-            let system = find_arg(&args, "system").map(|v| v.to_display_string()).unwrap_or_default();
-            let user = find_arg(&args, "user").map(|v| v.to_display_string()).unwrap_or_default();
-            let response_format = find_arg(&args, "response_format").map(|v| v.to_display_string());
+            let system = find_arg(&args, "system").map(|v| v.to_string()).unwrap_or_default();
+            let user = find_arg(&args, "user").map(|v| v.to_string()).unwrap_or_default();
+            let response_format = find_arg(&args, "response_format").map(|v| v.to_string());
             let (model, user_provider) = resolve_provider(host, &args);
             let max_tokens = host.current_max_tokens();
             let role = host.current_role();
@@ -305,7 +305,7 @@ pub(crate) fn namespace() -> Namespace {
 /// provider leaves the tag bare and is dispatched by re-entering the interpreter.
 fn resolve_provider(host: &dyn Host, args: &[CallArgValue]) -> (String, Option<String>) {
     let tag = match find_arg(args, "using") {
-        Some(v) => v.to_display_string(),
+        Some(v) => v.to_string(),
         None => host.current_model(),
     };
     route_tag(
@@ -413,7 +413,7 @@ fn classify_variants(host: &dyn Host, args: &[CallArgValue]) -> miette::Result<V
         }
         Some(Value::List(items)) => {
             // Inline form: `as: [low, medium, high]`
-            Ok(items.iter().map(|v| v.to_display_string()).collect())
+            Ok(items.iter().map(|v| v.to_string()).collect())
         }
         _ => Err(miette::miette!("ai.classify: missing `as:` argument")),
     }
@@ -427,7 +427,7 @@ fn extract_criteria(args: &[CallArgValue]) -> Vec<(String, String)> {
             .map(|(k, v)| {
                 let variant_name = match v {
                     Value::EnumVariant(_, variant, _) => variant.clone(),
-                    other => other.to_display_string(),
+                    other => other.to_string(),
                 };
                 (k.to_string(), variant_name)
             })
@@ -453,7 +453,7 @@ mod tests {
         let err = typed(LlmError::CallFailed("Ollama unreachable".into()));
         assert_eq!(err.type_name(), "AiError");
         assert_eq!(
-            err.fields.get("reason").map(|v| v.to_display_string()),
+            err.fields.get("reason").map(|v| v.to_string()),
             Some("unavailable".into())
         );
     }
@@ -463,7 +463,7 @@ mod tests {
         let err = typed(LlmError::ConfigError("model not mapped".into()));
         assert_eq!(err.type_name(), "AiError");
         assert_eq!(
-            err.fields.get("reason").map(|v| v.to_display_string()),
+            err.fields.get("reason").map(|v| v.to_string()),
             Some("provider".into())
         );
     }
@@ -475,7 +475,7 @@ mod tests {
         });
         assert_eq!(err.type_name(), "AiSchemaError");
         assert_eq!(
-            err.fields.get("got").map(|v| v.to_display_string()),
+            err.fields.get("got").map(|v| v.to_string()),
             Some("maybe".into())
         );
     }

--- a/crates/keel-runtime/src/runtime/namespaces/file.rs
+++ b/crates/keel-runtime/src/runtime/namespaces/file.rs
@@ -287,7 +287,7 @@ mod tests {
         let result = list(&mut interp, vec![arg(Value::String("d".into()))]).await;
         match result.unwrap() {
             Value::List(items) => {
-                let names: Vec<String> = items.iter().map(|v| v.to_display_string()).collect();
+                let names: Vec<String> = items.iter().map(|v| v.to_string()).collect();
                 assert!(names.contains(&"a.txt".to_string()));
                 assert!(names.contains(&"b.txt".to_string()));
             }
@@ -437,7 +437,7 @@ mod tests {
         let result = glob(&mut interp, vec![arg(Value::String("data/*.txt".into()))]).await;
         match result.unwrap() {
             Value::List(items) => {
-                let names: Vec<String> = items.iter().map(|v| v.to_display_string()).collect();
+                let names: Vec<String> = items.iter().map(|v| v.to_string()).collect();
                 assert!(
                     names.contains(&"data/a.txt".to_string()),
                     "missing a.txt: {names:?}"

--- a/crates/keel-runtime/src/runtime/namespaces/http.rs
+++ b/crates/keel-runtime/src/runtime/namespaces/http.rs
@@ -455,7 +455,7 @@ mod tests {
         match v {
             Value::Map(m) => m
                 .get(&MapKey::Str("body".into()))
-                .map(|v| v.to_display_string())
+                .map(|v| v.to_string())
                 .unwrap_or_default(),
             _ => String::new(),
         }

--- a/crates/keel-runtime/src/runtime/namespaces/io.rs
+++ b/crates/keel-runtime/src/runtime/namespaces/io.rs
@@ -6,7 +6,7 @@ use crate::runtime::namespace::{ns, positional};
 pub(crate) fn namespace() -> Namespace {
     ns!("io", {
         "notify" => |_host, args| Box::pin(async move {
-            let msg = positional(&args, 0).map(|v| v.to_display_string()).unwrap_or_default();
+            let msg = positional(&args, 0).map(|v| v.to_string()).unwrap_or_default();
             human::notify(&msg);
             Ok(Value::None)
         }),
@@ -16,7 +16,7 @@ pub(crate) fn namespace() -> Namespace {
             Ok(Value::None)
         }),
         "ask" => |_i, args| Box::pin(async move {
-            let prompt = positional(&args, 0).map(|v| v.to_display_string()).unwrap_or_default();
+            let prompt = positional(&args, 0).map(|v| v.to_string()).unwrap_or_default();
             // Off-thread the blocking stdin read so the tokio runtime
             // can keep polling other tasks (signal watcher, scheduler).
             let answer = tokio::task::spawn_blocking(move || human::ask(&prompt))
@@ -26,7 +26,7 @@ pub(crate) fn namespace() -> Namespace {
             Ok(Value::String(answer))
         }),
         "confirm" => |_i, args| Box::pin(async move {
-            let prompt = positional(&args, 0).map(|v| v.to_display_string()).unwrap_or_default();
+            let prompt = positional(&args, 0).map(|v| v.to_string()).unwrap_or_default();
             let answer = tokio::task::spawn_blocking(move || human::confirm(&prompt))
                 .await
                 .map_err(|e| miette::miette!("io.confirm task join error: {e}"))?

--- a/crates/keel-runtime/src/runtime/namespaces/log.rs
+++ b/crates/keel-runtime/src/runtime/namespaces/log.rs
@@ -14,22 +14,22 @@ fn log_if_enabled(host: &dyn Host, level: &str, msg: &str) {
 pub(crate) fn namespace() -> Namespace {
     ns!("log", {
         "info" => |host, args| Box::pin(async move {
-            let msg = positional(&args, 0).map(|v| v.to_display_string()).unwrap_or_default();
+            let msg = positional(&args, 0).map(|v| v.to_string()).unwrap_or_default();
             log_if_enabled(host, "info", &msg);
             Ok(Value::None)
         }),
         "warn" => |host, args| Box::pin(async move {
-            let msg = positional(&args, 0).map(|v| v.to_display_string()).unwrap_or_default();
+            let msg = positional(&args, 0).map(|v| v.to_string()).unwrap_or_default();
             log_if_enabled(host, "warn", &msg);
             Ok(Value::None)
         }),
         "error" => |host, args| Box::pin(async move {
-            let msg = positional(&args, 0).map(|v| v.to_display_string()).unwrap_or_default();
+            let msg = positional(&args, 0).map(|v| v.to_string()).unwrap_or_default();
             log_if_enabled(host, "error", &msg);
             Ok(Value::None)
         }),
         "debug" => |host, args| Box::pin(async move {
-            let msg = positional(&args, 0).map(|v| v.to_display_string()).unwrap_or_default();
+            let msg = positional(&args, 0).map(|v| v.to_string()).unwrap_or_default();
             log_if_enabled(host, "debug", &msg);
             Ok(Value::None)
         }),

--- a/crates/keel-runtime/src/runtime/namespaces/shell.rs
+++ b/crates/keel-runtime/src/runtime/namespaces/shell.rs
@@ -102,8 +102,7 @@ mod tests {
         match result {
             Value::Map(m) => {
                 assert_eq!(
-                    m.get(&MapKey::Str("stdout".into()))
-                        .map(|v| v.to_display_string()),
+                    m.get(&MapKey::Str("stdout".into())).map(|v| v.to_string()),
                     Some("hello\n".to_string())
                 );
                 assert_eq!(
@@ -170,7 +169,7 @@ mod tests {
             Value::Map(m) => {
                 let stdout = m
                     .get(&MapKey::Str("stdout".into()))
-                    .map(|v| v.to_display_string())
+                    .map(|v| v.to_string())
                     .unwrap_or_default();
                 // macOS resolves /var/folders/... symlinks; compare canonicalized paths.
                 let got = std::fs::canonicalize(stdout.trim()).expect("canonicalize stdout");
@@ -204,8 +203,7 @@ mod tests {
         match result {
             Value::Map(m) => {
                 assert_eq!(
-                    m.get(&MapKey::Str("stdout".into()))
-                        .map(|v| v.to_display_string()),
+                    m.get(&MapKey::Str("stdout".into())).map(|v| v.to_string()),
                     Some("hello from stdin".to_string())
                 );
             }

--- a/tests/integration/language/strings.rs
+++ b/tests/integration/language/strings.rs
@@ -476,7 +476,7 @@ run(A)
 #[test]
 fn format_spec_alignment_respects_custom_to_str() {
     // Alignment specs must call to_str() via impl dispatch, not fall back to
-    // to_display_string(), so {x:>10} and {x} produce the same base string.
+    // the default Display formatting, so {x:>10} and {x} produce the same base string.
     let src = r#"
 use std/io
 type Tag { value: str }


### PR DESCRIPTION
## Summary
- Removes `Value::to_display_string` and migrates all call sites to `.to_string()` via the existing `Display` impl on `Value` (functionally identical — `to_display_string` already just delegated to `Display` under the hood).
- Replaces the two dedicated `to_display_string` unit tests with a `display_scalars` test covering the same cases through `Display`.
- Updates stale references to the removed method in `AGENTS.md`, `CONTRIBUTING.md`, and a test comment.

Closes #43

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `KEEL_LLM=mock cargo test --workspace` (all suites pass)