### PR TITLE
Assign stable ns_id/method_id to stdlib namespace methods

### DIFF
--- a/crates/keel-catalog/src/builtins.rs
+++ b/crates/keel-catalog/src/builtins.rs
@@ -99,6 +99,13 @@ pub struct BuiltinMethod {
     pub namespace: &'static str,
     /// The method name as it appears in Keel source (e.g., `"read"`).
     pub name: &'static str,
+    /// Stable id for this method within its namespace, consumed by
+    /// `keel-kir`'s `CallTarget::Ns` lowering and `keel-rt-ffi`'s
+    /// `keel_rt_call_ns` dispatch. Assigned once per method and never
+    /// reused: removing a method leaves a gap rather than shifting the ids
+    /// of the methods after it. Unique only within a namespace — pair with
+    /// [`crate::specs::namespace_id`] for a globally unique id.
+    pub method_id: u16,
     /// Declared parameter list. Empty `&[]` means zero or variadic
     /// parameters that are not statically validated by the checker yet.
     #[allow(dead_code)]

--- a/crates/keel-catalog/src/lib.rs
+++ b/crates/keel-catalog/src/lib.rs
@@ -15,4 +15,4 @@ pub use providers::{
     BUILTIN_LLM_PROVIDERS, builtin_provider_prefix, is_builtin_llm_provider,
     provider_attribute_error,
 };
-pub use specs::{catalog, catalog_method, module_requires_capability};
+pub use specs::{catalog, catalog_method, module_requires_capability, namespace_id};

--- a/crates/keel-catalog/src/specs/ai.rs
+++ b/crates/keel-catalog/src/specs/ai.rs
@@ -6,6 +6,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "ai",
         name: "classify",
+        method_id: 0,
         params: &[],
         result: BuiltinResult::AiClassify,
         doc: "Classify text into an enum variant.",
@@ -13,6 +14,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "ai",
         name: "summarize",
+        method_id: 1,
         params: &[],
         result: BuiltinResult::Fixed(TySpec::NullableStr),
         doc: "Summarize text.",
@@ -20,6 +22,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "ai",
         name: "draft",
+        method_id: 2,
         params: &[],
         result: BuiltinResult::Fixed(TySpec::NullableStr),
         doc: "Draft text from a prompt.",
@@ -27,6 +30,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "ai",
         name: "extract",
+        method_id: 3,
         params: &[],
         result: BuiltinResult::AiExtract,
         doc: "Extract a typed value from text.",
@@ -34,6 +38,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "ai",
         name: "translate",
+        method_id: 4,
         params: &[],
         result: BuiltinResult::Fixed(TySpec::NullableStr),
         doc: "Translate text to another language.",
@@ -41,6 +46,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "ai",
         name: "decide",
+        method_id: 5,
         params: &[],
         result: BuiltinResult::AiExtract,
         doc: "Decide by extracting a typed value from context.",
@@ -48,6 +54,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "ai",
         name: "prompt",
+        method_id: 6,
         params: &[],
         result: BuiltinResult::Fixed(TySpec::NullableStr),
         doc: "Send a raw prompt to the LLM and return its response.",
@@ -55,6 +62,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "ai",
         name: "embed",
+        method_id: 7,
         params: &[],
         result: BuiltinResult::Unknown,
         doc: "Embed text into a vector (reserved, not yet stable).",
@@ -62,6 +70,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "ai",
         name: "install",
+        method_id: 8,
         params: &[],
         result: BuiltinResult::Fixed(TySpec::None_),
         doc: "Register a user-authored `LlmProvider` as the program-wide backend.",

--- a/crates/keel-catalog/src/specs/asynchronous.rs
+++ b/crates/keel-catalog/src/specs/asynchronous.rs
@@ -6,6 +6,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "async",
         name: "spawn",
+        method_id: 0,
         params: &[],
         result: BuiltinResult::Unknown,
         doc: "Spawn a concurrent task and return a handle.",
@@ -13,6 +14,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "async",
         name: "join_all",
+        method_id: 1,
         params: &[BuiltinParam {
             name: "handles",
             ty: TySpec::Dynamic,
@@ -24,6 +26,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "async",
         name: "select",
+        method_id: 2,
         params: &[BuiltinParam {
             name: "handles",
             ty: TySpec::Dynamic,
@@ -35,6 +38,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "async",
         name: "sleep",
+        method_id: 3,
         params: &[BuiltinParam {
             name: "duration",
             ty: TySpec::Duration,

--- a/crates/keel-catalog/src/specs/cache.rs
+++ b/crates/keel-catalog/src/specs/cache.rs
@@ -6,6 +6,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "cache",
         name: "set",
+        method_id: 0,
         params: &[
             BuiltinParam {
                 name: "key",
@@ -29,6 +30,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "cache",
         name: "get",
+        method_id: 1,
         params: &[BuiltinParam {
             name: "key",
             ty: TySpec::Str,
@@ -40,6 +42,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "cache",
         name: "delete",
+        method_id: 2,
         params: &[BuiltinParam {
             name: "key",
             ty: TySpec::Str,
@@ -51,6 +54,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "cache",
         name: "clear",
+        method_id: 3,
         params: &[],
         result: BuiltinResult::Fixed(TySpec::None_),
         doc: "Clear all entries from the cache.",

--- a/crates/keel-catalog/src/specs/control.rs
+++ b/crates/keel-catalog/src/specs/control.rs
@@ -6,6 +6,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "control",
         name: "retry",
+        method_id: 0,
         params: &[],
         result: BuiltinResult::Unknown,
         doc: "Retry a task on failure with configurable backoff.",
@@ -13,6 +14,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "control",
         name: "with_timeout",
+        method_id: 1,
         params: &[BuiltinParam {
             name: "duration",
             ty: TySpec::Duration,
@@ -24,6 +26,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "control",
         name: "with_deadline",
+        method_id: 2,
         params: &[BuiltinParam {
             name: "deadline",
             ty: TySpec::Datetime,

--- a/crates/keel-catalog/src/specs/crypto.rs
+++ b/crates/keel-catalog/src/specs/crypto.rs
@@ -6,6 +6,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "crypto",
         name: "sha224",
+        method_id: 0,
         params: &[BuiltinParam {
             name: "data",
             ty: TySpec::Str,
@@ -17,6 +18,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "crypto",
         name: "sha256",
+        method_id: 1,
         params: &[BuiltinParam {
             name: "data",
             ty: TySpec::Str,
@@ -28,6 +30,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "crypto",
         name: "sha384",
+        method_id: 2,
         params: &[BuiltinParam {
             name: "data",
             ty: TySpec::Str,
@@ -39,6 +42,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "crypto",
         name: "sha512",
+        method_id: 3,
         params: &[BuiltinParam {
             name: "data",
             ty: TySpec::Str,
@@ -50,6 +54,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "crypto",
         name: "sha512_224",
+        method_id: 4,
         params: &[BuiltinParam {
             name: "data",
             ty: TySpec::Str,
@@ -61,6 +66,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "crypto",
         name: "sha512_256",
+        method_id: 5,
         params: &[BuiltinParam {
             name: "data",
             ty: TySpec::Str,
@@ -72,6 +78,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "crypto",
         name: "hmac_sha224",
+        method_id: 6,
         params: &[
             BuiltinParam {
                 name: "key",
@@ -90,6 +97,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "crypto",
         name: "hmac_sha256",
+        method_id: 7,
         params: &[
             BuiltinParam {
                 name: "key",
@@ -108,6 +116,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "crypto",
         name: "hmac_sha384",
+        method_id: 8,
         params: &[
             BuiltinParam {
                 name: "key",
@@ -126,6 +135,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "crypto",
         name: "hmac_sha512",
+        method_id: 9,
         params: &[
             BuiltinParam {
                 name: "key",
@@ -144,6 +154,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "crypto",
         name: "hmac_sha512_224",
+        method_id: 10,
         params: &[
             BuiltinParam {
                 name: "key",
@@ -162,6 +173,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "crypto",
         name: "hmac_sha512_256",
+        method_id: 11,
         params: &[
             BuiltinParam {
                 name: "key",
@@ -180,6 +192,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "crypto",
         name: "token",
+        method_id: 12,
         params: &[BuiltinParam {
             name: "len",
             ty: TySpec::Int,
@@ -191,6 +204,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "crypto",
         name: "random_bytes",
+        method_id: 13,
         params: &[BuiltinParam {
             name: "len",
             ty: TySpec::Int,

--- a/crates/keel-catalog/src/specs/csv.rs
+++ b/crates/keel-catalog/src/specs/csv.rs
@@ -6,6 +6,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "csv",
         name: "parse",
+        method_id: 0,
         params: &[BuiltinParam {
             name: "s",
             ty: TySpec::Str,
@@ -17,6 +18,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "csv",
         name: "parse_records",
+        method_id: 1,
         params: &[BuiltinParam {
             name: "s",
             ty: TySpec::Str,
@@ -28,6 +30,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "csv",
         name: "stringify",
+        method_id: 2,
         params: &[BuiltinParam {
             name: "rows",
             ty: TySpec::Dynamic,

--- a/crates/keel-catalog/src/specs/db.rs
+++ b/crates/keel-catalog/src/specs/db.rs
@@ -5,6 +5,7 @@ use crate::builtins::*;
 pub const SPEC: &[BuiltinMethod] = &[BuiltinMethod {
     namespace: "db",
     name: "connect",
+    method_id: 0,
     params: &[BuiltinParam {
         name: "url",
         ty: TySpec::Str,

--- a/crates/keel-catalog/src/specs/email.rs
+++ b/crates/keel-catalog/src/specs/email.rs
@@ -6,6 +6,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "email",
         name: "fetch",
+        method_id: 0,
         params: &[],
         result: BuiltinResult::Unknown,
         doc: "Fetch messages from the configured email inbox.",
@@ -13,6 +14,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "email",
         name: "send",
+        method_id: 1,
         params: &[
             BuiltinParam {
                 name: "to",
@@ -36,6 +38,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "email",
         name: "archive",
+        method_id: 2,
         params: &[BuiltinParam {
             name: "id",
             ty: TySpec::Str,

--- a/crates/keel-catalog/src/specs/env.rs
+++ b/crates/keel-catalog/src/specs/env.rs
@@ -6,6 +6,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "env",
         name: "get",
+        method_id: 0,
         params: &[BuiltinParam {
             name: "key",
             ty: TySpec::Str,
@@ -17,6 +18,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "env",
         name: "require",
+        method_id: 1,
         params: &[BuiltinParam {
             name: "key",
             ty: TySpec::Str,

--- a/crates/keel-catalog/src/specs/file.rs
+++ b/crates/keel-catalog/src/specs/file.rs
@@ -6,6 +6,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "file",
         name: "read",
+        method_id: 0,
         params: &[BuiltinParam {
             name: "path",
             ty: TySpec::Str,
@@ -17,6 +18,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "file",
         name: "write",
+        method_id: 1,
         params: &[
             BuiltinParam {
                 name: "path",
@@ -35,6 +37,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "file",
         name: "exists",
+        method_id: 2,
         params: &[BuiltinParam {
             name: "path",
             ty: TySpec::Str,
@@ -46,6 +49,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "file",
         name: "list",
+        method_id: 3,
         params: &[BuiltinParam {
             name: "path",
             ty: TySpec::Str,
@@ -57,6 +61,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "file",
         name: "mkdir",
+        method_id: 4,
         params: &[BuiltinParam {
             name: "path",
             ty: TySpec::Str,
@@ -68,6 +73,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "file",
         name: "remove",
+        method_id: 5,
         params: &[BuiltinParam {
             name: "path",
             ty: TySpec::Str,
@@ -79,6 +85,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "file",
         name: "copy",
+        method_id: 6,
         params: &[
             BuiltinParam {
                 name: "src",
@@ -97,6 +104,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "file",
         name: "glob",
+        method_id: 7,
         params: &[BuiltinParam {
             name: "pattern",
             ty: TySpec::Str,
@@ -108,6 +116,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "file",
         name: "move",
+        method_id: 8,
         params: &[
             BuiltinParam {
                 name: "src",
@@ -126,6 +135,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "file",
         name: "mktemp",
+        method_id: 9,
         params: &[],
         result: BuiltinResult::Fixed(TySpec::Str),
         doc: "Create a temporary file and return its path.",

--- a/crates/keel-catalog/src/specs/http.rs
+++ b/crates/keel-catalog/src/specs/http.rs
@@ -6,6 +6,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "http",
         name: "get",
+        method_id: 0,
         params: &[BuiltinParam {
             name: "url",
             ty: TySpec::Str,
@@ -17,6 +18,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "http",
         name: "post",
+        method_id: 1,
         params: &[
             BuiltinParam {
                 name: "url",
@@ -35,6 +37,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "http",
         name: "request",
+        method_id: 2,
         params: &[
             BuiltinParam {
                 name: "method",
@@ -53,6 +56,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "http",
         name: "serve",
+        method_id: 3,
         params: &[BuiltinParam {
             name: "port",
             ty: TySpec::Int,

--- a/crates/keel-catalog/src/specs/io.rs
+++ b/crates/keel-catalog/src/specs/io.rs
@@ -6,6 +6,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "io",
         name: "ask",
+        method_id: 0,
         params: &[BuiltinParam {
             name: "prompt",
             ty: TySpec::Str,
@@ -17,6 +18,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "io",
         name: "confirm",
+        method_id: 1,
         params: &[BuiltinParam {
             name: "prompt",
             ty: TySpec::Str,
@@ -28,6 +30,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "io",
         name: "notify",
+        method_id: 2,
         params: &[BuiltinParam {
             name: "message",
             ty: TySpec::Str,
@@ -39,6 +42,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "io",
         name: "show",
+        method_id: 3,
         params: &[BuiltinParam {
             name: "value",
             ty: TySpec::Dynamic,

--- a/crates/keel-catalog/src/specs/json.rs
+++ b/crates/keel-catalog/src/specs/json.rs
@@ -6,6 +6,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "json",
         name: "parse",
+        method_id: 0,
         params: &[BuiltinParam {
             name: "s",
             ty: TySpec::Str,
@@ -20,6 +21,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "json",
         name: "stringify",
+        method_id: 1,
         params: &[BuiltinParam {
             name: "value",
             ty: TySpec::Dynamic,

--- a/crates/keel-catalog/src/specs/log.rs
+++ b/crates/keel-catalog/src/specs/log.rs
@@ -6,6 +6,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "log",
         name: "info",
+        method_id: 0,
         params: &[BuiltinParam {
             name: "message",
             ty: TySpec::Dynamic,
@@ -17,6 +18,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "log",
         name: "warn",
+        method_id: 1,
         params: &[BuiltinParam {
             name: "message",
             ty: TySpec::Dynamic,
@@ -28,6 +30,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "log",
         name: "error",
+        method_id: 2,
         params: &[BuiltinParam {
             name: "message",
             ty: TySpec::Dynamic,
@@ -39,6 +42,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "log",
         name: "debug",
+        method_id: 3,
         params: &[BuiltinParam {
             name: "message",
             ty: TySpec::Dynamic,
@@ -50,6 +54,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "log",
         name: "set_level",
+        method_id: 4,
         params: &[BuiltinParam {
             name: "level",
             ty: TySpec::Str,
@@ -61,6 +66,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "log",
         name: "level",
+        method_id: 5,
         params: &[],
         result: BuiltinResult::Fixed(TySpec::Str),
         doc: "Return the current log level as a string.",

--- a/crates/keel-catalog/src/specs/math.rs
+++ b/crates/keel-catalog/src/specs/math.rs
@@ -6,6 +6,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "math",
         name: "PI",
+        method_id: 0,
         params: &[],
         result: BuiltinResult::Fixed(TySpec::Float),
         doc: "The mathematical constant π (3.14159…).",
@@ -13,6 +14,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "math",
         name: "E",
+        method_id: 1,
         params: &[],
         result: BuiltinResult::Fixed(TySpec::Float),
         doc: "The mathematical constant e (2.71828…).",
@@ -20,6 +22,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "math",
         name: "sqrt",
+        method_id: 2,
         params: &[BuiltinParam {
             name: "x",
             ty: TySpec::Float,
@@ -31,6 +34,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "math",
         name: "pow",
+        method_id: 3,
         params: &[
             BuiltinParam {
                 name: "x",
@@ -49,6 +53,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "math",
         name: "exp",
+        method_id: 4,
         params: &[BuiltinParam {
             name: "x",
             ty: TySpec::Float,
@@ -60,6 +65,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "math",
         name: "log",
+        method_id: 5,
         params: &[BuiltinParam {
             name: "x",
             ty: TySpec::Float,
@@ -71,6 +77,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "math",
         name: "log2",
+        method_id: 6,
         params: &[BuiltinParam {
             name: "x",
             ty: TySpec::Float,
@@ -82,6 +89,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "math",
         name: "log10",
+        method_id: 7,
         params: &[BuiltinParam {
             name: "x",
             ty: TySpec::Float,
@@ -93,6 +101,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "math",
         name: "sin",
+        method_id: 8,
         params: &[BuiltinParam {
             name: "x",
             ty: TySpec::Float,
@@ -104,6 +113,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "math",
         name: "cos",
+        method_id: 9,
         params: &[BuiltinParam {
             name: "x",
             ty: TySpec::Float,
@@ -115,6 +125,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "math",
         name: "tan",
+        method_id: 10,
         params: &[BuiltinParam {
             name: "x",
             ty: TySpec::Float,
@@ -126,6 +137,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "math",
         name: "asin",
+        method_id: 11,
         params: &[BuiltinParam {
             name: "x",
             ty: TySpec::Float,
@@ -137,6 +149,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "math",
         name: "acos",
+        method_id: 12,
         params: &[BuiltinParam {
             name: "x",
             ty: TySpec::Float,
@@ -148,6 +161,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "math",
         name: "atan",
+        method_id: 13,
         params: &[BuiltinParam {
             name: "x",
             ty: TySpec::Float,
@@ -159,6 +173,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "math",
         name: "atan2",
+        method_id: 14,
         params: &[
             BuiltinParam {
                 name: "y",

--- a/crates/keel-catalog/src/specs/memory.rs
+++ b/crates/keel-catalog/src/specs/memory.rs
@@ -6,6 +6,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "memory",
         name: "remember",
+        method_id: 0,
         params: &[
             BuiltinParam {
                 name: "key",
@@ -24,6 +25,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "memory",
         name: "recall",
+        method_id: 1,
         params: &[BuiltinParam {
             name: "key",
             ty: TySpec::Str,
@@ -35,6 +37,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "memory",
         name: "forget",
+        method_id: 2,
         params: &[BuiltinParam {
             name: "key",
             ty: TySpec::Str,

--- a/crates/keel-catalog/src/specs/mod.rs
+++ b/crates/keel-catalog/src/specs/mod.rs
@@ -66,6 +66,52 @@ pub fn catalog_method(namespace: &str, name: &str) -> Option<&'static BuiltinMet
     catalog().find(|m| m.namespace == namespace && m.name == name)
 }
 
+/// Stable id for each of the 23 stdlib namespaces, consumed by `keel-kir`'s
+/// `CallTarget::Ns` lowering and `keel-rt-ffi`'s `keel_rt_call_ns(ns_id,
+/// method_id, ...)` generic dispatch entry point. Assigned once and
+/// append-only: never reassign or reuse an id when a namespace is removed,
+/// so a compiled program's dispatch ids stay meaningful across commits.
+///
+/// Paired with each method's [`BuiltinMethod::method_id`] (unique within the
+/// namespace) this gives every stdlib method a globally unique `(ns_id,
+/// method_id)` pair. The `spec_matches_installed_methods_for_all_namespaces`
+/// test in `keel-runtime` pins both halves.
+pub const NAMESPACE_IDS: &[(&str, u16)] = &[
+    ("ai", 0),
+    ("async", 1),
+    ("cache", 2),
+    ("control", 3),
+    ("crypto", 4),
+    ("csv", 5),
+    ("db", 6),
+    ("email", 7),
+    ("env", 8),
+    ("file", 9),
+    ("http", 10),
+    ("io", 11),
+    ("json", 12),
+    ("log", 13),
+    ("math", 14),
+    ("memory", 15),
+    ("random", 16),
+    ("schedule", 17),
+    ("search", 18),
+    ("shell", 19),
+    ("testing", 20),
+    ("time", 21),
+    ("uuid", 22),
+];
+
+/// Look up the stable [`NAMESPACE_IDS`] id for a namespace by name.
+///
+/// Returns `None` if `namespace` is not a registered stdlib namespace.
+pub fn namespace_id(namespace: &str) -> Option<u16> {
+    NAMESPACE_IDS
+        .iter()
+        .find(|(name, _)| *name == namespace)
+        .map(|(_, id)| *id)
+}
+
 /// Modules whose entry points exercise authority over the world outside the
 /// process — network, filesystem, subprocesses, external services, ambient
 /// secrets, humans, and LLMs. Only these require an `@tools` capability.

--- a/crates/keel-catalog/src/specs/random.rs
+++ b/crates/keel-catalog/src/specs/random.rs
@@ -6,6 +6,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "random",
         name: "float",
+        method_id: 0,
         params: &[],
         result: BuiltinResult::Fixed(TySpec::Float),
         doc: "Return a random float in the range [0, 1).",
@@ -13,6 +14,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "random",
         name: "int",
+        method_id: 1,
         params: &[
             BuiltinParam {
                 name: "min",
@@ -31,6 +33,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "random",
         name: "bool",
+        method_id: 2,
         params: &[],
         result: BuiltinResult::Fixed(TySpec::Bool),
         doc: "Return a random boolean.",

--- a/crates/keel-catalog/src/specs/schedule.rs
+++ b/crates/keel-catalog/src/specs/schedule.rs
@@ -6,6 +6,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "schedule",
         name: "every",
+        method_id: 0,
         params: &[BuiltinParam {
             name: "interval",
             ty: TySpec::Duration,
@@ -17,6 +18,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "schedule",
         name: "after",
+        method_id: 1,
         params: &[BuiltinParam {
             name: "delay",
             ty: TySpec::Duration,
@@ -28,6 +30,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "schedule",
         name: "at",
+        method_id: 2,
         params: &[BuiltinParam {
             name: "time",
             ty: TySpec::Str,
@@ -39,6 +42,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "schedule",
         name: "cron",
+        method_id: 3,
         params: &[BuiltinParam {
             name: "expr",
             ty: TySpec::Str,
@@ -50,6 +54,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "schedule",
         name: "sleep",
+        method_id: 4,
         params: &[BuiltinParam {
             name: "duration",
             ty: TySpec::Duration,

--- a/crates/keel-catalog/src/specs/search.rs
+++ b/crates/keel-catalog/src/specs/search.rs
@@ -6,6 +6,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "search",
         name: "web",
+        method_id: 0,
         params: &[BuiltinParam {
             name: "query",
             ty: TySpec::Str,
@@ -17,6 +18,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "search",
         name: "news",
+        method_id: 1,
         params: &[BuiltinParam {
             name: "query",
             ty: TySpec::Str,

--- a/crates/keel-catalog/src/specs/shell.rs
+++ b/crates/keel-catalog/src/specs/shell.rs
@@ -5,6 +5,7 @@ use crate::builtins::*;
 pub const SPEC: &[BuiltinMethod] = &[BuiltinMethod {
     namespace: "shell",
     name: "run",
+    method_id: 0,
     params: &[BuiltinParam {
         name: "cmd",
         ty: TySpec::Str,

--- a/crates/keel-catalog/src/specs/testing.rs
+++ b/crates/keel-catalog/src/specs/testing.rs
@@ -5,6 +5,7 @@ use crate::builtins::*;
 pub const SPEC: &[BuiltinMethod] = &[BuiltinMethod {
     namespace: "testing",
     name: "mock",
+    method_id: 0,
     params: &[],
     result: BuiltinResult::Fixed(TySpec::Unknown),
     doc: "Create a test-local mock handle for a namespace method.",

--- a/crates/keel-catalog/src/specs/time.rs
+++ b/crates/keel-catalog/src/specs/time.rs
@@ -6,6 +6,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "time",
         name: "now",
+        method_id: 0,
         params: &[],
         result: BuiltinResult::Fixed(TySpec::Datetime),
         doc: "Return the current UTC datetime.",
@@ -13,6 +14,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "time",
         name: "epoch_ms",
+        method_id: 1,
         params: &[],
         result: BuiltinResult::Fixed(TySpec::Int),
         doc: "Return the current Unix timestamp in milliseconds.",
@@ -20,6 +22,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "time",
         name: "parse",
+        method_id: 2,
         params: &[BuiltinParam {
             name: "s",
             ty: TySpec::Str,

--- a/crates/keel-catalog/src/specs/uuid.rs
+++ b/crates/keel-catalog/src/specs/uuid.rs
@@ -6,6 +6,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "uuid",
         name: "v4",
+        method_id: 0,
         params: &[],
         result: BuiltinResult::Fixed(TySpec::Uuid),
         doc: "Generate a random UUID v4.",
@@ -13,6 +14,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "uuid",
         name: "v7",
+        method_id: 1,
         params: &[],
         result: BuiltinResult::Fixed(TySpec::Uuid),
         doc: "Generate a time-sortable UUID v7.",
@@ -20,6 +22,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "uuid",
         name: "v5",
+        method_id: 2,
         params: &[
             BuiltinParam {
                 name: "ns",
@@ -38,6 +41,7 @@ pub const SPEC: &[BuiltinMethod] = &[
     BuiltinMethod {
         namespace: "uuid",
         name: "parse",
+        method_id: 3,
         params: &[BuiltinParam {
             name: "s",
             ty: TySpec::Str,

--- a/crates/keel-runtime/src/runtime/namespaces/mod.rs
+++ b/crates/keel-runtime/src/runtime/namespaces/mod.rs
@@ -116,4 +116,47 @@ mod tests {
             );
         }
     }
+
+    /// Every namespace installed by `namespaces()` must have a stable
+    /// `ns_id` in `keel_catalog::specs::NAMESPACE_IDS`, ids must be unique,
+    /// and there must be no orphaned entries for namespaces that no longer
+    /// exist. Pins the compiled path's `keel_rt_call_ns(ns_id, ..)` dispatch
+    /// table against accidental drift (see designs/llvm-compilation.md §2.7).
+    #[test]
+    fn namespace_ids_are_stable_and_complete() {
+        let installed = namespaces();
+        let installed_ns_names: HashSet<&str> =
+            installed.iter().map(|ns| ns.name.as_str()).collect();
+
+        let mut seen_ids = HashSet::new();
+        let mut ided_ns_names = HashSet::new();
+        for (name, id) in keel_catalog::specs::NAMESPACE_IDS {
+            assert!(
+                seen_ids.insert(*id),
+                "duplicate ns_id {id} (namespace {name:?})"
+            );
+            ided_ns_names.insert(*name);
+        }
+
+        assert_eq!(
+            installed_ns_names, ided_ns_names,
+            "installed namespaces and NAMESPACE_IDS disagree"
+        );
+    }
+
+    /// Every method in the catalog must have a `method_id` unique within its
+    /// namespace, so `(ns_id, method_id)` is a globally unique dispatch key.
+    #[test]
+    fn method_ids_are_unique_within_each_namespace() {
+        let mut seen: HashMap<&str, HashSet<u16>> = HashMap::new();
+        for m in keel_catalog::catalog() {
+            assert!(
+                seen.entry(m.namespace).or_default().insert(m.method_id),
+                "{}: duplicate method_id {} ({})",
+                m.namespace,
+                m.method_id,
+                m.name
+            );
+        }
+    }
 }

--- a/tests/conformance/main.rs
+++ b/tests/conformance/main.rs
@@ -28,12 +28,15 @@
 //! process stdout via `println!` (no injectable writer exists in the
 //! runtime today — out of scope to add here), capturing a single program's
 //! output requires redirecting fd 1 for the duration of that one call; see
-//! [`capture_stdout`]. That's safe here specifically because this whole
-//! corpus runs from **one sequential test function** in **its own test
-//! binary process** (`tests/conformance/main.rs` — Cargo gives every
-//! `tests/*.rs`/`tests/<dir>/main.rs` file its own binary): no other test
-//! shares this process, and nothing here spawns concurrent programs, so
-//! fd 1 is never contended.
+//! [`capture_stdout`]. This binary has two `#[tokio::test]` functions, and
+//! libtest runs them concurrently on separate OS threads by default; both
+//! acquire [`SEQUENTIAL_GUARD`] for their full duration so only one is ever
+//! executing at a time. That's required, not just tidy: libtest itself
+//! writes each test's `test <name> ... ok` status line to real stdout (fd 1)
+//! the moment that test function returns, so without the guard, that print
+//! can land in the middle of the other test's fd-1 redirect window and
+//! corrupt a captured program's output — exactly the kind of "conformance
+//! failure" this harness exists to catch, except spurious.
 //!
 //! Unix-only (`libc::dup`/`dup2`) — deferred for Windows, same as the rest
 //! of the native-backend work this issue is scaffolding for.
@@ -48,6 +51,13 @@ use std::time::Duration;
 
 use corpus::discover_corpus;
 use engine::{Engine, EngineError, EngineOutput};
+use tokio::sync::Mutex;
+
+/// Serializes the two `#[tokio::test]` functions in this binary so libtest's
+/// own per-test status print can never land during the other test's fd-1
+/// redirect window. See the module doc comment. `tokio::sync::Mutex` (not
+/// `std::sync::Mutex`) because the guard must stay held across `.await`.
+static SEQUENTIAL_GUARD: Mutex<()> = Mutex::const_new(());
 
 /// Per-program wall-clock budget. Generous enough for the mock LLM path and
 /// agent handshake overhead, tight enough that a genuinely hung program
@@ -167,6 +177,8 @@ fn skip_reason(stem: &str) -> Option<&'static str> {
 
 #[tokio::test]
 async fn interpreter_is_deterministic_across_the_corpus() {
+    let _guard = SEQUENTIAL_GUARD.lock().await;
+
     // KEEL_LLM=mock keeps `ai.*` deterministic and offline; KEEL_ONESHOT=1
     // makes agent programs exit after one idle window instead of serving
     // forever. Set once, process-wide — safe because this whole corpus runs
@@ -232,13 +244,14 @@ async fn interpreter_is_deterministic_across_the_corpus() {
 /// test independent of which examples happen to be skipped.
 ///
 /// Calls `Engine::run` directly rather than going through `run_one` — that
-/// helper redirects fd 1 and changes the process cwd, which is only safe
-/// with exactly one sequential caller in this process (see the module doc
-/// comment); `Engine::Compiled` doesn't touch either, so it can run
-/// concurrently with `interpreter_is_deterministic_across_the_corpus`
-/// (libtest's default) without contending on process-global state.
+/// helper redirects fd 1 and changes the process cwd, which `Engine::Compiled`
+/// doesn't need. Still takes [`SEQUENTIAL_GUARD`] itself: this test's own
+/// completion print from libtest must not land inside the other test's fd-1
+/// redirect window either (see the module doc comment).
 #[tokio::test]
 async fn compiled_engine_reports_not_implemented() {
+    let _guard = SEQUENTIAL_GUARD.lock().await;
+
     let fixtures = corpus::fixtures_dir();
     let path = fixtures.join("agent_lifecycle.keel");
     let err = Engine::Compiled


### PR DESCRIPTION
## Summary
- Adds a `method_id: u16` field to `BuiltinMethod`, assigned per method across all 23 stdlib namespace spec files.
- Adds `NAMESPACE_IDS`/`namespace_id()` in `keel-catalog::specs` — a stable id per namespace.
- Extends the catalog<->namespaces cross-check test in `keel-runtime` with two new tests pinning id uniqueness and completeness.

No interpreter behavior change — additive metadata only, consumed by the upcoming `keel-kir`/`keel-rt-ffi` compiled-path work (#130, #135).

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p keel-catalog -p keel-runtime` (429 passed, including the 2 new pinning tests)

Close #129