### PR TITLE
keel-codegen: new crate — walking skeleton (KIR to native binary)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,12 @@ jobs:
       - name: Check formatting
         run: cargo fmt --check
 
+      # No --all-features here: `build-backend` (keel-codegen, LLVM) is
+      # exercised by its own job below so this job — and every ordinary
+      # contributor's `keel run`/`check`/`lsp` workflow — never needs LLVM
+      # installed (designs/llvm-compilation.md §2.2, §5 risks).
       - name: Run Clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo clippy --all-targets -- -D warnings
 
       - name: Check documentation
         run: cargo doc --no-deps --document-private-items
@@ -61,3 +65,47 @@ jobs:
 
       - name: Run tests
         run: cargo test
+
+  # Exercises the `build-backend` feature (keel-codegen, LLVM/inkwell) in
+  # isolation so the LLVM toolchain install never touches the `check` job
+  # above — see designs/llvm-compilation.md §2.2 and §5 risks, and the
+  # verified install recipe in designs/llvm-toolchain-spike.md.
+  build-backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+
+      # LLVM 22 via apt.llvm.org's official install script — the same
+      # recipe proved working (object emission + link + run) for both
+      # platforms in designs/llvm-toolchain-spike.md. `llvm.sh` alone is not
+      # sufficient: llvm-sys statically links Polly, which needs the
+      # separate libpolly-*-dev package.
+      - name: Install LLVM 22
+        run: |
+          curl -fsSL https://apt.llvm.org/llvm.sh -o /tmp/llvm.sh
+          chmod +x /tmp/llvm.sh
+          sudo /tmp/llvm.sh 22
+          sudo apt-get install -y libpolly-22-dev zlib1g-dev libzstd-dev
+
+      - name: Build workspace with build-backend
+        env:
+          LLVM_SYS_221_PREFIX: /usr/lib/llvm-22
+        run: cargo build --workspace --features build-backend
+
+      - name: Run Clippy (build-backend)
+        env:
+          LLVM_SYS_221_PREFIX: /usr/lib/llvm-22
+        run: cargo clippy --workspace --all-targets --features build-backend -- -D warnings
+
+      - name: Run tests (build-backend)
+        env:
+          LLVM_SYS_221_PREFIX: /usr/lib/llvm-22
+        run: cargo test --workspace --features build-backend

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
 name = "ar_archive_writer"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1300,6 +1306,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "inkwell"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7decbc9dfa45a4a827a6ff7b822c113b1285678a937e84213417d4ca8a095782"
+dependencies = [
+ "bitflags 2.13.1",
+ "inkwell_internals",
+ "libc",
+ "llvm-sys",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "inkwell_internals"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cfe97ee860815a90ed17e09639513269e39420a7440f3f4c996f238c514cf8d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1398,6 +1428,16 @@ name = "keel-catalog"
 version = "0.2.4"
 
 [[package]]
+name = "keel-codegen"
+version = "0.2.4"
+dependencies = [
+ "inkwell",
+ "keel-kir",
+ "keel-syntax",
+ "tempfile",
+]
+
+[[package]]
 name = "keel-compiler"
 version = "0.2.4"
 dependencies = [
@@ -1439,6 +1479,7 @@ dependencies = [
  "csv",
  "glob",
  "keel-catalog",
+ "keel-codegen",
  "keel-compiler",
  "keel-dap",
  "keel-kir",
@@ -1500,6 +1541,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "lettre"
 version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1554,6 +1601,20 @@ name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "llvm-sys"
+version = "221.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2abcc34a3b190f03c2a61b555f218f529589ff13657bdd2ff8ac3e85f2abe6bb"
+dependencies = [
+ "anyhow",
+ "cc",
+ "lazy_static",
+ "libc",
+ "regex-lite",
+ "semver",
+]
 
 [[package]]
 name = "lock_api"
@@ -2104,6 +2165,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,14 @@ exclude = ["target/", "docs/", ".claude/"]
 name = "keel"
 path = "src/main.rs"
 
+[features]
+# `keel-codegen` links LLVM (inkwell); everything else in the workspace stays
+# LLVM-free. See crates/keel-codegen/README.md for the toolchain requirement.
+build-backend = ["dep:keel-codegen"]
+
 [dependencies]
 keel-catalog = { path = "crates/keel-catalog" }
+keel-codegen = { path = "crates/keel-codegen", optional = true }
 keel-compiler = { path = "crates/keel-compiler" }
 keel-dap = { path = "crates/keel-dap" }
 keel-kir = { path = "crates/keel-kir" }

--- a/crates/keel-codegen/Cargo.toml
+++ b/crates/keel-codegen/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "keel-codegen"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "KIR -> LLVM IR -> native object/binary codegen for `keel build` (designs/llvm-compilation.md). Requires a system LLVM install — see README.md."
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+keel-kir = { path = "../keel-kir" }
+inkwell = { version = "0.9.0", features = ["llvm22-1"] }
+
+[dev-dependencies]
+keel-syntax = { path = "../keel-syntax" }
+tempfile = { workspace = true }

--- a/crates/keel-codegen/README.md
+++ b/crates/keel-codegen/README.md
@@ -1,0 +1,31 @@
+# keel-codegen
+
+`KirType`/KIR → LLVM IR → native object → linked binary, via [`inkwell`](https://docs.rs/inkwell).
+The only crate in the workspace that links LLVM (`designs/llvm-compilation.md` §2.2)
+— `keel run`/`check`/`lsp` never need it, since the root crate only depends on
+this one behind the `build-backend` cargo feature.
+
+## Toolchain requirement
+
+Building (or testing) this crate — or the root crate with `--features
+build-backend` — requires a system LLVM 22 install, found via `llvm-sys`'s
+`LLVM_SYS_221_PREFIX` environment variable. Full install steps and the
+verified proof-of-concept for both macOS and Linux live in
+[`designs/llvm-toolchain-spike.md`](../../designs/llvm-toolchain-spike.md);
+short version:
+
+```sh
+# macOS
+brew install llvm@22
+export LLVM_SYS_221_PREFIX=/opt/homebrew/opt/llvm@22
+
+# Linux (Ubuntu)
+curl -fsSL https://apt.llvm.org/llvm.sh -o /tmp/llvm.sh && chmod +x /tmp/llvm.sh
+sudo /tmp/llvm.sh 22
+sudo apt-get install -y libpolly-22-dev zlib1g-dev libzstd-dev
+export LLVM_SYS_221_PREFIX=/usr/lib/llvm-22
+```
+
+Without `LLVM_SYS_221_PREFIX` set (and no `llvm-config`/`llvm-config-22` on
+`PATH`), `cargo build -p keel-codegen` fails at the `llvm-sys` build script
+with an actionable error naming the missing prefix.

--- a/crates/keel-codegen/src/context.rs
+++ b/crates/keel-codegen/src/context.rs
@@ -1,0 +1,44 @@
+//! Host `TargetMachine` creation. `inkwell::context::Context`/`Module`/
+//! `Builder` construction itself is trivial enough (three constructor calls)
+//! that `lib.rs::compile` does it inline; this module holds the one part
+//! with real failure modes — talking to LLVM's target registry.
+
+use inkwell::OptimizationLevel;
+use inkwell::targets::{CodeModel, InitializationConfig, RelocMode, Target, TargetMachine};
+
+use crate::CodegenError;
+
+/// Creates a `TargetMachine` for the host triple, initializing the native
+/// LLVM target backend first. No cross-compilation / `--target` support yet
+/// (M1 scope) — always the machine this process is running on.
+pub(crate) fn host_target_machine() -> Result<TargetMachine, CodegenError> {
+    Target::initialize_native(&InitializationConfig::default()).map_err(CodegenError::Target)?;
+
+    let triple = TargetMachine::get_default_triple();
+    let target = Target::from_triple(&triple).map_err(|e| CodegenError::Target(e.to_string()))?;
+
+    let cpu = TargetMachine::get_host_cpu_name();
+    let features = TargetMachine::get_host_cpu_features();
+    let cpu = cpu
+        .to_str()
+        .map_err(|e| CodegenError::Target(e.to_string()))?;
+    let features = features
+        .to_str()
+        .map_err(|e| CodegenError::Target(e.to_string()))?;
+
+    target
+        .create_target_machine(
+            &triple,
+            cpu,
+            features,
+            OptimizationLevel::Default,
+            RelocMode::PIC,
+            CodeModel::Default,
+        )
+        .ok_or_else(|| {
+            CodegenError::Target(format!(
+                "failed to create a TargetMachine for host triple {}",
+                triple.as_str().to_string_lossy()
+            ))
+        })
+}

--- a/crates/keel-codegen/src/expr.rs
+++ b/crates/keel-codegen/src/expr.rs
@@ -1,0 +1,210 @@
+//! Expression codegen — M1 walking-skeleton scope: literals, locals,
+//! arithmetic/comparison/logical binary ops, unary `-`/`not`. `str` and
+//! calls are rejected (see `layout.rs` and issues #133/#135).
+
+use inkwell::values::BasicValueEnum;
+use inkwell::{FloatPredicate, IntPredicate};
+
+use keel_kir::ir::{BinOp, Expr, UnOp};
+use keel_kir::types::KirType;
+
+use crate::CodegenError;
+use crate::func::FuncCtx;
+use crate::layout;
+
+fn llvm_err(e: impl std::fmt::Display) -> CodegenError {
+    CodegenError::Llvm(e.to_string())
+}
+
+/// A KIR invariant this crate relies on was violated — `keel_kir::passes::
+/// verify` already checks the shapes codegen assumes, so reaching one of
+/// these means a codegen bug, not a bad program.
+fn unreachable_combo(op: impl std::fmt::Debug, ty: KirType) -> CodegenError {
+    CodegenError::Llvm(format!(
+        "{op:?} on {ty} operand(s) should be unreachable — keel-kir's type inference rejects it"
+    ))
+}
+
+pub(crate) fn emit_expr<'ctx>(
+    fcx: &FuncCtx<'ctx, '_>,
+    expr: &Expr,
+) -> Result<BasicValueEnum<'ctx>, CodegenError> {
+    match expr {
+        Expr::ConstInt(v) => Ok(fcx.context.i64_type().const_int(*v as u64, true).into()),
+        Expr::ConstFloat(v) => Ok(fcx.context.f64_type().const_float(*v).into()),
+        Expr::ConstBool(v) => Ok(fcx
+            .context
+            .bool_type()
+            .const_int(u64::from(*v), false)
+            .into()),
+        Expr::ConstStr(_) => Err(CodegenError::Unsupported(
+            "str literal (issue #135)".to_string(),
+        )),
+        Expr::Local { id, .. } => {
+            let ptr = *fcx
+                .locals
+                .get(id)
+                .expect("verified KIR: local declared before use (passes::verify)");
+            let ty = layout::llvm_type(fcx.context, expr.ty())?;
+            fcx.builder.build_load(ty, ptr, "load").map_err(llvm_err)
+        }
+        Expr::BinOp {
+            op, left, right, ..
+        } => emit_binop(fcx, *op, left, right),
+        Expr::UnOp { op, operand, .. } => emit_unop(fcx, *op, operand),
+        Expr::Call { .. } => Err(CodegenError::Unsupported(
+            "function calls (issue #133)".to_string(),
+        )),
+    }
+}
+
+fn emit_binop<'ctx>(
+    fcx: &FuncCtx<'ctx, '_>,
+    op: BinOp,
+    left: &Expr,
+    right: &Expr,
+) -> Result<BasicValueEnum<'ctx>, CodegenError> {
+    // Both operands share a type by construction (`infer_binop_ty`), so the
+    // left operand's KIR type picks which LLVM instructions to emit.
+    let operand_ty = left.ty();
+    let lv = emit_expr(fcx, left)?;
+    let rv = emit_expr(fcx, right)?;
+    let b = fcx.builder;
+
+    match operand_ty {
+        KirType::I64 => {
+            let l = lv.into_int_value();
+            let r = rv.into_int_value();
+            let result: BasicValueEnum = match op {
+                BinOp::Add => b.build_int_add(l, r, "add").map_err(llvm_err)?.into(),
+                BinOp::Sub => b.build_int_sub(l, r, "sub").map_err(llvm_err)?.into(),
+                BinOp::Mul => b.build_int_mul(l, r, "mul").map_err(llvm_err)?.into(),
+                BinOp::Div => b
+                    .build_int_signed_div(l, r, "sdiv")
+                    .map_err(llvm_err)?
+                    .into(),
+                BinOp::Mod => b
+                    .build_int_signed_rem(l, r, "srem")
+                    .map_err(llvm_err)?
+                    .into(),
+                BinOp::Eq => b
+                    .build_int_compare(IntPredicate::EQ, l, r, "eq")
+                    .map_err(llvm_err)?
+                    .into(),
+                BinOp::Neq => b
+                    .build_int_compare(IntPredicate::NE, l, r, "ne")
+                    .map_err(llvm_err)?
+                    .into(),
+                BinOp::Lt => b
+                    .build_int_compare(IntPredicate::SLT, l, r, "lt")
+                    .map_err(llvm_err)?
+                    .into(),
+                BinOp::Gt => b
+                    .build_int_compare(IntPredicate::SGT, l, r, "gt")
+                    .map_err(llvm_err)?
+                    .into(),
+                BinOp::Lte => b
+                    .build_int_compare(IntPredicate::SLE, l, r, "le")
+                    .map_err(llvm_err)?
+                    .into(),
+                BinOp::Gte => b
+                    .build_int_compare(IntPredicate::SGE, l, r, "ge")
+                    .map_err(llvm_err)?
+                    .into(),
+                BinOp::And | BinOp::Or => return Err(unreachable_combo(op, operand_ty)),
+            };
+            Ok(result)
+        }
+        KirType::F64 => {
+            let l = lv.into_float_value();
+            let r = rv.into_float_value();
+            let result: BasicValueEnum = match op {
+                BinOp::Add => b.build_float_add(l, r, "fadd").map_err(llvm_err)?.into(),
+                BinOp::Sub => b.build_float_sub(l, r, "fsub").map_err(llvm_err)?.into(),
+                BinOp::Mul => b.build_float_mul(l, r, "fmul").map_err(llvm_err)?.into(),
+                BinOp::Div => b.build_float_div(l, r, "fdiv").map_err(llvm_err)?.into(),
+                BinOp::Mod => {
+                    return Err(CodegenError::Unsupported(
+                        "float `%` codegen (not exercised by M1's scalar-arithmetic fixtures yet)"
+                            .to_string(),
+                    ));
+                }
+                BinOp::Eq => b
+                    .build_float_compare(FloatPredicate::OEQ, l, r, "feq")
+                    .map_err(llvm_err)?
+                    .into(),
+                BinOp::Neq => b
+                    .build_float_compare(FloatPredicate::ONE, l, r, "fne")
+                    .map_err(llvm_err)?
+                    .into(),
+                BinOp::Lt => b
+                    .build_float_compare(FloatPredicate::OLT, l, r, "flt")
+                    .map_err(llvm_err)?
+                    .into(),
+                BinOp::Gt => b
+                    .build_float_compare(FloatPredicate::OGT, l, r, "fgt")
+                    .map_err(llvm_err)?
+                    .into(),
+                BinOp::Lte => b
+                    .build_float_compare(FloatPredicate::OLE, l, r, "fle")
+                    .map_err(llvm_err)?
+                    .into(),
+                BinOp::Gte => b
+                    .build_float_compare(FloatPredicate::OGE, l, r, "fge")
+                    .map_err(llvm_err)?
+                    .into(),
+                BinOp::And | BinOp::Or => return Err(unreachable_combo(op, operand_ty)),
+            };
+            Ok(result)
+        }
+        KirType::Bool => {
+            let l = lv.into_int_value();
+            let r = rv.into_int_value();
+            let result: BasicValueEnum = match op {
+                BinOp::Eq => b
+                    .build_int_compare(IntPredicate::EQ, l, r, "beq")
+                    .map_err(llvm_err)?
+                    .into(),
+                BinOp::Neq => b
+                    .build_int_compare(IntPredicate::NE, l, r, "bne")
+                    .map_err(llvm_err)?
+                    .into(),
+                BinOp::And => b.build_and(l, r, "and").map_err(llvm_err)?.into(),
+                BinOp::Or => b.build_or(l, r, "or").map_err(llvm_err)?.into(),
+                _ => return Err(unreachable_combo(op, operand_ty)),
+            };
+            Ok(result)
+        }
+        KirType::Str => Err(CodegenError::Unsupported(
+            "str concatenation/comparison (issue #135)".to_string(),
+        )),
+        KirType::Unit => Err(unreachable_combo(op, operand_ty)),
+    }
+}
+
+fn emit_unop<'ctx>(
+    fcx: &FuncCtx<'ctx, '_>,
+    op: UnOp,
+    operand: &Expr,
+) -> Result<BasicValueEnum<'ctx>, CodegenError> {
+    let operand_ty = operand.ty();
+    let v = emit_expr(fcx, operand)?;
+    match (op, operand_ty) {
+        (UnOp::Neg, KirType::I64) => Ok(fcx
+            .builder
+            .build_int_neg(v.into_int_value(), "neg")
+            .map_err(llvm_err)?
+            .into()),
+        (UnOp::Neg, KirType::F64) => Ok(fcx
+            .builder
+            .build_float_neg(v.into_float_value(), "fneg")
+            .map_err(llvm_err)?
+            .into()),
+        (UnOp::Not, KirType::Bool) => Ok(fcx
+            .builder
+            .build_not(v.into_int_value(), "not")
+            .map_err(llvm_err)?
+            .into()),
+        _ => Err(unreachable_combo(op, operand_ty)),
+    }
+}

--- a/crates/keel-codegen/src/func.rs
+++ b/crates/keel-codegen/src/func.rs
@@ -1,0 +1,75 @@
+//! Emits the M1 walking-skeleton `main`: runs the program's `toplevel` KIR
+//! function's statements directly inside `main`'s body (no separate LLVM
+//! function for it yet — that starts once `keel_rt_start` needs something to
+//! call it, see issue #134) and computes a process exit code from it.
+//!
+//! # The M1 entry/exit convention (temporary, replaced by #134)
+//!
+//! Real top-level Keel statements always lower to a `Unit`-returning
+//! `toplevel` KIR function (`keel-kir` forces this — top-level `return
+//! <value>` is a type error), so there is no way for real source to make
+//! `main` exit with a *computed* value yet: there's no `keel_rt_start`/
+//! `io.*`/process-exit surface wired up. So, for this issue's "prove object
+//! emission + linking" exit criterion only: if the toplevel function's last
+//! statement is a bare `int` expression (e.g. a file whose only content is
+//! `2 + 2 * 10`), its value becomes the process exit code (truncated to
+//! `i32`, mirroring how returning a value from a hosted C `main` becomes its
+//! exit status); otherwise `main` exits `0`. This has nothing to do with
+//! Keel's `return` statement, and this whole function is replaced wholesale
+//! once #134 wires `main` to call `keel_rt_start` instead.
+
+use std::collections::HashMap;
+
+use inkwell::builder::Builder;
+use inkwell::context::Context;
+use inkwell::module::Module;
+use inkwell::values::{BasicValueEnum, PointerValue};
+
+use keel_kir::ir::{KirProgram, LocalId};
+use keel_kir::types::KirType;
+
+use crate::CodegenError;
+use crate::stmt;
+
+/// Per-function codegen state: where each KIR local's `alloca` lives.
+/// M1 only ever compiles one function (see the module doc), so this never
+/// needs a call stack of these — `func.rs` in later issues will change that.
+pub(crate) struct FuncCtx<'ctx, 'a> {
+    pub(crate) context: &'ctx Context,
+    pub(crate) builder: &'a Builder<'ctx>,
+    pub(crate) locals: HashMap<LocalId, PointerValue<'ctx>>,
+}
+
+fn llvm_err(e: impl std::fmt::Display) -> CodegenError {
+    CodegenError::Llvm(e.to_string())
+}
+
+pub(crate) fn emit_main<'ctx>(
+    context: &'ctx Context,
+    module: &Module<'ctx>,
+    builder: &Builder<'ctx>,
+    program: &KirProgram,
+) -> Result<(), CodegenError> {
+    let i32_type = context.i32_type();
+    let main_type = i32_type.fn_type(&[], false);
+    let main_fn = module.add_function("main", main_type, None);
+    let entry = context.append_basic_block(main_fn, "entry");
+    builder.position_at_end(entry);
+
+    let toplevel = &program.functions[program.toplevel];
+    let mut fcx = FuncCtx {
+        context,
+        builder,
+        locals: HashMap::new(),
+    };
+    let last = stmt::emit_block(&mut fcx, &toplevel.body)?;
+
+    let exit_code = match last {
+        Some((BasicValueEnum::IntValue(v), KirType::I64)) => builder
+            .build_int_truncate(v, i32_type, "exit_code")
+            .map_err(llvm_err)?,
+        _ => i32_type.const_zero(),
+    };
+    builder.build_return(Some(&exit_code)).map_err(llvm_err)?;
+    Ok(())
+}

--- a/crates/keel-codegen/src/layout.rs
+++ b/crates/keel-codegen/src/layout.rs
@@ -1,0 +1,29 @@
+//! `KirType` -> LLVM type. M1 walking-skeleton scope: `I64`/`F64`/`Bool`
+//! only, per `designs/llvm-compilation.md` §1.1's lowering table — `Str`
+//! (needs the `KeelStr` runtime ABI) and `Unit` (has no LLVM *value*
+//! representation; call sites branch on it directly, see `func.rs`) are not
+//! representable as a [`BasicTypeEnum`] and are rejected here.
+
+use inkwell::context::Context;
+use inkwell::types::BasicTypeEnum;
+
+use keel_kir::types::KirType;
+
+use crate::CodegenError;
+
+pub(crate) fn llvm_type<'ctx>(
+    context: &'ctx Context,
+    ty: KirType,
+) -> Result<BasicTypeEnum<'ctx>, CodegenError> {
+    match ty {
+        KirType::I64 => Ok(context.i64_type().into()),
+        KirType::F64 => Ok(context.f64_type().into()),
+        KirType::Bool => Ok(context.bool_type().into()),
+        KirType::Unit => Err(CodegenError::Unsupported(
+            "none (Unit) has no LLVM value representation".to_string(),
+        )),
+        KirType::Str => Err(CodegenError::Unsupported(
+            "str (needs the KeelStr runtime ABI, issue #135)".to_string(),
+        )),
+    }
+}

--- a/crates/keel-codegen/src/lib.rs
+++ b/crates/keel-codegen/src/lib.rs
@@ -1,0 +1,110 @@
+//! `keel-codegen` — KIR -> LLVM IR -> native object -> linked binary
+//! (`designs/llvm-compilation.md` §2.2). The only crate in the workspace
+//! that links LLVM; gated behind the root crate's `build-backend` feature.
+//!
+//! # M1 walking-skeleton scope
+//!
+//! This is the narrowest vertical slice that proves the codegen/link/run
+//! loop end to end: scalar arithmetic on `int`/`float`/`bool` only, a single
+//! compiled function (no cross-function `Call`, no `if`/`while`/`for` — see
+//! `designs/llvm-compilation.md` §4 M1 and issue #133), no runtime, no I/O.
+//! `compile` emits a bare C-style `main` that runs the program's `toplevel`
+//! KIR function and exits with a computed value — see the module doc on
+//! [`func`] for exactly how, and why that's a temporary M1-only convention
+//! superseded once `keel_rt_start` lands (issue #134).
+//!
+//! Entry point: [`compile`].
+
+mod context;
+mod expr;
+mod func;
+mod layout;
+mod link;
+mod stmt;
+
+use std::path::PathBuf;
+
+use inkwell::context::Context;
+use keel_kir::ir::KirProgram;
+
+/// Where to write the intermediate object file and the linked binary.
+#[derive(Debug, Clone)]
+pub struct BuildOptions {
+    pub out_dir: PathBuf,
+}
+
+/// Everything that can go wrong turning a [`KirProgram`] into a running
+/// native binary.
+#[derive(Debug)]
+pub enum CodegenError {
+    /// A KIR construct this milestone's codegen does not lower yet (e.g.
+    /// `str`, cross-function calls, control flow — see the relevant later
+    /// issue).
+    Unsupported(String),
+    /// The native LLVM target backend could not be initialized, or no
+    /// `TargetMachine` could be created for the host triple — almost always
+    /// a broken/missing local LLVM install (see this crate's README).
+    Target(String),
+    /// An `inkwell` builder call failed, or the LLVM module verifier
+    /// rejected the emitted IR — an internal codegen bug, not a KIR/user
+    /// error (the KIR that reached this crate already passed
+    /// `keel_kir::passes::verify`).
+    Llvm(String),
+    /// Emitting the native object file failed.
+    ObjectEmission(String),
+    /// The system `cc` link step failed to spawn or exited non-zero.
+    Link(String),
+    Io(std::io::Error),
+}
+
+impl std::fmt::Display for CodegenError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CodegenError::Unsupported(what) => {
+                write!(f, "`{what}` is not supported by keel-codegen yet")
+            }
+            CodegenError::Target(msg) => write!(f, "LLVM target error: {msg}"),
+            CodegenError::Llvm(msg) => write!(f, "LLVM codegen error: {msg}"),
+            CodegenError::ObjectEmission(msg) => write!(f, "object emission failed: {msg}"),
+            CodegenError::Link(msg) => write!(f, "link step failed: {msg}"),
+            CodegenError::Io(e) => write!(f, "I/O error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for CodegenError {}
+
+impl From<std::io::Error> for CodegenError {
+    fn from(e: std::io::Error) -> Self {
+        CodegenError::Io(e)
+    }
+}
+
+/// Compiles `program` to a native binary under `opts.out_dir`, returning the
+/// binary's path.
+///
+/// # Errors
+///
+/// See [`CodegenError`].
+pub fn compile(program: &KirProgram, opts: &BuildOptions) -> Result<PathBuf, CodegenError> {
+    std::fs::create_dir_all(&opts.out_dir)?;
+
+    let llvm_context = Context::create();
+    let module = llvm_context.create_module("keel_program");
+    let builder = llvm_context.create_builder();
+
+    func::emit_main(&llvm_context, &module, &builder, program)?;
+
+    module
+        .verify()
+        .map_err(|e| CodegenError::Llvm(e.to_string()))?;
+
+    let machine = context::host_target_machine()?;
+
+    let obj_path = opts.out_dir.join("keel_program.o");
+    let bin_path = opts.out_dir.join("keel_program");
+    link::emit_object(&machine, &module, &obj_path)?;
+    link::link_binary(&obj_path, &bin_path)?;
+
+    Ok(bin_path)
+}

--- a/crates/keel-codegen/src/link.rs
+++ b/crates/keel-codegen/src/link.rs
@@ -1,0 +1,41 @@
+//! Object emission + link — the loop proven in `spikes/llvm-poc`
+//! (`designs/llvm-toolchain-spike.md`), made `Result`-returning instead of
+//! `expect`-panicking now that it's production code, not a throwaway spike.
+
+use std::path::Path;
+use std::process::Command;
+
+use inkwell::module::Module;
+use inkwell::targets::{FileType, TargetMachine};
+
+use crate::CodegenError;
+
+/// Emits a native object file for `module` at `obj_path`.
+pub(crate) fn emit_object(
+    machine: &TargetMachine,
+    module: &Module,
+    obj_path: &Path,
+) -> Result<(), CodegenError> {
+    machine
+        .write_to_file(module, FileType::Object, obj_path)
+        .map_err(|e| CodegenError::ObjectEmission(e.to_string()))
+}
+
+/// Links `obj` into an executable at `bin` via the system `cc` driver.
+pub(crate) fn link_binary(obj: &Path, bin: &Path) -> Result<(), CodegenError> {
+    let output = Command::new("cc")
+        .arg(obj)
+        .arg("-o")
+        .arg(bin)
+        .output()
+        .map_err(|e| CodegenError::Link(format!("spawn `cc` failed: {e}")))?;
+
+    if !output.status.success() {
+        return Err(CodegenError::Link(format!(
+            "`cc` exited with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+    Ok(())
+}

--- a/crates/keel-codegen/src/stmt.rs
+++ b/crates/keel-codegen/src/stmt.rs
@@ -1,0 +1,68 @@
+//! Statement codegen — M1 walking-skeleton scope only: `let`/assign and bare
+//! expression statements. `if`/`while`/`for`/`return` land in issue #133
+//! (control flow needs basic-block wiring this crate doesn't have yet).
+
+use inkwell::values::BasicValueEnum;
+
+use keel_kir::ir::{Block, Stmt};
+use keel_kir::types::KirType;
+
+use crate::CodegenError;
+use crate::expr;
+use crate::func::FuncCtx;
+use crate::layout;
+
+fn llvm_err(e: impl std::fmt::Display) -> CodegenError {
+    CodegenError::Llvm(e.to_string())
+}
+
+/// Emits every statement in `block` in order. Returns the last statement's
+/// value *only* if that last statement was a bare `Stmt::Expr` — see
+/// `func.rs`'s module doc for why `emit_main` needs this.
+pub(crate) fn emit_block<'ctx>(
+    fcx: &mut FuncCtx<'ctx, '_>,
+    block: &Block,
+) -> Result<Option<(BasicValueEnum<'ctx>, KirType)>, CodegenError> {
+    let mut last = None;
+    for s in block {
+        last = emit_stmt(fcx, s)?;
+    }
+    Ok(last)
+}
+
+fn emit_stmt<'ctx>(
+    fcx: &mut FuncCtx<'ctx, '_>,
+    stmt: &Stmt,
+) -> Result<Option<(BasicValueEnum<'ctx>, KirType)>, CodegenError> {
+    match stmt {
+        Stmt::Let { local, init } => {
+            let value = expr::emit_expr(fcx, init)?;
+            let ty = layout::llvm_type(fcx.context, init.ty())?;
+            let ptr = fcx
+                .builder
+                .build_alloca(ty, &format!("local.{local}"))
+                .map_err(llvm_err)?;
+            fcx.builder.build_store(ptr, value).map_err(llvm_err)?;
+            fcx.locals.insert(*local, ptr);
+            Ok(None)
+        }
+        Stmt::Assign { local, value } => {
+            let v = expr::emit_expr(fcx, value)?;
+            let ptr = *fcx
+                .locals
+                .get(local)
+                .expect("verified KIR: local exists before assignment (passes::verify)");
+            fcx.builder.build_store(ptr, v).map_err(llvm_err)?;
+            Ok(None)
+        }
+        Stmt::Expr(e) => Ok(Some((expr::emit_expr(fcx, e)?, e.ty()))),
+        Stmt::Return(_) => Err(CodegenError::Unsupported(
+            "return (function-level codegen lands in #133/#134)".to_string(),
+        )),
+        Stmt::If { .. } => Err(CodegenError::Unsupported(
+            "if/else (issue #133)".to_string(),
+        )),
+        Stmt::While { .. } => Err(CodegenError::Unsupported("while (issue #133)".to_string())),
+        Stmt::ForIndex { .. } => Err(CodegenError::Unsupported("for (issue #133)".to_string())),
+    }
+}

--- a/crates/keel-codegen/tests/walking_skeleton.rs
+++ b/crates/keel-codegen/tests/walking_skeleton.rs
@@ -1,0 +1,104 @@
+//! Exit criterion for issue #132: a `.keel` file containing only arithmetic
+//! on ints compiles, links, and the resulting binary's exit code matches
+//! the computed value. See `func.rs`'s module doc for the temporary
+//! "bare top-level `int` expression -> exit code" convention this relies on
+//! — the interpreter never surfaces a computed value as a process exit code
+//! (`keel run` always exits 0/1/130), so "matches the interpreter" here
+//! means "the arithmetic gives the same answer," independently checked by
+//! ordinary Rust arithmetic in each assertion below.
+
+use std::path::Path;
+use std::process::Command;
+
+use keel_codegen::{BuildOptions, CodegenError};
+
+fn compile_and_run(source: &str) -> (i32, tempfile::TempDir) {
+    let (program, _named) =
+        keel_syntax::parse_source(source, "t.keel").expect("fixture must parse");
+    let kir = keel_kir::lower(&program, "t.keel").expect("fixture must lower to KIR");
+
+    let out_dir = tempfile::tempdir().expect("create temp out dir");
+    let opts = BuildOptions {
+        out_dir: out_dir.path().to_path_buf(),
+    };
+    let bin = keel_codegen::compile(&kir, &opts).expect("compile must succeed");
+
+    let run = Command::new(&bin).output().expect("run compiled binary");
+    (
+        run.status.code().expect("process exited via a signal"),
+        out_dir,
+    )
+}
+
+fn compile_err(source: &str) -> CodegenError {
+    let (program, _named) =
+        keel_syntax::parse_source(source, "t.keel").expect("fixture must parse");
+    let kir = keel_kir::lower(&program, "t.keel").expect("fixture must lower to KIR");
+
+    let out_dir = tempfile::tempdir().expect("create temp out dir");
+    let opts = BuildOptions {
+        out_dir: out_dir.path().to_path_buf(),
+    };
+    keel_codegen::compile(&kir, &opts).expect_err("compile must be rejected")
+}
+
+#[test]
+fn int_arithmetic_becomes_the_exit_code() {
+    // 2 + 2 * 10 = 22 (mul binds tighter than add).
+    let (code, _dir) = compile_and_run("2 + 2 * 10\n");
+    assert_eq!(code, 22);
+}
+
+#[test]
+fn let_and_augmented_assign_become_the_exit_code() {
+    let (code, _dir) = compile_and_run("n = 5\nn += 3\nn * 2\n");
+    assert_eq!(code, 16);
+}
+
+#[test]
+fn negative_and_comparison_ints_compile_and_run() {
+    // -(3 + 4) < 0 is true (1); as a bare top-level expr its KirType is
+    // bool, not int, so the M1 exit-code convention doesn't apply — exit 0.
+    let (code, _dir) = compile_and_run("-(3 + 4) < 0\n");
+    assert_eq!(code, 0);
+}
+
+#[test]
+fn float_and_bool_arithmetic_compiles_and_runs() {
+    // Exercises the F64/Bool codegen paths in layout.rs/expr.rs; only an
+    // `int`-typed bare expression becomes the exit code (see func.rs), so
+    // this just proves it compiles, links, and exits cleanly.
+    let (code, _dir) = compile_and_run("1.5 + 2.5\ntrue and not false\n");
+    assert_eq!(code, 0);
+}
+
+#[test]
+fn empty_program_compiles_and_exits_zero() {
+    let (code, _dir) = compile_and_run("");
+    assert_eq!(code, 0);
+}
+
+#[test]
+fn str_expression_is_rejected_not_silently_dropped() {
+    let err = compile_err("\"hi\"\n");
+    assert!(
+        matches!(err, CodegenError::Unsupported(ref msg) if msg.contains("str")),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn top_level_if_is_rejected_not_silently_dropped() {
+    let err = compile_err("x = 1\nif x == 1 {\n  x = 2\n}\n");
+    assert!(
+        matches!(err, CodegenError::Unsupported(ref msg) if msg.contains("if/else")),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn binary_actually_exists_on_disk() {
+    let (_code, dir) = compile_and_run("1\n");
+    let bin = dir.path().join("keel_program");
+    assert!(Path::new(&bin).exists(), "expected a linked binary on disk");
+}

--- a/tests/conformance/main.rs
+++ b/tests/conformance/main.rs
@@ -28,15 +28,26 @@
 //! process stdout via `println!` (no injectable writer exists in the
 //! runtime today — out of scope to add here), capturing a single program's
 //! output requires redirecting fd 1 for the duration of that one call; see
-//! [`capture_stdout`]. This binary has two `#[tokio::test]` functions, and
-//! libtest runs them concurrently on separate OS threads by default; both
-//! acquire [`SEQUENTIAL_GUARD`] for their full duration so only one is ever
-//! executing at a time. That's required, not just tidy: libtest itself
-//! writes each test's `test <name> ... ok` status line to real stdout (fd 1)
-//! the moment that test function returns, so without the guard, that print
-//! can land in the middle of the other test's fd-1 redirect window and
-//! corrupt a captured program's output — exactly the kind of "conformance
-//! failure" this harness exists to catch, except spurious.
+//! [`capture_stdout`]. That's safe here specifically because this whole
+//! corpus runs from **one sequential test function** in **its own test
+//! binary process** (`tests/conformance/main.rs` — Cargo gives every
+//! `tests/*.rs`/`tests/<dir>/main.rs` file its own binary): no other test
+//! shares this process, and nothing here spawns concurrent programs, so
+//! fd 1 is never contended.
+//!
+//! This is a hard requirement, not just tidy structure: a second
+//! `#[tokio::test]` in this binary — even one that never touches fd 1
+//! itself — is enough to break it. libtest runs sibling tests concurrently
+//! by default and writes each one's `test <name> ... ok` status line to
+//! real stdout (fd 1) some time after that test's future resolves (the
+//! print is not synchronous with the function returning — it goes through
+//! libtest's own result-reporting path). A mutex serializing the two test
+//! *bodies* was tried and was not sufficient: it narrows the race but the
+//! delayed status print can still land inside this test's `capture_stdout`
+//! window regardless of body ordering. The only fully robust fix is what
+//! this file does now — exactly one `#[tokio::test]` in the binary, so
+//! there is only ever one status line, printed once, after everything here
+//! has already finished.
 //!
 //! Unix-only (`libc::dup`/`dup2`) — deferred for Windows, same as the rest
 //! of the native-backend work this issue is scaffolding for.
@@ -51,13 +62,6 @@ use std::time::Duration;
 
 use corpus::discover_corpus;
 use engine::{Engine, EngineError, EngineOutput};
-use tokio::sync::Mutex;
-
-/// Serializes the two `#[tokio::test]` functions in this binary so libtest's
-/// own per-test status print can never land during the other test's fd-1
-/// redirect window. See the module doc comment. `tokio::sync::Mutex` (not
-/// `std::sync::Mutex`) because the guard must stay held across `.await`.
-static SEQUENTIAL_GUARD: Mutex<()> = Mutex::const_new(());
 
 /// Per-program wall-clock budget. Generous enough for the mock LLM path and
 /// agent handshake overhead, tight enough that a genuinely hung program
@@ -177,18 +181,15 @@ fn skip_reason(stem: &str) -> Option<&'static str> {
 
 #[tokio::test]
 async fn interpreter_is_deterministic_across_the_corpus() {
-    let _guard = SEQUENTIAL_GUARD.lock().await;
-
     // KEEL_LLM=mock keeps `ai.*` deterministic and offline; KEEL_ONESHOT=1
     // makes agent programs exit after one idle window instead of serving
     // forever. Set once, process-wide — safe because this whole corpus runs
     // sequentially from this one test function in its own test-binary
-    // process (see the module doc comment).
+    // process (see the module doc comment), and nothing else in this
+    // process reads env vars concurrently.
     // SAFETY: process-wide env mutation is unsafe in general (data races with
     // concurrent readers), but this runs before any corpus program (hence
-    // any concurrent env reader) starts, and the only other test in this
-    // binary (`compiled_engine_reports_not_implemented`) never reads env
-    // vars — see its doc comment.
+    // any concurrent env reader) starts.
     unsafe {
         std::env::set_var("KEEL_LLM", "mock");
         std::env::set_var("KEEL_ONESHOT", "1");
@@ -237,21 +238,15 @@ async fn interpreter_is_deterministic_across_the_corpus() {
         failures.len(),
         failures.join("\n")
     );
-}
 
-/// Exercises the `Engine::Compiled` stub directly (not through the corpus
-/// loop above) so the "not implemented" contract has its own regression
-/// test independent of which examples happen to be skipped.
-///
-/// Calls `Engine::run` directly rather than going through `run_one` — that
-/// helper redirects fd 1 and changes the process cwd, which `Engine::Compiled`
-/// doesn't need. Still takes [`SEQUENTIAL_GUARD`] itself: this test's own
-/// completion print from libtest must not land inside the other test's fd-1
-/// redirect window either (see the module doc comment).
-#[tokio::test]
-async fn compiled_engine_reports_not_implemented() {
-    let _guard = SEQUENTIAL_GUARD.lock().await;
-
+    // Exercises the `Engine::Compiled` stub directly (not through the corpus
+    // loop above) so the "not implemented" contract has its own regression
+    // coverage independent of which examples happen to be skipped. Inlined
+    // into this same test function rather than a separate #[test] — see the
+    // module doc comment for why a second test in this binary isn't safe.
+    // Calls `Engine::run` directly rather than through `run_one`: that
+    // helper redirects fd 1 and changes the process cwd, which
+    // `Engine::Compiled` doesn't need.
     let fixtures = corpus::fixtures_dir();
     let path = fixtures.join("agent_lifecycle.keel");
     let err = Engine::Compiled


### PR DESCRIPTION
## Summary
- New `keel-codegen` crate: `KirType` -> LLVM type (int/float/bool only), a single-function scalar-arithmetic codegen path (`context.rs`/`layout.rs`/`func.rs`/`stmt.rs`/`expr.rs`), and object emission + `cc` link (`link.rs`) — the exact loop already proven in `spikes/llvm-poc`, now `Result`-returning instead of panicking.
- `main` runs the toplevel KIR function's statements inline. A documented, temporary M1-only convention: a bare top-level `int` expression becomes the process exit code (real top-level statements always lower to `Unit`, so there's no other way to get a computed value out yet — this is replaced once `main` calls `keel_rt_start` in #134).
- Root `Cargo.toml`: `build-backend = ["dep:keel-codegen"]` optional dependency/feature, per the dependency rule in `designs/llvm-compilation.md` §2.2 (only `keel-codegen` links LLVM).
- **CI**: the existing `check` job's clippy step used `--all-features`, which would have silently required LLVM to lint this new crate on every PR. Split it into a dedicated `build-backend` job that installs LLVM 22 via the exact recipe already verified in `designs/llvm-toolchain-spike.md` (apt.llvm.org + the Polly static-lib packages) — so the main job stays LLVM-free and this crate's code is actually exercised in CI, not just locally.
- Crate README documents the `LLVM_SYS_221_PREFIX` toolchain requirement.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (default features — confirmed LLVM-free even with `LLVM_SYS_221_PREFIX` unset)
- [x] `cargo clippy --workspace --all-targets --features build-backend -- -D warnings`
- [x] `cargo test --workspace --features build-backend` (all green, including 8 new `keel-codegen` integration tests proving the exit criterion: arithmetic -> compile -> link -> run -> exit code)
- [x] `cargo build --release` / `cargo doc` confirmed unaffected (no LLVM needed)

Close #132