### PR TITLE
keel-kir: lower for-over-ranges to an indexed loop

### DIFF
--- a/crates/keel-kir/src/dump.rs
+++ b/crates/keel-kir/src/dump.rs
@@ -101,6 +101,24 @@ fn dump_stmt(
             indent(out, depth);
             out.push_str("}\n");
         }
+        Stmt::ForIndex {
+            var,
+            low,
+            high,
+            body,
+        } => {
+            let v = &func.locals[*var];
+            let _ = writeln!(
+                out,
+                "for {} in {}..{} {{",
+                v.name,
+                fmt_expr(program, func, low),
+                fmt_expr(program, func, high)
+            );
+            dump_block(out, program, func, body, depth + 1);
+            indent(out, depth);
+            out.push_str("}\n");
+        }
         Stmt::Return(None) => {
             out.push_str("return\n");
         }

--- a/crates/keel-kir/src/ir.rs
+++ b/crates/keel-kir/src/ir.rs
@@ -94,6 +94,21 @@ pub enum Stmt {
         cond: Expr,
         body: Block,
     },
+    /// `for x in a..b { ... }` lowered to an indexed loop — the only `for`
+    /// shape M1 lowers (see `designs/llvm-compilation.md` §2.3, §4 M1).
+    /// `var` is a fresh `LocalId` of type `I64`, redeclared (per Keel's
+    /// always-declares assignment scoping) and rebound each iteration;
+    /// `low`/`high` are evaluated once, before the loop starts, in the
+    /// enclosing scope (they cannot see `var`). Both bounds are inclusive,
+    /// matching the interpreter's `Value::Range(lo, hi)` (`lo..=hi`).
+    /// Non-range iterables (lists, etc.) are out of scope until the
+    /// container ABI lands (M2).
+    ForIndex {
+        var: LocalId,
+        low: Expr,
+        high: Expr,
+        body: Block,
+    },
     /// `return expr` / bare `return`.
     Return(Option<Expr>),
     /// Expression evaluated for its side effect (e.g. a bare call).

--- a/crates/keel-kir/src/lower/stmt.rs
+++ b/crates/keel-kir/src/lower/stmt.rs
@@ -1,7 +1,9 @@
-//! Statement lowering — the M0 scalar subset: `let`/assign, `if`/`else`,
-//! `while`, `return`, and bare expression statements. Everything else
-//! (`for`, `when`, `try`/`catch`, `raise`, `assert`, `break`/`continue`,
-//! `self.field = ...`) is rejected; see module docs on `lower/mod.rs`.
+//! Statement lowering — the M0 scalar subset plus M1's `for`-over-ranges:
+//! `let`/assign, `if`/`else`, `while`, `for x in a..b`, `return`, and bare
+//! expression statements. Everything else (`when`, `try`/`catch`, `raise`,
+//! `assert`, `break`/`continue`, `self.field = ...`, `for` with a `where`
+//! filter or a non-range iterable) is rejected; see module docs on
+//! `lower/mod.rs`.
 
 use std::collections::HashMap;
 
@@ -157,7 +159,52 @@ pub(crate) fn lower_stmt(
             "self.field assignment",
             stmt.span.clone(),
         )),
-        ast::Stmt::For { .. } => Err(LowerError::unsupported("for loop", stmt.span.clone())),
+        ast::Stmt::For {
+            binding,
+            iter,
+            filter,
+            body,
+        } => {
+            if filter.is_some() {
+                return Err(LowerError::unsupported(
+                    "`for ... where` filter",
+                    stmt.span.clone(),
+                ));
+            }
+            let name = binding_ident(binding, &stmt.span)?;
+            let ast::Expr::Range(start, end) = &iter.kind else {
+                return Err(LowerError::unsupported(
+                    "`for` over a non-range iterable (container ABI lands in M2)",
+                    iter.span.clone(),
+                ));
+            };
+            // Bounds are evaluated once, before `var` exists, so they lower
+            // in the enclosing scope and cannot reference the loop variable.
+            let low = lower_expr(start, ctx, funcs, table)?;
+            if low.ty() != KirType::I64 {
+                return Err(LowerError::new(
+                    format!("`for` range start is `{}`, expected `int`", low.ty()),
+                    start.span.clone(),
+                ));
+            }
+            let high = lower_expr(end, ctx, funcs, table)?;
+            if high.ty() != KirType::I64 {
+                return Err(LowerError::new(
+                    format!("`for` range end is `{}`, expected `int`", high.ty()),
+                    end.span.clone(),
+                ));
+            }
+            ctx.push_scope();
+            let var = ctx.declare(name, KirType::I64);
+            let body = lower_block(body, ctx, funcs, table, ret_ty)?;
+            ctx.pop_scope();
+            Ok(ir::Stmt::ForIndex {
+                var,
+                low,
+                high,
+                body,
+            })
+        }
         ast::Stmt::When { .. } => Err(LowerError::unsupported("when statement", stmt.span.clone())),
         ast::Stmt::TryCatch { .. } => Err(LowerError::unsupported("try/catch", stmt.span.clone())),
         ast::Stmt::Raise(_) => Err(LowerError::unsupported("raise", stmt.span.clone())),

--- a/crates/keel-kir/src/passes/verify.rs
+++ b/crates/keel-kir/src/passes/verify.rs
@@ -154,6 +154,30 @@ fn verify_stmt(program: &KirProgram, func: &KirFunction, stmt: &Stmt) -> Result<
             }
             verify_block(program, func, body)
         }
+        Stmt::ForIndex {
+            var,
+            low,
+            high,
+            body,
+        } => {
+            check_local(func, *var)?;
+            verify_expr(program, func, low)?;
+            verify_expr(program, func, high)?;
+            let var_ty = func.locals[*var].ty;
+            if var_ty != KirType::I64 {
+                return Err(format!("for-loop variable {var} is {var_ty}, expected int"));
+            }
+            if low.ty() != KirType::I64 {
+                return Err(format!(
+                    "for-loop range start is {}, expected int",
+                    low.ty()
+                ));
+            }
+            if high.ty() != KirType::I64 {
+                return Err(format!("for-loop range end is {}, expected int", high.ty()));
+            }
+            verify_block(program, func, body)
+        }
         Stmt::Return(None) => {
             if func.ret != KirType::Unit {
                 return Err(format!(

--- a/crates/keel-kir/tests/fixtures/for_range.keel
+++ b/crates/keel-kir/tests/fixtures/for_range.keel
@@ -1,0 +1,7 @@
+task sum_upto(n: int) -> int {
+  total = 0
+  for i in 0..n {
+    total += i
+  }
+  return total
+}

--- a/crates/keel-kir/tests/fixtures/for_range.kir
+++ b/crates/keel-kir/tests/fixtures/for_range.kir
@@ -1,0 +1,10 @@
+fn sum_upto(n: int) -> int {
+  let total: int = 0
+  for i in 0..n {
+    total = (total + i)
+  }
+  return total
+}
+
+fn <toplevel>() -> none {
+}

--- a/crates/keel-kir/tests/lower_errors.rs
+++ b/crates/keel-kir/tests/lower_errors.rs
@@ -10,7 +10,10 @@ fn lower_err(source: &str) -> String {
 }
 
 #[test]
-fn for_loop_is_rejected() {
+fn for_over_list_param_is_rejected_at_signature() {
+    // `for` over a range lowers now (see golden fixture `for_range.kir`);
+    // this pins that a `list[int]` param is still rejected — at the
+    // signature, before the for-loop body is ever reached.
     let msg = lower_err(
         r#"
 task sum(xs: list[int]) -> int {
@@ -23,6 +26,51 @@ task sum(xs: list[int]) -> int {
 "#,
     );
     assert!(msg.contains("list type"), "unexpected message: {msg}");
+}
+
+#[test]
+fn for_over_non_range_iterable_is_rejected() {
+    let msg = lower_err(
+        r#"
+task f(n: int) -> int {
+  for x in n {
+  }
+  return 0
+}
+"#,
+    );
+    assert!(
+        msg.contains("non-range iterable"),
+        "unexpected message: {msg}"
+    );
+}
+
+#[test]
+fn for_with_where_filter_is_rejected() {
+    let msg = lower_err(
+        r#"
+task f() -> int {
+  for x in 0..5 if x > 2 {
+  }
+  return 0
+}
+"#,
+    );
+    assert!(msg.contains("filter"), "unexpected message: {msg}");
+}
+
+#[test]
+fn for_range_bound_type_mismatch_is_rejected() {
+    let msg = lower_err(
+        r#"
+task f() -> int {
+  for x in 0..1.5 {
+  }
+  return 0
+}
+"#,
+    );
+    assert!(msg.contains("expected `int`"), "unexpected message: {msg}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Adds `Stmt::ForIndex` to KIR: `for x in a..b { ... }` lowers to an indexed loop with bounds evaluated once (inclusive, matching the interpreter's `Value::Range` semantics).
- Rejects non-range iterables, `where`/`if` filters, and non-`int` bounds with clear errors (container iteration is M2 scope).
- Extends the textual dump and `passes/verify.rs` (both exhaustively matched, so the compiler forced every call site).
- New golden fixture (`for_range.keel`/`.kir`) and 4 new `lower_errors.rs` regression tests.

Verified end-to-end via `keel build --emit=kir` on `for i in 0..n { ... }`, matching #131's exit criterion.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (all green)
- [x] Manual `keel build --emit=kir` smoke test

Close #131