### PR TITLE
Add unit test for send's non-agent-target error path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to Keel.
 
 - **Dependency upgrades.** `rustyline` 15→18, `logos` 0.14→0.16, `colored` 2→3, `rusqlite` 0.32→0.40, `sha2` 0.10→0.11, `getrandom` 0.2→0.4, `async-native-tls` 0.5→0.6, plus a routine `cargo update` of compatible transitive versions. No user-facing behavior change; internal call sites (`getrandom::fill`, digest-to-hex formatting, a logos comment-token lint annotation) were updated to match each library's new API surface.
 - **Removed `Value::to_display_string`.** All call sites now go through the `Display` impl on `Value` directly (`.to_string()`), which was already functionally identical. No user-facing behavior change.
+- **`send`'s non-agent-target error path now has dedicated unit test coverage.** Unlike `delegate`, `send`'s first argument isn't validated by the type checker, so a non-agent value type-checks and only fails at runtime — that branch had no test anywhere in the suite. (`control.rs`, `json.rs`, and `io.rs` were also audited for the same gap; all three already had this covered via existing integration tests, so no changes were needed there.)
 
 ### Fixed
 

--- a/crates/keel-runtime/src/runtime/namespaces/agent.rs
+++ b/crates/keel-runtime/src/runtime/namespaces/agent.rs
@@ -164,3 +164,46 @@ fn agents_in_team(host: &dyn Host, team: &str) -> Vec<String> {
     }
     out
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::interpreter::Interpreter;
+
+    fn arg(v: Value) -> CallArgValue {
+        CallArgValue {
+            name: None,
+            value: v,
+        }
+    }
+
+    // `delegate`'s target shape is validated at compile time by
+    // `check_delegate_call` in the checker, so its runtime `_ => Err` branch
+    // is unreachable from well-typed programs. `send`'s target is not
+    // specially checked — a non-agent value type-checks as a generic call
+    // and only fails here, at runtime, so this is the one messaging verb
+    // whose argument validation needs its own coverage.
+    #[tokio::test]
+    async fn send_rejects_non_agent_target() {
+        let mut interp = Interpreter::default();
+        install_messaging_fns(&mut interp);
+        let send = interp
+            .namespaces
+            .get("__global")
+            .and_then(|ns| ns.methods.get("send"))
+            .expect("send must be registered")
+            .clone();
+
+        let err = send(
+            &mut interp,
+            vec![
+                arg(Value::String("not-an-agent".into())),
+                arg(Value::Integer(1)),
+            ],
+        )
+        .await
+        .expect_err("non-agent target must fail");
+
+        assert_eq!(err.to_string(), "send: first arg must be an agent");
+    }
+}


### PR DESCRIPTION
## Summary

#55 named 7 namespace files with zero dedicated unit tests: `agent`, `ai`, `asynchronous`, `control`, `http`, `io`, `json`. Auditing the current state before writing anything:

- `ai`, `asynchronous`, `http` already have unit tests (added since the issue was filed).
- `control` and `json` have no *unit* tests, but their error paths are already fully exercised by integration tests (`tests/integration/util.rs` for `control.*`, `tests/integration/namespaces/data.rs` and `tests/integration/language/builtin_interfaces.rs` for `json.*`, including the trickier struct-promotion logic). Adding unit tests there would just duplicate existing coverage.
- `io.rs`'s `notify`/`show` have no error path to test, and `ask`/`confirm` are already integration-tested in `tests/integration/agent.rs`.
- `agent.rs` had one genuine gap: `send`'s first argument (must be an `AgentRef`) isn't validated by the type checker the way `delegate`'s is (`check_delegate_call` special-cases `delegate` at compile time), so a non-agent value type-checks fine and only fails at runtime — and that branch wasn't covered anywhere.

This PR closes that one gap rather than padding out the other three files with tests that wouldn't catch any regression the integration suite doesn't already catch.

Closes #55

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `KEEL_LLM=mock cargo test --workspace` (all suites pass, incl. new test)