### PR TITLE
keel-kir: lower namespace method calls (CallTarget::Ns)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,6 +1467,7 @@ dependencies = [
 name = "keel-kir"
 version = "0.2.4"
 dependencies = [
+ "keel-catalog",
  "keel-syntax",
 ]
 

--- a/crates/keel-kir/Cargo.toml
+++ b/crates/keel-kir/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
+keel-catalog = { path = "../keel-catalog" }
 keel-syntax = { path = "../keel-syntax" }
 
 [dev-dependencies]

--- a/crates/keel-kir/src/dump.rs
+++ b/crates/keel-kir/src/dump.rs
@@ -7,7 +7,7 @@
 
 use std::fmt::Write as _;
 
-use crate::ir::{BinOp, Block, Expr, FuncId, KirFunction, KirProgram, Stmt, UnOp};
+use crate::ir::{BinOp, Block, CallTarget, Expr, FuncId, KirFunction, KirProgram, Stmt, UnOp};
 
 /// Renders every function in `program`, in declaration order.
 #[must_use]
@@ -156,7 +156,7 @@ fn fmt_expr(program: &KirProgram, func: &KirFunction, expr: &Expr) -> String {
             format!("({}{})", unop_symbol(*op), fmt_expr(program, func, operand))
         }
         Expr::Call { target, args, .. } => {
-            let name = fn_name(program, *target);
+            let name = call_target_name(program, *target);
             let args = args
                 .iter()
                 .map(|a| fmt_expr(program, func, a))
@@ -169,6 +169,21 @@ fn fmt_expr(program: &KirProgram, func: &KirFunction, expr: &Expr) -> String {
 
 fn fn_name(program: &KirProgram, id: FuncId) -> &str {
     &program.functions[id].name
+}
+
+/// `foo` for a direct call, `namespace.method` for a namespace call —
+/// resolved back from `(ns_id, method_id)` via the catalog purely for dump
+/// readability (KIR itself only stores the numeric ids; see `ir::CallTarget`).
+fn call_target_name(program: &KirProgram, target: CallTarget) -> String {
+    match target {
+        CallTarget::Fn(id) => fn_name(program, id).to_string(),
+        CallTarget::Ns { ns_id, method_id } => keel_catalog::catalog()
+            .find(|m| {
+                keel_catalog::namespace_id(m.namespace) == Some(ns_id) && m.method_id == method_id
+            })
+            .map(|m| format!("{}.{}", m.namespace, m.name))
+            .unwrap_or_else(|| format!("ns#{ns_id}.method#{method_id}")),
+    }
 }
 
 fn binop_symbol(op: BinOp) -> &'static str {

--- a/crates/keel-kir/src/ir.rs
+++ b/crates/keel-kir/src/ir.rs
@@ -136,16 +136,28 @@ pub enum Expr {
         operand: Box<Expr>,
         ty: KirType,
     },
-    /// Direct call to a compiled Keel function — the only `CallTarget` M0
-    /// lowers to (no namespace dispatch, no value methods, no indirect
-    /// lambda calls yet; see `designs/llvm-compilation.md` §2.3
-    /// `CallTarget`).
+    /// A call to a compiled Keel function or a stdlib namespace method (see
+    /// [`CallTarget`]). Value methods and indirect lambda calls are not
+    /// lowered yet — see `designs/llvm-compilation.md` §2.3 `CallTarget`.
     Call {
-        target: FuncId,
+        target: CallTarget,
         args: Vec<Expr>,
         ty: KirType,
         span: SpanId,
     },
+}
+
+/// What an `Expr::Call` invokes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CallTarget {
+    /// Direct call to another compiled Keel task.
+    Fn(FuncId),
+    /// Generic stdlib namespace dispatch: `io.show(...)`, `log.info(...)`.
+    /// `ns_id`/`method_id` are the stable ids from
+    /// `keel_catalog::specs::NAMESPACE_IDS`/`BuiltinMethod::method_id`,
+    /// resolved at lowering time — `keel-codegen` (M1+) compiles this to a
+    /// call into `keel_rt_call_ns(ns_id, method_id, ...)` (§2.7).
+    Ns { ns_id: u16, method_id: u16 },
 }
 
 impl Expr {

--- a/crates/keel-kir/src/lower/decl.rs
+++ b/crates/keel-kir/src/lower/decl.rs
@@ -51,6 +51,7 @@ pub(crate) fn lower_task_body(
     task: &TaskDecl,
     sig: &FuncSig,
     funcs: &HashMap<String, FuncSig>,
+    ns_bindings: &HashMap<String, String>,
     table: &mut SpanTable,
 ) -> Result<KirFunction, LowerError> {
     let mut ctx = FnCtx::new();
@@ -61,7 +62,7 @@ pub(crate) fn lower_task_body(
         params.push(Param { local, ty: *ty });
     }
 
-    let body = super::stmt::lower_block(&task.body, &mut ctx, funcs, table, sig.ret)?;
+    let body = super::stmt::lower_block(&task.body, &mut ctx, funcs, ns_bindings, table, sig.ret)?;
 
     Ok(KirFunction {
         id: sig.func_id,

--- a/crates/keel-kir/src/lower/expr.rs
+++ b/crates/keel-kir/src/lower/expr.rs
@@ -1,17 +1,21 @@
-//! Expression lowering — the M0 scalar subset: literals, identifiers,
+//! Expression lowering — the M0 scalar subset (literals, identifiers,
 //! arithmetic/comparison/logical binary ops, unary `-`/`not`, and direct
-//! calls to other lowered tasks. Everything else (field/index access,
-//! method calls, casts, `if`/`when` as expressions, lambdas, compound
-//! literals, string interpolation, `?.`/`??`, ranges, pipelines, duration
-//! literals, enum variants) is rejected; see module docs on `lower/mod.rs`.
+//! calls to other lowered tasks) plus M1's stdlib namespace calls
+//! (`io.show(...)`, `log.info(...)` — see [`lower_call`]). Everything else
+//! (field/index access, value method calls, casts, `if`/`when` as
+//! expressions, lambdas, compound literals, string interpolation, `?.`/`??`,
+//! pipelines, duration literals, enum variants) is rejected; see module docs
+//! on `lower/mod.rs`.
 
 use std::collections::HashMap;
 
 use keel_syntax::ast::{self, SpannedExpr};
 use keel_syntax::lexer::Span;
 
+use keel_catalog::builtins::BuiltinResult;
+
 use super::{FnCtx, FuncSig, LowerError};
-use crate::ir::{self, Expr};
+use crate::ir::{self, CallTarget, Expr};
 use crate::span_table::SpanTable;
 use crate::types::KirType;
 
@@ -94,6 +98,7 @@ pub(crate) fn lower_expr(
     expr: &SpannedExpr,
     ctx: &mut FnCtx,
     funcs: &HashMap<String, FuncSig>,
+    ns_bindings: &HashMap<String, String>,
     table: &mut SpanTable,
 ) -> Result<Expr, LowerError> {
     match &expr.kind {
@@ -109,8 +114,8 @@ pub(crate) fn lower_expr(
             Ok(Expr::Local { id: local, ty })
         }
         ast::Expr::BinaryOp { left, op, right } => {
-            let left_e = lower_expr(left, ctx, funcs, table)?;
-            let right_e = lower_expr(right, ctx, funcs, table)?;
+            let left_e = lower_expr(left, ctx, funcs, ns_bindings, table)?;
+            let right_e = lower_expr(right, ctx, funcs, ns_bindings, table)?;
             let kir_op = convert_binop(*op);
             let ty = infer_binop_ty(kir_op, left_e.ty(), right_e.ty(), &expr.span)?;
             Ok(Expr::BinOp {
@@ -121,7 +126,7 @@ pub(crate) fn lower_expr(
             })
         }
         ast::Expr::UnaryOp { op, expr: operand } => {
-            let operand_e = lower_expr(operand, ctx, funcs, table)?;
+            let operand_e = lower_expr(operand, ctx, funcs, ns_bindings, table)?;
             let ty = match op {
                 ast::UnOp::Neg if operand_e.ty().is_numeric() => operand_e.ty(),
                 ast::UnOp::Not if operand_e.ty() == KirType::Bool => KirType::Bool,
@@ -148,7 +153,9 @@ pub(crate) fn lower_expr(
                 ty,
             })
         }
-        ast::Expr::Call { callee, args } => lower_call(callee, args, ctx, funcs, table, &expr.span),
+        ast::Expr::Call { callee, args } => {
+            lower_call(callee, args, ctx, funcs, ns_bindings, table, &expr.span)
+        }
         ast::Expr::FieldAccess(..) => {
             Err(LowerError::unsupported("field access", expr.span.clone()))
         }
@@ -174,8 +181,35 @@ pub(crate) fn lower_expr(
         ast::Expr::NullCoalesce(..) => Err(LowerError::unsupported("`??`", expr.span.clone())),
         ast::Expr::Pipeline(..) => Err(LowerError::unsupported("`|>` pipeline", expr.span.clone())),
         ast::Expr::Range(..) => Err(LowerError::unsupported("range", expr.span.clone())),
-        ast::Expr::MethodCall { .. } => {
-            Err(LowerError::unsupported("method call", expr.span.clone()))
+        ast::Expr::MethodCall {
+            object,
+            method,
+            args,
+        } => {
+            // Namespace call (`io.show(...)`): recognized only when `object`
+            // is a bare identifier bound by `use std/<name>` *and* not
+            // shadowed by a local — mirrors the checker's "lexical locals
+            // shadow globals" precedence (`db = db.connect(...)` rebinds
+            // `db` to a connection value; see `checker/expr.rs`). Anything
+            // else (a real value method call, `xs.map(f)`) isn't lowered
+            // yet — value methods land alongside the container ABI (M2+).
+            if let ast::Expr::Ident(obj_name) = &object.kind
+                && ctx.resolve(obj_name).is_none()
+                && let Some(namespace) = ns_bindings.get(obj_name)
+            {
+                lower_ns_call(
+                    namespace,
+                    method,
+                    args,
+                    ctx,
+                    funcs,
+                    ns_bindings,
+                    table,
+                    &expr.span,
+                )
+            } else {
+                Err(LowerError::unsupported("method call", expr.span.clone()))
+            }
         }
         ast::Expr::Cast { .. } => Err(LowerError::unsupported("`as` cast", expr.span.clone())),
         ast::Expr::IfExpr { .. } => Err(LowerError::unsupported(
@@ -212,17 +246,22 @@ fn lower_string_lit(parts: &[ast::StringPart], span: &Span) -> Result<Expr, Lowe
     }
 }
 
+/// Lowers a direct call to another lowered task. `namespace.method(...)`
+/// calls never reach here — the parser produces `ast::Expr::MethodCall` for
+/// all dot-call syntax, not `Call` with a field-access callee; see the
+/// `ast::Expr::MethodCall` arm in `lower_expr` for namespace-call lowering.
 fn lower_call(
     callee: &SpannedExpr,
     args: &[ast::CallArg],
     ctx: &mut FnCtx,
     funcs: &HashMap<String, FuncSig>,
+    ns_bindings: &HashMap<String, String>,
     table: &mut SpanTable,
     call_span: &Span,
 ) -> Result<Expr, LowerError> {
     let ast::Expr::Ident(name) = &callee.kind else {
         return Err(LowerError::unsupported(
-            "indirect/method call (only direct calls to named tasks are supported)",
+            "indirect call (only direct calls to named tasks are supported)",
             callee.span.clone(),
         ));
     };
@@ -249,7 +288,7 @@ fn lower_call(
                 arg.value.span.clone(),
             ));
         }
-        let lowered = lower_expr(&arg.value, ctx, funcs, table)?;
+        let lowered = lower_expr(&arg.value, ctx, funcs, ns_bindings, table)?;
         if lowered.ty() != *expected_ty {
             return Err(LowerError::new(
                 format!(
@@ -263,9 +302,103 @@ fn lower_call(
     }
 
     Ok(Expr::Call {
-        target: sig.func_id,
+        target: CallTarget::Fn(sig.func_id),
         args: lowered_args,
         ty: sig.ret,
         span: table.intern(call_span.clone()),
+    })
+}
+
+/// Lowers a stdlib namespace call (`namespace.method(args)`) to
+/// `CallTarget::Ns`. Argument *types* are not checked against the catalog's
+/// declared params here (most of M1's catalog surface — including every
+/// method reachable from this issue's `io`/`log` scope — takes `dynamic`,
+/// which has no `KirType` until the boxing pass lands in M2/M3; `keel
+/// check` already validated the call before lowering ever sees it). Arity
+/// *is* checked, and named/spread arguments are rejected — no M1 namespace
+/// method in the scalar-subset surface needs them yet.
+///
+/// `namespace`/`method`/`call_span` push this one function over clippy's
+/// default argument-count threshold; the other five are the same lowering
+/// state every function in this module already threads (`ctx`, `funcs`,
+/// `ns_bindings`, `table`) plus the call's own arg list. Bundling all of it
+/// into a shared "lowering context" struct is a reasonable future
+/// refactor, but not one this issue's scope should force — see `lower_call`
+/// just above, at 7 params, one under the limit, using the same pattern.
+#[allow(clippy::too_many_arguments)]
+fn lower_ns_call(
+    namespace: &str,
+    method: &str,
+    args: &[ast::CallArg],
+    ctx: &mut FnCtx,
+    funcs: &HashMap<String, FuncSig>,
+    ns_bindings: &HashMap<String, String>,
+    table: &mut SpanTable,
+    call_span: &Span,
+) -> Result<Expr, LowerError> {
+    let builtin = keel_catalog::catalog_method(namespace, method).ok_or_else(|| {
+        LowerError::new(
+            format!("`{namespace}` has no method `{method}`"),
+            call_span.clone(),
+        )
+    })?;
+    let ns_id = keel_catalog::namespace_id(namespace)
+        .expect("ns_bindings only ever contains namespaces validated in lower_use");
+
+    let required = builtin.params.iter().filter(|p| !p.optional).count();
+    if args.len() < required || args.len() > builtin.params.len() {
+        return Err(LowerError::new(
+            format!(
+                "`{namespace}.{method}` takes {} argument(s), got {}",
+                if required == builtin.params.len() {
+                    required.to_string()
+                } else {
+                    format!("{required}-{}", builtin.params.len())
+                },
+                args.len()
+            ),
+            call_span.clone(),
+        ));
+    }
+
+    let mut lowered_args = Vec::with_capacity(args.len());
+    for arg in args {
+        if arg.name.is_some() || arg.spread {
+            return Err(LowerError::unsupported(
+                "named or spread arguments to a stdlib namespace call",
+                arg.value.span.clone(),
+            ));
+        }
+        lowered_args.push(lower_expr(&arg.value, ctx, funcs, ns_bindings, table)?);
+    }
+
+    let ty = result_ty_to_kir(builtin.result, call_span)?;
+
+    Ok(Expr::Call {
+        target: CallTarget::Ns {
+            ns_id,
+            method_id: builtin.method_id,
+        },
+        args: lowered_args,
+        ty,
+        span: table.intern(call_span.clone()),
+    })
+}
+
+/// Resolves a catalog method's declared result to a `KirType`, rejecting
+/// anything that needs boxing/context-dependent resolution (M2/M3 scope).
+fn result_ty_to_kir(result: BuiltinResult, span: &Span) -> Result<KirType, LowerError> {
+    let BuiltinResult::Fixed(spec) = result else {
+        return Err(LowerError::unsupported(
+            "a namespace method whose result type depends on runtime context (`as:`-typed \
+             extraction/classification, or otherwise dynamic — needs the boxing pass, M2/M3)",
+            span.clone(),
+        ));
+    };
+    KirType::from_tyspec(spec).ok_or_else(|| {
+        LowerError::unsupported(
+            &format!("a namespace method returning `{spec:?}` (needs M2+ types)"),
+            span.clone(),
+        )
     })
 }

--- a/crates/keel-kir/src/lower/mod.rs
+++ b/crates/keel-kir/src/lower/mod.rs
@@ -44,7 +44,7 @@ pub mod sugar;
 use std::collections::HashMap;
 use std::fmt;
 
-use keel_syntax::ast::{Binding, Decl, Program};
+use keel_syntax::ast::{Binding, Decl, Program, UseDecl, UseKind, UseSource};
 use keel_syntax::lexer::Span;
 
 use crate::ir::{FuncId, KirFunction, KirProgram, LocalId};
@@ -158,10 +158,13 @@ impl FnCtx {
 pub fn lower_program(program: &Program, file_name: &str) -> Result<KirProgram, LowerError> {
     let mut span_table = SpanTable::new(file_name);
     let mut funcs: HashMap<String, FuncSig> = HashMap::new();
+    let mut ns_bindings: HashMap<String, String> = HashMap::new();
     let mut task_order: Vec<&keel_syntax::ast::TaskDecl> = Vec::new();
 
-    // Pass 1: collect every task signature so calls resolve regardless of
-    // declaration order (forward references, mutual/self recursion).
+    // Pass 1: collect every task signature (so calls resolve regardless of
+    // declaration order — forward references, mutual/self recursion) and
+    // every `use std/<name>` namespace binding (so namespace calls resolve
+    // regardless of whether the `use` appears before or after they're used).
     for decl in &program.declarations {
         match &decl.kind {
             Decl::Task(task) => {
@@ -177,6 +180,9 @@ pub fn lower_program(program: &Program, file_name: &str) -> Result<KirProgram, L
                     },
                 );
             }
+            Decl::Use(use_decl) => {
+                lower_use(use_decl, &decl.span, &mut ns_bindings)?;
+            }
             Decl::Stmt(_) => {} // handled in pass 2 (toplevel)
             other => {
                 return Err(LowerError::unsupported(
@@ -187,11 +193,17 @@ pub fn lower_program(program: &Program, file_name: &str) -> Result<KirProgram, L
         }
     }
 
-    // Pass 2: lower each task body now that `funcs` is complete.
+    // Pass 2: lower each task body now that `funcs`/`ns_bindings` are complete.
     let mut functions: Vec<KirFunction> = Vec::with_capacity(task_order.len() + 1);
     for task in &task_order {
         let sig = &funcs[&task.name];
-        functions.push(decl::lower_task_body(task, sig, &funcs, &mut span_table)?);
+        functions.push(decl::lower_task_body(
+            task,
+            sig,
+            &funcs,
+            &ns_bindings,
+            &mut span_table,
+        )?);
     }
 
     // Toplevel: every `Decl::Stmt` compiles into one synthetic function,
@@ -205,6 +217,7 @@ pub fn lower_program(program: &Program, file_name: &str) -> Result<KirProgram, L
                 stmt,
                 &mut ctx,
                 &funcs,
+                &ns_bindings,
                 &mut span_table,
                 KirType::Unit,
             )?);
@@ -224,6 +237,47 @@ pub fn lower_program(program: &Program, file_name: &str) -> Result<KirProgram, L
         toplevel: toplevel_id,
         span_table,
     })
+}
+
+/// Lowers a `use` declaration into a `ns_bindings` entry (bound identifier
+/// -> stdlib namespace name), or rejects it. Only `use std/<name>` (flat
+/// stdlib module imports, no symbol lists, no relative-file imports) is in
+/// scope: M1's namespace-call lowering only needs to know which identifier
+/// a namespace is bound under, and multi-module/local-file lowering isn't
+/// wired up yet (`lower_program` still takes one file, not a `ModuleGraph`).
+fn lower_use(
+    use_decl: &UseDecl,
+    span: &Span,
+    ns_bindings: &mut HashMap<String, String>,
+) -> Result<(), LowerError> {
+    let UseKind::Module { source, alias } = &use_decl.kind else {
+        return Err(LowerError::unsupported(
+            "symbol-list `use ... from ...` import",
+            span.clone(),
+        ));
+    };
+    let UseSource::Module(segments) = source else {
+        return Err(LowerError::unsupported(
+            "file-path `use` import (multi-module lowering isn't wired up yet)",
+            span.clone(),
+        ));
+    };
+    if segments.len() != 2 || segments[0] != "std" {
+        return Err(LowerError::unsupported(
+            "a `use` path other than `std/<name>`",
+            span.clone(),
+        ));
+    }
+    let namespace = &segments[1];
+    if keel_catalog::namespace_id(namespace).is_none() {
+        return Err(LowerError::new(
+            format!("unknown std module `std/{namespace}`"),
+            span.clone(),
+        ));
+    }
+    let bound_name = alias.clone().unwrap_or_else(|| namespace.clone());
+    ns_bindings.insert(bound_name, namespace.clone());
+    Ok(())
 }
 
 fn decl_kind_name(decl: &Decl) -> &'static str {

--- a/crates/keel-kir/src/lower/stmt.rs
+++ b/crates/keel-kir/src/lower/stmt.rs
@@ -21,13 +21,14 @@ pub(crate) fn lower_block(
     block: &ast::Block,
     ctx: &mut FnCtx,
     funcs: &HashMap<String, FuncSig>,
+    ns_bindings: &HashMap<String, String>,
     table: &mut SpanTable,
     ret_ty: KirType,
 ) -> Result<Block, LowerError> {
     ctx.push_scope();
     let mut out = Vec::with_capacity(block.len());
     for stmt in block {
-        out.push(lower_stmt(stmt, ctx, funcs, table, ret_ty)?);
+        out.push(lower_stmt(stmt, ctx, funcs, ns_bindings, table, ret_ty)?);
     }
     ctx.pop_scope();
     Ok(out)
@@ -41,13 +42,14 @@ pub(crate) fn lower_stmt(
     stmt: &Node<ast::Stmt>,
     ctx: &mut FnCtx,
     funcs: &HashMap<String, FuncSig>,
+    ns_bindings: &HashMap<String, String>,
     table: &mut SpanTable,
     ret_ty: KirType,
 ) -> Result<ir::Stmt, LowerError> {
     match &stmt.kind {
         ast::Stmt::Let { binding, ty, value } => {
             let name = binding_ident(binding, &stmt.span)?;
-            let init = lower_expr(value, ctx, funcs, table)?;
+            let init = lower_expr(value, ctx, funcs, ns_bindings, table)?;
             let declared_ty = init.ty();
             if let Some(annotation) = ty {
                 let annotated = ty_expr_to_kir(annotation)?;
@@ -73,7 +75,7 @@ pub(crate) fn lower_stmt(
                 LowerError::new(format!("unknown identifier `{name}`"), name_span.clone())
             })?;
             let local_ty = ctx.locals[local].ty;
-            let rhs_expr = lower_expr(rhs, ctx, funcs, table)?;
+            let rhs_expr = lower_expr(rhs, ctx, funcs, ns_bindings, table)?;
             let op = super::expr::convert_binop(*op);
             let result_ty = super::expr::infer_binop_ty(op, local_ty, rhs_expr.ty(), &stmt.span)?;
             if result_ty != local_ty {
@@ -105,7 +107,7 @@ pub(crate) fn lower_stmt(
             Ok(ir::Stmt::Return(None))
         }
         ast::Stmt::Return(Some(value)) => {
-            let expr = lower_expr(value, ctx, funcs, table)?;
+            let expr = lower_expr(value, ctx, funcs, ns_bindings, table)?;
             if expr.ty() != ret_ty {
                 return Err(LowerError::new(
                     format!(
@@ -122,16 +124,16 @@ pub(crate) fn lower_stmt(
             then_body,
             else_body,
         } => {
-            let cond_expr = lower_expr(cond, ctx, funcs, table)?;
+            let cond_expr = lower_expr(cond, ctx, funcs, ns_bindings, table)?;
             if cond_expr.ty() != KirType::Bool {
                 return Err(LowerError::new(
                     format!("`if` condition is `{}`, expected `bool`", cond_expr.ty()),
                     cond.span.clone(),
                 ));
             }
-            let then_branch = lower_block(then_body, ctx, funcs, table, ret_ty)?;
+            let then_branch = lower_block(then_body, ctx, funcs, ns_bindings, table, ret_ty)?;
             let else_branch = match else_body {
-                Some(body) => lower_block(body, ctx, funcs, table, ret_ty)?,
+                Some(body) => lower_block(body, ctx, funcs, ns_bindings, table, ret_ty)?,
                 None => Vec::new(),
             };
             Ok(ir::Stmt::If {
@@ -141,20 +143,26 @@ pub(crate) fn lower_stmt(
             })
         }
         ast::Stmt::While { cond, body } => {
-            let cond_expr = lower_expr(cond, ctx, funcs, table)?;
+            let cond_expr = lower_expr(cond, ctx, funcs, ns_bindings, table)?;
             if cond_expr.ty() != KirType::Bool {
                 return Err(LowerError::new(
                     format!("`while` condition is `{}`, expected `bool`", cond_expr.ty()),
                     cond.span.clone(),
                 ));
             }
-            let body = lower_block(body, ctx, funcs, table, ret_ty)?;
+            let body = lower_block(body, ctx, funcs, ns_bindings, table, ret_ty)?;
             Ok(ir::Stmt::While {
                 cond: cond_expr,
                 body,
             })
         }
-        ast::Stmt::Expr(expr) => Ok(ir::Stmt::Expr(lower_expr(expr, ctx, funcs, table)?)),
+        ast::Stmt::Expr(expr) => Ok(ir::Stmt::Expr(lower_expr(
+            expr,
+            ctx,
+            funcs,
+            ns_bindings,
+            table,
+        )?)),
         ast::Stmt::SelfAssign { .. } => Err(LowerError::unsupported(
             "self.field assignment",
             stmt.span.clone(),
@@ -180,14 +188,14 @@ pub(crate) fn lower_stmt(
             };
             // Bounds are evaluated once, before `var` exists, so they lower
             // in the enclosing scope and cannot reference the loop variable.
-            let low = lower_expr(start, ctx, funcs, table)?;
+            let low = lower_expr(start, ctx, funcs, ns_bindings, table)?;
             if low.ty() != KirType::I64 {
                 return Err(LowerError::new(
                     format!("`for` range start is `{}`, expected `int`", low.ty()),
                     start.span.clone(),
                 ));
             }
-            let high = lower_expr(end, ctx, funcs, table)?;
+            let high = lower_expr(end, ctx, funcs, ns_bindings, table)?;
             if high.ty() != KirType::I64 {
                 return Err(LowerError::new(
                     format!("`for` range end is `{}`, expected `int`", high.ty()),
@@ -196,7 +204,7 @@ pub(crate) fn lower_stmt(
             }
             ctx.push_scope();
             let var = ctx.declare(name, KirType::I64);
-            let body = lower_block(body, ctx, funcs, table, ret_ty)?;
+            let body = lower_block(body, ctx, funcs, ns_bindings, table, ret_ty)?;
             ctx.pop_scope();
             Ok(ir::Stmt::ForIndex {
                 var,

--- a/crates/keel-kir/src/passes/verify.rs
+++ b/crates/keel-kir/src/passes/verify.rs
@@ -12,7 +12,7 @@
 
 use std::fmt;
 
-use crate::ir::{Block, Expr, FuncId, KirFunction, KirProgram, LocalId, Stmt};
+use crate::ir::{Block, CallTarget, Expr, FuncId, KirFunction, KirProgram, LocalId, Stmt};
 use crate::types::KirType;
 
 #[derive(Debug, Clone)]
@@ -223,34 +223,93 @@ fn verify_expr(program: &KirProgram, func: &KirFunction, expr: &Expr) -> Result<
         Expr::Call {
             target, args, ty, ..
         } => {
-            check_func(program, *target)?;
-            let callee = &program.functions[*target];
-            if callee.ret != *ty {
-                return Err(format!(
-                    "call to `{}` has result type {ty} but the callee returns {}",
-                    callee.name, callee.ret
-                ));
-            }
-            if callee.params.len() != args.len() {
-                return Err(format!(
-                    "call to `{}` passes {} arg(s), callee takes {}",
-                    callee.name,
-                    args.len(),
-                    callee.params.len()
-                ));
-            }
-            for (arg, param) in args.iter().zip(&callee.params) {
+            for arg in args {
                 verify_expr(program, func, arg)?;
-                if arg.ty() != param.ty {
-                    return Err(format!(
-                        "call to `{}` passes {} where {} is expected",
-                        callee.name,
-                        arg.ty(),
-                        param.ty
-                    ));
+            }
+            match target {
+                CallTarget::Fn(id) => verify_fn_call(program, *id, args, *ty),
+                CallTarget::Ns { ns_id, method_id } => {
+                    verify_ns_call(*ns_id, *method_id, args, *ty)
                 }
             }
-            Ok(())
         }
     }
+}
+
+fn verify_fn_call(
+    program: &KirProgram,
+    id: FuncId,
+    args: &[Expr],
+    ty: KirType,
+) -> Result<(), String> {
+    check_func(program, id)?;
+    let callee = &program.functions[id];
+    if callee.ret != ty {
+        return Err(format!(
+            "call to `{}` has result type {ty} but the callee returns {}",
+            callee.name, callee.ret
+        ));
+    }
+    if callee.params.len() != args.len() {
+        return Err(format!(
+            "call to `{}` passes {} arg(s), callee takes {}",
+            callee.name,
+            args.len(),
+            callee.params.len()
+        ));
+    }
+    for (arg, param) in args.iter().zip(&callee.params) {
+        if arg.ty() != param.ty {
+            return Err(format!(
+                "call to `{}` passes {} where {} is expected",
+                callee.name,
+                arg.ty(),
+                param.ty
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Verifies a `CallTarget::Ns` call shape: `(ns_id, method_id)` must
+/// resolve to a real catalog method, arity must fit its param count, and
+/// the call's `ty` must match what the catalog declares (via
+/// `KirType::from_tyspec` — anything that maps to `None` there was already
+/// rejected at lowering time, so should never reach a verified program).
+fn verify_ns_call(ns_id: u16, method_id: u16, args: &[Expr], ty: KirType) -> Result<(), String> {
+    let builtin = keel_catalog::catalog()
+        .find(|m| {
+            keel_catalog::namespace_id(m.namespace) == Some(ns_id) && m.method_id == method_id
+        })
+        .ok_or_else(|| {
+            format!(
+                "CallTarget::Ns references an unknown method (ns_id={ns_id}, method_id={method_id})"
+            )
+        })?;
+
+    let required = builtin.params.iter().filter(|p| !p.optional).count();
+    if args.len() < required || args.len() > builtin.params.len() {
+        return Err(format!(
+            "call to `{}.{}` passes {} arg(s), method takes {required}-{}",
+            builtin.namespace,
+            builtin.name,
+            args.len(),
+            builtin.params.len()
+        ));
+    }
+
+    let keel_catalog::builtins::BuiltinResult::Fixed(spec) = builtin.result else {
+        return Err(format!(
+            "call to `{}.{}` has a runtime-context-dependent result type, not representable \
+             as a KirType yet",
+            builtin.namespace, builtin.name
+        ));
+    };
+    if KirType::from_tyspec(spec) != Some(ty) {
+        return Err(format!(
+            "call to `{}.{}` has result type {ty} but the catalog says {spec:?}",
+            builtin.namespace, builtin.name
+        ));
+    }
+    Ok(())
 }

--- a/crates/keel-kir/src/types.rs
+++ b/crates/keel-kir/src/types.rs
@@ -43,6 +43,40 @@ impl KirType {
     pub const fn is_numeric(self) -> bool {
         matches!(self, KirType::I64 | KirType::F64)
     }
+
+    /// Maps a catalog [`keel_catalog::builtins::TySpec`] to the equivalent
+    /// `KirType`, for the scalar subset a stdlib namespace method can take
+    /// or return in M1. `None` for anything needing boxing, containers, or
+    /// nullable (M2+) — callers reject those with a `LowerError`/
+    /// `VerifyError` naming the construct, not a panic.
+    #[must_use]
+    pub fn from_tyspec(spec: keel_catalog::builtins::TySpec) -> Option<KirType> {
+        use keel_catalog::builtins::TySpec;
+        match spec {
+            TySpec::Int => Some(KirType::I64),
+            TySpec::Float => Some(KirType::F64),
+            TySpec::Bool => Some(KirType::Bool),
+            TySpec::Str => Some(KirType::Str),
+            TySpec::None_ => Some(KirType::Unit),
+            TySpec::Datetime
+            | TySpec::Duration
+            | TySpec::Uuid
+            | TySpec::Dynamic
+            | TySpec::DbConnection
+            | TySpec::NullableStr
+            | TySpec::NullableInt
+            | TySpec::NullableFloat
+            | TySpec::NullableUuid
+            | TySpec::NullableDatetime
+            | TySpec::NullableDynamic
+            | TySpec::ListOfStr
+            | TySpec::ListOfInt
+            | TySpec::ListOfListOfStr
+            | TySpec::ListOfMapStrStr
+            | TySpec::ListOfMapStrDynamic
+            | TySpec::Unknown => None,
+        }
+    }
 }
 
 impl std::fmt::Display for KirType {

--- a/crates/keel-kir/tests/fixtures/ns_call.keel
+++ b/crates/keel-kir/tests/fixtures/ns_call.keel
@@ -1,0 +1,5 @@
+use std/io
+use std/log
+
+io.show("hello")
+log.info("started")

--- a/crates/keel-kir/tests/fixtures/ns_call.kir
+++ b/crates/keel-kir/tests/fixtures/ns_call.kir
@@ -1,0 +1,4 @@
+fn <toplevel>() -> none {
+  io.show("hello")
+  log.info("started")
+}

--- a/crates/keel-kir/tests/lower_errors.rs
+++ b/crates/keel-kir/tests/lower_errors.rs
@@ -154,3 +154,90 @@ x = add(1)
     );
     assert!(msg.contains("argument"), "unexpected message: {msg}");
 }
+
+#[test]
+fn unknown_std_module_is_rejected() {
+    let msg = lower_err("use std/bogus\n");
+    assert!(
+        msg.contains("unknown std module"),
+        "unexpected message: {msg}"
+    );
+}
+
+#[test]
+fn file_path_use_import_is_rejected() {
+    let msg = lower_err("use \"./other.keel\"\n");
+    assert!(msg.contains("file-path"), "unexpected message: {msg}");
+}
+
+#[test]
+fn symbol_list_use_import_is_rejected() {
+    let msg = lower_err("use read from std/file\n");
+    assert!(msg.contains("symbol-list"), "unexpected message: {msg}");
+}
+
+#[test]
+fn unknown_namespace_method_is_rejected() {
+    let msg = lower_err(
+        r#"
+use std/io
+
+io.nonexistent("hi")
+"#,
+    );
+    assert!(msg.contains("has no method"), "unexpected message: {msg}");
+}
+
+#[test]
+fn namespace_call_wrong_arg_count_is_rejected() {
+    let msg = lower_err(
+        r#"
+use std/io
+
+io.show()
+"#,
+    );
+    assert!(msg.contains("argument"), "unexpected message: {msg}");
+}
+
+#[test]
+fn named_argument_to_namespace_call_is_rejected() {
+    let msg = lower_err(
+        r#"
+use std/io
+
+io.show(value: "hi")
+"#,
+    );
+    assert!(msg.contains("named or spread"), "unexpected message: {msg}");
+}
+
+#[test]
+fn namespace_method_with_dynamic_result_is_rejected() {
+    // `env.get` returns `TySpec::NullableStr`, which has no `KirType`
+    // equivalent until nullable types land (M2+).
+    let msg = lower_err(
+        r#"
+use std/env
+
+x = env.get("HOME")
+"#,
+    );
+    assert!(msg.contains("M2+ types"), "unexpected message: {msg}");
+}
+
+#[test]
+fn local_shadowing_a_namespace_binding_is_not_lowered_as_a_namespace_call() {
+    // Mirrors the checker's "lexical locals shadow globals" rule
+    // (`db = db.connect(...)` rebinds `db`) — once `io` is a local, `io.foo()`
+    // is an ordinary (unsupported) value method call, not a namespace call.
+    let msg = lower_err(
+        r#"
+use std/io
+
+io = 5
+io.show("hi")
+"#,
+    );
+    assert!(msg.contains("method call"), "unexpected message: {msg}");
+}


### PR DESCRIPTION
## Summary
- Adds `CallTarget::Ns { ns_id, method_id }` to KIR's call expression, resolved from the catalog ids at lowering time.
- Teaches lowering to accept `use std/<name>` declarations (previously rejected outright) — flat stdlib module imports only; file-path and symbol-list imports stay rejected pending multi-module lowering.
- Lowers `io.show(...)`/`log.*(...)` (namespace calls) to `CallTarget::Ns`. Note: the parser produces `ast::Expr::MethodCall` for all dot-call syntax, not `Call` with a `FieldAccess` callee — the namespace-call recognition lives in the `MethodCall` arm and respects the checker's "lexical locals shadow globals" precedence (a local named `io` shadows the namespace).
- Result types resolve via a new `KirType::from_tyspec` mapping; most of the catalog is `dynamic`-typed (needs the M2/M3 boxing pass) and is rejected with a clear error rather than approximated.
- Extends `dump.rs` (renders `namespace.method(...)`, resolved back from the numeric ids purely for readability) and `passes/verify.rs`.

Verified end-to-end via `keel build --emit=kir` on a real `use std/io` + `io.show(...)` + `use std/log` + `log.info(...)` program, matching #130's exit criterion exactly.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` and `--features build-backend` variant
- [x] `cargo test --workspace --features build-backend` (all green — 18 `keel-kir` lowering-rejection tests, including 8 new ones, plus a new golden-dump fixture)
- [x] Manual `keel build --emit=kir` smoke test

Close #130