### PR TITLE
keel-codegen: if/while/for and direct task calls

### DIFF
--- a/crates/keel-codegen/src/expr.rs
+++ b/crates/keel-codegen/src/expr.rs
@@ -1,11 +1,12 @@
-//! Expression codegen — M1 walking-skeleton scope: literals, locals,
-//! arithmetic/comparison/logical binary ops, unary `-`/`not`. `str` and
-//! calls are rejected (see `layout.rs` and issues #133/#135).
+//! Expression codegen: literals, locals, arithmetic/comparison/logical
+//! binary ops, unary `-`/`not`, and direct `CallTarget::Fn` calls between
+//! compiled Keel functions. `str` literals and `CallTarget::Ns` (namespace
+//! dispatch) are rejected — see `layout.rs` and issue #135.
 
-use inkwell::values::BasicValueEnum;
+use inkwell::values::{BasicMetadataValueEnum, BasicValueEnum, ValueKind};
 use inkwell::{FloatPredicate, IntPredicate};
 
-use keel_kir::ir::{BinOp, Expr, UnOp};
+use keel_kir::ir::{BinOp, CallTarget, Expr, UnOp};
 use keel_kir::types::KirType;
 
 use crate::CodegenError;
@@ -52,9 +53,45 @@ pub(crate) fn emit_expr<'ctx>(
             op, left, right, ..
         } => emit_binop(fcx, *op, left, right),
         Expr::UnOp { op, operand, .. } => emit_unop(fcx, *op, operand),
-        Expr::Call { .. } => Err(CodegenError::Unsupported(
-            "function calls (issue #133)".to_string(),
-        )),
+        Expr::Call {
+            target, args, ty, ..
+        } => emit_call(fcx, *target, args, *ty),
+    }
+}
+
+fn emit_call<'ctx>(
+    fcx: &FuncCtx<'ctx, '_>,
+    target: CallTarget,
+    args: &[Expr],
+    ty: KirType,
+) -> Result<BasicValueEnum<'ctx>, CodegenError> {
+    let CallTarget::Fn(func_id) = target else {
+        return Err(CodegenError::Unsupported(
+            "namespace method calls (issue #135)".to_string(),
+        ));
+    };
+    let callee = fcx.functions[func_id]
+        .expect("declare_functions declares every non-toplevel FuncId before any body is emitted");
+
+    let mut arg_values: Vec<BasicMetadataValueEnum> = Vec::with_capacity(args.len());
+    for arg in args {
+        arg_values.push(emit_expr(fcx, arg)?.into());
+    }
+
+    let call = fcx
+        .builder
+        .build_call(callee, &arg_values, "call")
+        .map_err(llvm_err)?;
+
+    match call.try_as_basic_value() {
+        ValueKind::Basic(v) => Ok(v),
+        // A Unit-returning (void) call. `ty` is Unit too (verified KIR), so
+        // no caller ever inspects this value — the exit-code convention in
+        // `func.rs` and every other consumer branch on `ty` first.
+        ValueKind::Instruction(_) => {
+            debug_assert_eq!(ty, KirType::Unit);
+            Ok(fcx.context.bool_type().const_zero().into())
+        }
     }
 }
 

--- a/crates/keel-codegen/src/func.rs
+++ b/crates/keel-codegen/src/func.rs
@@ -1,53 +1,130 @@
-//! Emits the M1 walking-skeleton `main`: runs the program's `toplevel` KIR
-//! function's statements directly inside `main`'s body (no separate LLVM
-//! function for it yet — that starts once `keel_rt_start` needs something to
-//! call it, see issue #134) and computes a process exit code from it.
+//! Function emission.
 //!
-//! # The M1 entry/exit convention (temporary, replaced by #134)
+//! Every `KirFunction` except the synthetic `toplevel` one compiles to a
+//! real, separate LLVM function — `emit_function` — so `CallTarget::Fn`
+//! calls between them are ordinary LLVM `call` instructions. `toplevel`'s
+//! statements are still inlined directly into `main` (`emit_main`), exactly
+//! as in the M1 walking-skeleton (issue #132): real top-level Keel
+//! statements always lower to a `Unit`-returning function with no way to
+//! produce a computed exit code, so `main`'s "bare `int` expression ->
+//! process exit code" convention documented there is unchanged — it's
+//! replaced wholesale once `main` calls `keel_rt_start` (issue #134).
 //!
-//! Real top-level Keel statements always lower to a `Unit`-returning
-//! `toplevel` KIR function (`keel-kir` forces this — top-level `return
-//! <value>` is a type error), so there is no way for real source to make
-//! `main` exit with a *computed* value yet: there's no `keel_rt_start`/
-//! `io.*`/process-exit surface wired up. So, for this issue's "prove object
-//! emission + linking" exit criterion only: if the toplevel function's last
-//! statement is a bare `int` expression (e.g. a file whose only content is
-//! `2 + 2 * 10`), its value becomes the process exit code (truncated to
-//! `i32`, mirroring how returning a value from a hosted C `main` becomes its
-//! exit status); otherwise `main` exits `0`. This has nothing to do with
-//! Keel's `return` statement, and this whole function is replaced wholesale
-//! once #134 wires `main` to call `keel_rt_start` instead.
+//! # Basic-block wiring
+//!
+//! `stmt.rs` builds real LLVM basic blocks for `if`/`while`/`for` (branches,
+//! loop header/body/exit) and relies on LLVM's `mem2reg` to turn the
+//! `alloca`-based locals back into SSA registers later, per
+//! `designs/llvm-compilation.md` §2.3's structured-IR rationale — this crate
+//! does no manual CFG/SSA construction of its own.
 
 use std::collections::HashMap;
 
 use inkwell::builder::Builder;
 use inkwell::context::Context;
 use inkwell::module::Module;
-use inkwell::values::{BasicValueEnum, PointerValue};
+use inkwell::types::BasicType;
+use inkwell::values::{BasicValueEnum, FunctionValue, PointerValue};
 
-use keel_kir::ir::{KirProgram, LocalId};
+use keel_kir::ir::{KirFunction, KirProgram, LocalId};
 use keel_kir::types::KirType;
 
 use crate::CodegenError;
 use crate::stmt;
 
-/// Per-function codegen state: where each KIR local's `alloca` lives.
-/// M1 only ever compiles one function (see the module doc), so this never
-/// needs a call stack of these — `func.rs` in later issues will change that.
-pub(crate) struct FuncCtx<'ctx, 'a> {
-    pub(crate) context: &'ctx Context,
-    pub(crate) builder: &'a Builder<'ctx>,
-    pub(crate) locals: HashMap<LocalId, PointerValue<'ctx>>,
-}
-
-fn llvm_err(e: impl std::fmt::Display) -> CodegenError {
+pub(crate) fn llvm_err(e: impl std::fmt::Display) -> CodegenError {
     CodegenError::Llvm(e.to_string())
 }
 
+/// Per-function codegen state, shared by every statement/expression walker.
+pub(crate) struct FuncCtx<'ctx, 'a> {
+    pub(crate) context: &'ctx Context,
+    pub(crate) builder: &'a Builder<'ctx>,
+    /// The LLVM function currently being emitted into — needed to attach
+    /// new basic blocks (`if`/`while`/`for` wiring).
+    pub(crate) function: FunctionValue<'ctx>,
+    /// Every non-`toplevel` `KirFunction`'s compiled `FunctionValue`,
+    /// indexed by `FuncId`, resolved up front (before any body is emitted)
+    /// so forward/mutual/recursive `CallTarget::Fn` calls resolve. The
+    /// `toplevel` slot is `None` — nothing ever calls it by `FuncId`.
+    pub(crate) functions: &'a [Option<FunctionValue<'ctx>>],
+    /// `true` while emitting `toplevel`'s statements inline into `main`.
+    /// `return` is rejected in that context (see the module doc) rather
+    /// than given ad hoc exit-code semantics.
+    pub(crate) is_toplevel_in_main: bool,
+    pub(crate) locals: HashMap<LocalId, PointerValue<'ctx>>,
+}
+
+/// Declares (signature only, no body) every `KirFunction` except
+/// `program.toplevel`, so calls between them resolve regardless of
+/// declaration order.
+pub(crate) fn declare_functions<'ctx>(
+    context: &'ctx Context,
+    module: &Module<'ctx>,
+    program: &KirProgram,
+) -> Result<Vec<Option<FunctionValue<'ctx>>>, CodegenError> {
+    let mut functions = vec![None; program.functions.len()];
+    for (id, func) in program.functions.iter().enumerate() {
+        if id == program.toplevel {
+            continue;
+        }
+        let param_types = func
+            .params
+            .iter()
+            .map(|p| crate::layout::llvm_type(context, p.ty).map(Into::into))
+            .collect::<Result<Vec<_>, _>>()?;
+        let fn_type = match func.ret {
+            KirType::Unit => context.void_type().fn_type(&param_types, false),
+            other => crate::layout::llvm_type(context, other)?.fn_type(&param_types, false),
+        };
+        functions[id] = Some(module.add_function(&func.name, fn_type, None));
+    }
+    Ok(functions)
+}
+
+/// Emits `func`'s body into its already-declared `function_value`.
+pub(crate) fn emit_function<'ctx>(
+    context: &'ctx Context,
+    builder: &Builder<'ctx>,
+    functions: &[Option<FunctionValue<'ctx>>],
+    func: &KirFunction,
+    function_value: FunctionValue<'ctx>,
+) -> Result<(), CodegenError> {
+    let entry = context.append_basic_block(function_value, "entry");
+    builder.position_at_end(entry);
+
+    let mut fcx = FuncCtx {
+        context,
+        builder,
+        function: function_value,
+        functions,
+        is_toplevel_in_main: false,
+        locals: HashMap::new(),
+    };
+
+    for (i, param) in func.params.iter().enumerate() {
+        let ty = crate::layout::llvm_type(context, param.ty)?;
+        let ptr = builder
+            .build_alloca(ty, &format!("local.{}", param.local))
+            .map_err(llvm_err)?;
+        let incoming = function_value
+            .get_nth_param(u32::try_from(i).expect("param index fits u32"))
+            .expect("verified KIR: param count matches the declared signature");
+        builder.build_store(ptr, incoming).map_err(llvm_err)?;
+        fcx.locals.insert(param.local, ptr);
+    }
+
+    stmt::emit_block(&mut fcx, &func.body)?;
+    finish_block(&fcx, func.ret)
+}
+
+/// Emits `main`, running `program.toplevel`'s statements directly in its
+/// body. See the module doc for the exit-code convention.
 pub(crate) fn emit_main<'ctx>(
     context: &'ctx Context,
     module: &Module<'ctx>,
     builder: &Builder<'ctx>,
+    functions: &[Option<FunctionValue<'ctx>>],
     program: &KirProgram,
 ) -> Result<(), CodegenError> {
     let i32_type = context.i32_type();
@@ -60,6 +137,9 @@ pub(crate) fn emit_main<'ctx>(
     let mut fcx = FuncCtx {
         context,
         builder,
+        function: main_fn,
+        functions,
+        is_toplevel_in_main: true,
         locals: HashMap::new(),
     };
     let last = stmt::emit_block(&mut fcx, &toplevel.body)?;
@@ -70,6 +150,35 @@ pub(crate) fn emit_main<'ctx>(
             .map_err(llvm_err)?,
         _ => i32_type.const_zero(),
     };
-    builder.build_return(Some(&exit_code)).map_err(llvm_err)?;
+    if !block_is_terminated(builder) {
+        builder.build_return(Some(&exit_code)).map_err(llvm_err)?;
+    }
+    Ok(())
+}
+
+/// `true` if the builder's current insertion block already ends in a
+/// terminator (a `return`, or both arms of an enclosing `if` already
+/// returned) — emitting another one after it would be invalid LLVM IR.
+pub(crate) fn block_is_terminated(builder: &Builder) -> bool {
+    builder
+        .get_insert_block()
+        .is_some_and(|bb| bb.get_terminator().is_some())
+}
+
+/// Adds a fallback terminator if the function's last block fell off the end
+/// without one. `keel check` requires every path through a non-`none`-typed
+/// task to return (this crate does not re-derive that guarantee — see
+/// AGENTS.md "trust internal invariants"), so `unreachable` is the correct
+/// terminator for a scalar-returning function's fallthrough: a well-typed
+/// program never actually reaches it.
+fn finish_block(fcx: &FuncCtx, ret_ty: KirType) -> Result<(), CodegenError> {
+    if block_is_terminated(fcx.builder) {
+        return Ok(());
+    }
+    if ret_ty == KirType::Unit {
+        fcx.builder.build_return(None).map_err(llvm_err)?;
+    } else {
+        fcx.builder.build_unreachable().map_err(llvm_err)?;
+    }
     Ok(())
 }

--- a/crates/keel-codegen/src/lib.rs
+++ b/crates/keel-codegen/src/lib.rs
@@ -2,16 +2,15 @@
 //! (`designs/llvm-compilation.md` §2.2). The only crate in the workspace
 //! that links LLVM; gated behind the root crate's `build-backend` feature.
 //!
-//! # M1 walking-skeleton scope
+//! # M1 scope
 //!
-//! This is the narrowest vertical slice that proves the codegen/link/run
-//! loop end to end: scalar arithmetic on `int`/`float`/`bool` only, a single
-//! compiled function (no cross-function `Call`, no `if`/`while`/`for` — see
-//! `designs/llvm-compilation.md` §4 M1 and issue #133), no runtime, no I/O.
-//! `compile` emits a bare C-style `main` that runs the program's `toplevel`
-//! KIR function and exits with a computed value — see the module doc on
-//! [`func`] for exactly how, and why that's a temporary M1-only convention
-//! superseded once `keel_rt_start` lands (issue #134).
+//! Scalar arithmetic on `int`/`float`/`bool`, `if`/`else`, `while`, `for`
+//! over a range, and direct calls between compiled tasks (`CallTarget::Fn`)
+//! — still no runtime and no I/O (`CallTarget::Ns` namespace dispatch lands
+//! in #135). `compile` emits a bare C-style `main` that runs the program's
+//! `toplevel` KIR function and exits with a computed value — see the module
+//! doc on [`func`] for exactly how, and why that's a temporary M1-only
+//! convention superseded once `keel_rt_start` lands (issue #134).
 //!
 //! Entry point: [`compile`].
 
@@ -93,7 +92,24 @@ pub fn compile(program: &KirProgram, opts: &BuildOptions) -> Result<PathBuf, Cod
     let module = llvm_context.create_module("keel_program");
     let builder = llvm_context.create_builder();
 
-    func::emit_main(&llvm_context, &module, &builder, program)?;
+    // Declare every non-`toplevel` function up front (so forward/mutual/
+    // recursive calls resolve), then emit bodies, then `main` (which inlines
+    // `toplevel` — see `func.rs`'s module doc).
+    let functions = func::declare_functions(&llvm_context, &module, program)?;
+    for (id, kir_func) in program.functions.iter().enumerate() {
+        if id == program.toplevel {
+            continue;
+        }
+        let function_value = functions[id].expect("declared above");
+        func::emit_function(
+            &llvm_context,
+            &builder,
+            &functions,
+            kir_func,
+            function_value,
+        )?;
+    }
+    func::emit_main(&llvm_context, &module, &builder, &functions, program)?;
 
     module
         .verify()

--- a/crates/keel-codegen/src/stmt.rs
+++ b/crates/keel-codegen/src/stmt.rs
@@ -1,7 +1,9 @@
-//! Statement codegen — M1 walking-skeleton scope only: `let`/assign and bare
-//! expression statements. `if`/`while`/`for`/`return` land in issue #133
-//! (control flow needs basic-block wiring this crate doesn't have yet).
+//! Statement codegen: `let`/assign, bare expressions, `if`/`else`, `while`,
+//! `for` (indexed range loop), and `return`. Control flow builds real LLVM
+//! basic blocks and relies on `mem2reg` to recover SSA form from the
+//! `alloca`-based locals later — see `func.rs`'s module doc.
 
+use inkwell::IntPredicate;
 use inkwell::values::BasicValueEnum;
 
 use keel_kir::ir::{Block, Stmt};
@@ -9,22 +11,25 @@ use keel_kir::types::KirType;
 
 use crate::CodegenError;
 use crate::expr;
-use crate::func::FuncCtx;
+use crate::func::{FuncCtx, block_is_terminated, llvm_err};
 use crate::layout;
-
-fn llvm_err(e: impl std::fmt::Display) -> CodegenError {
-    CodegenError::Llvm(e.to_string())
-}
 
 /// Emits every statement in `block` in order. Returns the last statement's
 /// value *only* if that last statement was a bare `Stmt::Expr` — see
-/// `func.rs`'s module doc for why `emit_main` needs this.
+/// `func.rs`'s module doc for why `emit_main` needs this. Stops emitting
+/// (but keeps returning `Ok`) once the current block is terminated: any
+/// statement after a `return` is unreachable and — since KIR is structured,
+/// not CFG-based — dead code that would otherwise try to build IR after a
+/// terminator, which LLVM rejects.
 pub(crate) fn emit_block<'ctx>(
     fcx: &mut FuncCtx<'ctx, '_>,
     block: &Block,
 ) -> Result<Option<(BasicValueEnum<'ctx>, KirType)>, CodegenError> {
     let mut last = None;
     for s in block {
+        if block_is_terminated(fcx.builder) {
+            break;
+        }
         last = emit_stmt(fcx, s)?;
     }
     Ok(last)
@@ -56,13 +61,188 @@ fn emit_stmt<'ctx>(
             Ok(None)
         }
         Stmt::Expr(e) => Ok(Some((expr::emit_expr(fcx, e)?, e.ty()))),
-        Stmt::Return(_) => Err(CodegenError::Unsupported(
-            "return (function-level codegen lands in #133/#134)".to_string(),
-        )),
-        Stmt::If { .. } => Err(CodegenError::Unsupported(
-            "if/else (issue #133)".to_string(),
-        )),
-        Stmt::While { .. } => Err(CodegenError::Unsupported("while (issue #133)".to_string())),
-        Stmt::ForIndex { .. } => Err(CodegenError::Unsupported("for (issue #133)".to_string())),
+        Stmt::If {
+            cond,
+            then_branch,
+            else_branch,
+        } => {
+            emit_if(fcx, cond, then_branch, else_branch)?;
+            Ok(None)
+        }
+        Stmt::While { cond, body } => {
+            emit_while(fcx, cond, body)?;
+            Ok(None)
+        }
+        Stmt::ForIndex {
+            var,
+            low,
+            high,
+            body,
+        } => {
+            emit_for_index(fcx, *var, low, high, body)?;
+            Ok(None)
+        }
+        Stmt::Return(value) => {
+            emit_return(fcx, value.as_ref())?;
+            Ok(None)
+        }
     }
+}
+
+fn emit_if<'ctx>(
+    fcx: &mut FuncCtx<'ctx, '_>,
+    cond: &keel_kir::ir::Expr,
+    then_branch: &Block,
+    else_branch: &Block,
+) -> Result<(), CodegenError> {
+    let cond_v = expr::emit_expr(fcx, cond)?.into_int_value();
+
+    let then_bb = fcx.context.append_basic_block(fcx.function, "if.then");
+    let else_bb = fcx.context.append_basic_block(fcx.function, "if.else");
+    let merge_bb = fcx.context.append_basic_block(fcx.function, "if.merge");
+
+    fcx.builder
+        .build_conditional_branch(cond_v, then_bb, else_bb)
+        .map_err(llvm_err)?;
+
+    fcx.builder.position_at_end(then_bb);
+    emit_block(fcx, then_branch)?;
+    if !block_is_terminated(fcx.builder) {
+        fcx.builder
+            .build_unconditional_branch(merge_bb)
+            .map_err(llvm_err)?;
+    }
+
+    fcx.builder.position_at_end(else_bb);
+    emit_block(fcx, else_branch)?;
+    if !block_is_terminated(fcx.builder) {
+        fcx.builder
+            .build_unconditional_branch(merge_bb)
+            .map_err(llvm_err)?;
+    }
+
+    fcx.builder.position_at_end(merge_bb);
+    Ok(())
+}
+
+fn emit_while<'ctx>(
+    fcx: &mut FuncCtx<'ctx, '_>,
+    cond: &keel_kir::ir::Expr,
+    body: &Block,
+) -> Result<(), CodegenError> {
+    let cond_bb = fcx.context.append_basic_block(fcx.function, "while.cond");
+    let body_bb = fcx.context.append_basic_block(fcx.function, "while.body");
+    let end_bb = fcx.context.append_basic_block(fcx.function, "while.end");
+
+    fcx.builder
+        .build_unconditional_branch(cond_bb)
+        .map_err(llvm_err)?;
+
+    fcx.builder.position_at_end(cond_bb);
+    let cond_v = expr::emit_expr(fcx, cond)?.into_int_value();
+    fcx.builder
+        .build_conditional_branch(cond_v, body_bb, end_bb)
+        .map_err(llvm_err)?;
+
+    fcx.builder.position_at_end(body_bb);
+    emit_block(fcx, body)?;
+    if !block_is_terminated(fcx.builder) {
+        fcx.builder
+            .build_unconditional_branch(cond_bb)
+            .map_err(llvm_err)?;
+    }
+
+    fcx.builder.position_at_end(end_bb);
+    Ok(())
+}
+
+/// `for var in low..high { body }` — both bounds inclusive (matches the
+/// interpreter's `Value::Range`, see `keel-kir`'s `ForIndex` doc). `low`/
+/// `high` are evaluated once, before the loop; `var`'s `alloca` is
+/// (re-)initialized to `low` every time this statement is *reached*
+/// (correct even when nested inside an outer loop — a fixed-size `alloca`
+/// is one stack slot for the whole function call, not one per dynamic
+/// execution, so re-running this statement just re-stores into the same
+/// slot).
+fn emit_for_index<'ctx>(
+    fcx: &mut FuncCtx<'ctx, '_>,
+    var: keel_kir::ir::LocalId,
+    low: &keel_kir::ir::Expr,
+    high: &keel_kir::ir::Expr,
+    body: &Block,
+) -> Result<(), CodegenError> {
+    let low_v = expr::emit_expr(fcx, low)?.into_int_value();
+    let high_v = expr::emit_expr(fcx, high)?.into_int_value();
+
+    let i64_type = fcx.context.i64_type();
+    let var_ptr = fcx
+        .builder
+        .build_alloca(i64_type, &format!("local.{var}"))
+        .map_err(llvm_err)?;
+    fcx.builder.build_store(var_ptr, low_v).map_err(llvm_err)?;
+    fcx.locals.insert(var, var_ptr);
+
+    let cond_bb = fcx.context.append_basic_block(fcx.function, "for.cond");
+    let body_bb = fcx.context.append_basic_block(fcx.function, "for.body");
+    let end_bb = fcx.context.append_basic_block(fcx.function, "for.end");
+
+    fcx.builder
+        .build_unconditional_branch(cond_bb)
+        .map_err(llvm_err)?;
+
+    fcx.builder.position_at_end(cond_bb);
+    let cur = fcx
+        .builder
+        .build_load(i64_type, var_ptr, "for.cur")
+        .map_err(llvm_err)?
+        .into_int_value();
+    let cond_v = fcx
+        .builder
+        .build_int_compare(IntPredicate::SLE, cur, high_v, "for.test")
+        .map_err(llvm_err)?;
+    fcx.builder
+        .build_conditional_branch(cond_v, body_bb, end_bb)
+        .map_err(llvm_err)?;
+
+    fcx.builder.position_at_end(body_bb);
+    emit_block(fcx, body)?;
+    if !block_is_terminated(fcx.builder) {
+        let cur = fcx
+            .builder
+            .build_load(i64_type, var_ptr, "for.cur")
+            .map_err(llvm_err)?
+            .into_int_value();
+        let next = fcx
+            .builder
+            .build_int_add(cur, i64_type.const_int(1, false), "for.next")
+            .map_err(llvm_err)?;
+        fcx.builder.build_store(var_ptr, next).map_err(llvm_err)?;
+        fcx.builder
+            .build_unconditional_branch(cond_bb)
+            .map_err(llvm_err)?;
+    }
+
+    fcx.builder.position_at_end(end_bb);
+    Ok(())
+}
+
+fn emit_return<'ctx>(
+    fcx: &mut FuncCtx<'ctx, '_>,
+    value: Option<&keel_kir::ir::Expr>,
+) -> Result<(), CodegenError> {
+    if fcx.is_toplevel_in_main {
+        return Err(CodegenError::Unsupported(
+            "`return` in top-level code (M1 walking-skeleton scope — put it in a task)".to_string(),
+        ));
+    }
+    match value {
+        Some(e) => {
+            let v = expr::emit_expr(fcx, e)?;
+            fcx.builder.build_return(Some(&v)).map_err(llvm_err)?;
+        }
+        None => {
+            fcx.builder.build_return(None).map_err(llvm_err)?;
+        }
+    }
+    Ok(())
 }

--- a/crates/keel-codegen/tests/control_flow_and_calls.rs
+++ b/crates/keel-codegen/tests/control_flow_and_calls.rs
@@ -1,0 +1,235 @@
+//! Exit criterion for issue #133: a scalar-only `.keel` example using
+//! `if`/`else`, `while`, `for` over a range, and calls between compiled
+//! tasks compiles, links, and its exit code matches the independently
+//! computed value. See `func.rs`'s module doc: real top-level statements
+//! can't produce a computed exit code directly (no `return` at top level),
+//! so every fixture here ends with a *bare call* to a task — the call's
+//! `int` result becomes the exit code via the same convention #132
+//! established for bare arithmetic.
+
+use std::process::Command;
+
+use keel_codegen::{BuildOptions, CodegenError};
+
+fn compile_and_run(source: &str) -> i32 {
+    let (program, _named) =
+        keel_syntax::parse_source(source, "t.keel").expect("fixture must parse");
+    let kir = keel_kir::lower(&program, "t.keel").expect("fixture must lower to KIR");
+
+    let out_dir = tempfile::tempdir().expect("create temp out dir");
+    let opts = BuildOptions {
+        out_dir: out_dir.path().to_path_buf(),
+    };
+    let bin = keel_codegen::compile(&kir, &opts).expect("compile must succeed");
+
+    let run = Command::new(&bin).output().expect("run compiled binary");
+    run.status.code().expect("process exited via a signal")
+}
+
+fn compile_err(source: &str) -> CodegenError {
+    let (program, _named) =
+        keel_syntax::parse_source(source, "t.keel").expect("fixture must parse");
+    let kir = keel_kir::lower(&program, "t.keel").expect("fixture must lower to KIR");
+
+    let out_dir = tempfile::tempdir().expect("create temp out dir");
+    let opts = BuildOptions {
+        out_dir: out_dir.path().to_path_buf(),
+    };
+    keel_codegen::compile(&kir, &opts).expect_err("compile must be rejected")
+}
+
+#[test]
+fn if_else_selects_the_correct_branch() {
+    let source = r#"
+task classify(n: int) -> int {
+  if n < 0 {
+    return 1
+  } else {
+    return 2
+  }
+}
+
+classify(-5)
+"#;
+    assert_eq!(compile_and_run(source), 1);
+
+    let source = r#"
+task classify(n: int) -> int {
+  if n < 0 {
+    return 1
+  } else {
+    return 2
+  }
+}
+
+classify(5)
+"#;
+    assert_eq!(compile_and_run(source), 2);
+}
+
+#[test]
+fn if_without_else_falls_through_correctly() {
+    // No `else` — the non-taken-branch path must still reach `return total`
+    // (proves the `if.merge` block wiring works when `else_branch` is empty).
+    let source = r#"
+task bump(n: int) -> int {
+  total = n
+  if n < 10 {
+    total += 100
+  }
+  return total
+}
+
+bump(3)
+"#;
+    assert_eq!(compile_and_run(source), 103);
+
+    let source = r#"
+task bump(n: int) -> int {
+  total = n
+  if n < 10 {
+    total += 100
+  }
+  return total
+}
+
+bump(20)
+"#;
+    assert_eq!(compile_and_run(source), 20);
+}
+
+#[test]
+fn while_loop_computes_correct_sum() {
+    let source = r#"
+task sum_upto(n: int) -> int {
+  total = 0
+  i = 0
+  while i < n {
+    total += i
+    i += 1
+  }
+  return total
+}
+
+sum_upto(5)
+"#;
+    // 0 + 1 + 2 + 3 + 4 = 10
+    assert_eq!(compile_and_run(source), 10);
+}
+
+#[test]
+fn for_over_range_computes_correct_sum() {
+    let source = r#"
+task sum_range(n: int) -> int {
+  total = 0
+  for i in 0..n {
+    total += i
+  }
+  return total
+}
+
+sum_range(5)
+"#;
+    // Inclusive range: 0 + 1 + 2 + 3 + 4 + 5 = 15
+    assert_eq!(compile_and_run(source), 15);
+}
+
+#[test]
+fn calls_between_compiled_tasks_compose() {
+    let source = r#"
+task double(x: int) -> int {
+  return x * 2
+}
+
+task quadruple(x: int) -> int {
+  return double(double(x))
+}
+
+quadruple(3)
+"#;
+    assert_eq!(compile_and_run(source), 12);
+}
+
+#[test]
+fn forward_reference_to_a_later_declared_task_resolves() {
+    // `caller` is declared (and calls `callee`) before `callee`'s own
+    // declaration — proves declare_functions's up-front pass, not emission
+    // order, is what makes the call resolve.
+    let source = r#"
+task caller(x: int) -> int {
+  return callee(x) + 1
+}
+
+task callee(x: int) -> int {
+  return x * 10
+}
+
+caller(4)
+"#;
+    assert_eq!(compile_and_run(source), 41);
+}
+
+#[test]
+fn everything_together_matches_the_independently_computed_value() {
+    let source = r#"
+task classify(n: int) -> int {
+  if n < 0 {
+    return 1
+  } else {
+    return 2
+  }
+}
+
+task sum_upto(n: int) -> int {
+  total = 0
+  i = 0
+  while i < n {
+    total += i
+    i += 1
+  }
+  return total
+}
+
+task sum_range(n: int) -> int {
+  total = 0
+  for i in 0..n {
+    total += i
+  }
+  return total
+}
+
+task double(x: int) -> int {
+  return x * 2
+}
+
+task quadruple(x: int) -> int {
+  return double(double(x))
+}
+
+classify(-5) + sum_upto(5) + sum_range(5) + quadruple(3)
+"#;
+    // 1 + 10 + 15 + 12 = 38
+    assert_eq!(compile_and_run(source), 38);
+}
+
+#[test]
+fn return_in_top_level_code_is_still_rejected() {
+    // Real top-level statements always lower to a Unit-returning function
+    // (keel-kir forces this); `main`'s exit-code convention only handles a
+    // bare trailing `int` expression, not `return` — see func.rs.
+    let err = compile_err("return\n");
+    assert!(
+        matches!(err, CodegenError::Unsupported(ref msg) if msg.contains("top-level")),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn namespace_call_is_still_rejected() {
+    // CallTarget::Ns dispatch lands in #135 (keel_rt_call_ns).
+    let err = compile_err("use std/io\n\nio.show(\"hi\")\n");
+    assert!(
+        matches!(err, CodegenError::Unsupported(ref msg) if msg.contains("namespace method")),
+        "unexpected error: {err}"
+    );
+}

--- a/crates/keel-codegen/tests/walking_skeleton.rs
+++ b/crates/keel-codegen/tests/walking_skeleton.rs
@@ -88,15 +88,6 @@ fn str_expression_is_rejected_not_silently_dropped() {
 }
 
 #[test]
-fn top_level_if_is_rejected_not_silently_dropped() {
-    let err = compile_err("x = 1\nif x == 1 {\n  x = 2\n}\n");
-    assert!(
-        matches!(err, CodegenError::Unsupported(ref msg) if msg.contains("if/else")),
-        "unexpected error: {err}"
-    );
-}
-
-#[test]
 fn binary_actually_exists_on_disk() {
     let (_code, dir) = compile_and_run("1\n");
     let bin = dir.path().join("keel_program");


### PR DESCRIPTION
## Summary
- Every non-`toplevel` `KirFunction` now compiles to a real, separate LLVM function — declared up front in one pass (forward/mutual/recursive calls resolve regardless of source order), bodies emitted after. `toplevel` still inlines into `main` (walking-skeleton exit-code convention, unchanged).
- `if`/`else`, `while`, `for` build real LLVM basic blocks (branches, loop header/body/exit), tracking block termination so nested control flow (e.g. both `if` arms returning) composes correctly.
- `return` now works for real functions; still explicitly rejected inside top-level code (documented — that context has no return-based exit path yet).

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` and `--features build-backend` variant
- [x] `cargo test --workspace --features build-backend` (all green — 16 `keel-codegen` tests total, 9 new, covering if/else with and without `else`, while, for, direct calls including forward references, and a combined scenario, all verified by actually compiling/linking/running the binary)
- [x] Confirmed default (no `build-backend`) build/test stay LLVM-free

Close #133