### PR TITLE
Add keel-rt-ffi: runtime handshake for compiled binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1434,6 +1434,7 @@ dependencies = [
  "inkwell",
  "keel-kir",
  "keel-syntax",
+ "serde_json",
  "tempfile",
 ]
 
@@ -1497,6 +1498,17 @@ dependencies = [
  "tempfile",
  "tokio",
  "tower-lsp",
+]
+
+[[package]]
+name = "keel-rt-ffi"
+version = "0.2.4"
+dependencies = [
+ "keel-runtime",
+ "keel-syntax",
+ "miette",
+ "parking_lot",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/keel-codegen/Cargo.toml
+++ b/crates/keel-codegen/Cargo.toml
@@ -16,3 +16,4 @@ inkwell = { version = "0.9.0", features = ["llvm22-1"] }
 [dev-dependencies]
 keel-syntax = { path = "../keel-syntax" }
 tempfile = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/keel-codegen/src/func.rs
+++ b/crates/keel-codegen/src/func.rs
@@ -1,14 +1,19 @@
 //! Function emission.
 //!
-//! Every `KirFunction` except the synthetic `toplevel` one compiles to a
-//! real, separate LLVM function — `emit_function` — so `CallTarget::Fn`
-//! calls between them are ordinary LLVM `call` instructions. `toplevel`'s
-//! statements are still inlined directly into `main` (`emit_main`), exactly
-//! as in the M1 walking-skeleton (issue #132): real top-level Keel
-//! statements always lower to a `Unit`-returning function with no way to
-//! produce a computed exit code, so `main`'s "bare `int` expression ->
-//! process exit code" convention documented there is unchanged — it's
-//! replaced wholesale once `main` calls `keel_rt_start` (issue #134).
+//! Every `KirFunction`, including the synthetic `toplevel` one, compiles to
+//! a real, separate LLVM function — `emit_function` for ordinary functions,
+//! `emit_toplevel_function` for `toplevel` (named `keel_user_toplevel`, the
+//! symbol `keel-rt-ffi`'s `keel_rt_start` calls back into). `toplevel`'s KIR
+//! return type is always `Unit` (real top-level Keel statements have no
+//! `return <value>` to give one), so `keel_user_toplevel` keeps the M1
+//! "bare `int` expression -> process exit code" convention from the
+//! walking-skeleton (issue #132) as its *own* return value instead of
+//! `main`'s: a bare top-level `int` expression becomes the exit code, a bare
+//! `return` (with no value — the only form `keel_user_toplevel`'s KIR can
+//! contain) exits with code `0`, and falling off the end without either
+//! defaults to `0` too. `main` itself (`emit_main`) is now just a thin
+//! wrapper that calls `keel_rt_start` and returns its result — see
+//! `designs/llvm-compilation.md` §2.6 and issue #134.
 //!
 //! # Basic-block wiring
 //!
@@ -24,7 +29,7 @@ use inkwell::builder::Builder;
 use inkwell::context::Context;
 use inkwell::module::Module;
 use inkwell::types::BasicType;
-use inkwell::values::{BasicValueEnum, FunctionValue, PointerValue};
+use inkwell::values::{BasicValueEnum, FunctionValue, PointerValue, ValueKind};
 
 use keel_kir::ir::{KirFunction, KirProgram, LocalId};
 use keel_kir::types::KirType;
@@ -46,12 +51,13 @@ pub(crate) struct FuncCtx<'ctx, 'a> {
     /// Every non-`toplevel` `KirFunction`'s compiled `FunctionValue`,
     /// indexed by `FuncId`, resolved up front (before any body is emitted)
     /// so forward/mutual/recursive `CallTarget::Fn` calls resolve. The
-    /// `toplevel` slot is `None` — nothing ever calls it by `FuncId`.
+    /// `toplevel` slot is `None` — nothing ever calls it by `FuncId`
+    /// (`keel-rt-ffi` calls it by symbol name, `keel_user_toplevel`).
     pub(crate) functions: &'a [Option<FunctionValue<'ctx>>],
-    /// `true` while emitting `toplevel`'s statements inline into `main`.
-    /// `return` is rejected in that context (see the module doc) rather
-    /// than given ad hoc exit-code semantics.
-    pub(crate) is_toplevel_in_main: bool,
+    /// `true` while emitting `toplevel`'s body as `keel_user_toplevel`. A
+    /// bare `return` there (the only form `toplevel`'s KIR can contain —
+    /// see the module doc) means "exit 0 now" instead of `ret void`.
+    pub(crate) is_toplevel: bool,
     pub(crate) locals: HashMap<LocalId, PointerValue<'ctx>>,
 }
 
@@ -98,7 +104,7 @@ pub(crate) fn emit_function<'ctx>(
         builder,
         function: function_value,
         functions,
-        is_toplevel_in_main: false,
+        is_toplevel: false,
         locals: HashMap::new(),
     };
 
@@ -118,9 +124,11 @@ pub(crate) fn emit_function<'ctx>(
     finish_block(&fcx, func.ret)
 }
 
-/// Emits `main`, running `program.toplevel`'s statements directly in its
-/// body. See the module doc for the exit-code convention.
-pub(crate) fn emit_main<'ctx>(
+/// Emits `program.toplevel`'s body as a real function named
+/// `keel_user_toplevel` — the symbol `keel-rt-ffi`'s `keel_rt_start` calls
+/// back into once it has booted the runtime. See the module doc for the
+/// exit-code convention this function's `i32` return value follows.
+pub(crate) fn emit_toplevel_function<'ctx>(
     context: &'ctx Context,
     module: &Module<'ctx>,
     builder: &Builder<'ctx>,
@@ -128,31 +136,59 @@ pub(crate) fn emit_main<'ctx>(
     program: &KirProgram,
 ) -> Result<(), CodegenError> {
     let i32_type = context.i32_type();
-    let main_type = i32_type.fn_type(&[], false);
-    let main_fn = module.add_function("main", main_type, None);
-    let entry = context.append_basic_block(main_fn, "entry");
+    let fn_type = i32_type.fn_type(&[], false);
+    let toplevel_fn = module.add_function("keel_user_toplevel", fn_type, None);
+    let entry = context.append_basic_block(toplevel_fn, "entry");
     builder.position_at_end(entry);
 
     let toplevel = &program.functions[program.toplevel];
     let mut fcx = FuncCtx {
         context,
         builder,
-        function: main_fn,
+        function: toplevel_fn,
         functions,
-        is_toplevel_in_main: true,
+        is_toplevel: true,
         locals: HashMap::new(),
     };
     let last = stmt::emit_block(&mut fcx, &toplevel.body)?;
 
-    let exit_code = match last {
-        Some((BasicValueEnum::IntValue(v), KirType::I64)) => builder
-            .build_int_truncate(v, i32_type, "exit_code")
-            .map_err(llvm_err)?,
-        _ => i32_type.const_zero(),
-    };
     if !block_is_terminated(builder) {
+        let exit_code = match last {
+            Some((BasicValueEnum::IntValue(v), KirType::I64)) => builder
+                .build_int_truncate(v, i32_type, "exit_code")
+                .map_err(llvm_err)?,
+            _ => i32_type.const_zero(),
+        };
         builder.build_return(Some(&exit_code)).map_err(llvm_err)?;
     }
+    Ok(())
+}
+
+/// Emits `main` as a thin wrapper around `keel_rt_start` (defined in
+/// `keel-rt-ffi`, linked in via `BuildOptions::runtime_link_args`) — it boots
+/// the runtime and calls back into `keel_user_toplevel`, and `main` just
+/// propagates whatever it returns as the process exit code.
+pub(crate) fn emit_main<'ctx>(
+    context: &'ctx Context,
+    module: &Module<'ctx>,
+    builder: &Builder<'ctx>,
+) -> Result<(), CodegenError> {
+    let i32_type = context.i32_type();
+    let no_args_i32 = i32_type.fn_type(&[], false);
+
+    let main_fn = module.add_function("main", no_args_i32, None);
+    let entry = context.append_basic_block(main_fn, "entry");
+    builder.position_at_end(entry);
+
+    let rt_start_fn = module.add_function("keel_rt_start", no_args_i32, None);
+    let call = builder
+        .build_call(rt_start_fn, &[], "rt_start")
+        .map_err(llvm_err)?;
+    let result = match call.try_as_basic_value() {
+        ValueKind::Basic(v) => v,
+        ValueKind::Instruction(_) => unreachable!("keel_rt_start returns i32, never void"),
+    };
+    builder.build_return(Some(&result)).map_err(llvm_err)?;
     Ok(())
 }
 

--- a/crates/keel-codegen/src/lib.rs
+++ b/crates/keel-codegen/src/lib.rs
@@ -6,11 +6,12 @@
 //!
 //! Scalar arithmetic on `int`/`float`/`bool`, `if`/`else`, `while`, `for`
 //! over a range, and direct calls between compiled tasks (`CallTarget::Fn`)
-//! — still no runtime and no I/O (`CallTarget::Ns` namespace dispatch lands
-//! in #135). `compile` emits a bare C-style `main` that runs the program's
-//! `toplevel` KIR function and exits with a computed value — see the module
-//! doc on [`func`] for exactly how, and why that's a temporary M1-only
-//! convention superseded once `keel_rt_start` lands (issue #134).
+//! — still no I/O (`CallTarget::Ns` namespace dispatch lands in #135). The
+//! program's `toplevel` KIR function compiles to a real `keel_user_toplevel`
+//! function (see the module doc on [`func`] for the bare-`int`-expression ->
+//! exit-code convention it still follows), and the emitted `main` just calls
+//! into `keel_rt_start` (from the separate `keel-rt-ffi` crate) to boot the
+//! runtime and invoke it — see [`BuildOptions::runtime_link_args`].
 //!
 //! Entry point: [`compile`].
 
@@ -30,6 +31,13 @@ use keel_kir::ir::KirProgram;
 #[derive(Debug, Clone)]
 pub struct BuildOptions {
     pub out_dir: PathBuf,
+    /// Extra `cc` arguments needed to link the emitted `main` (which calls
+    /// `keel_rt_start`) against `libkeel_rt.a` — the archive's path followed
+    /// by its `native-static-libs` (platform-specific system libs a Rust
+    /// staticlib needs; see `rustc --print native-static-libs`). `keel-codegen`
+    /// treats this as opaque link input and never depends on `keel-rt-ffi`
+    /// itself, per the dependency rule in `designs/llvm-compilation.md` §2.2.
+    pub runtime_link_args: Vec<String>,
 }
 
 /// Everything that can go wrong turning a [`KirProgram`] into a running
@@ -93,8 +101,9 @@ pub fn compile(program: &KirProgram, opts: &BuildOptions) -> Result<PathBuf, Cod
     let builder = llvm_context.create_builder();
 
     // Declare every non-`toplevel` function up front (so forward/mutual/
-    // recursive calls resolve), then emit bodies, then `main` (which inlines
-    // `toplevel` — see `func.rs`'s module doc).
+    // recursive calls resolve), then emit bodies, then `toplevel` itself
+    // (as `keel_user_toplevel`), then the trivial `main` that hands off to
+    // `keel_rt_start`.
     let functions = func::declare_functions(&llvm_context, &module, program)?;
     for (id, kir_func) in program.functions.iter().enumerate() {
         if id == program.toplevel {
@@ -109,7 +118,8 @@ pub fn compile(program: &KirProgram, opts: &BuildOptions) -> Result<PathBuf, Cod
             function_value,
         )?;
     }
-    func::emit_main(&llvm_context, &module, &builder, &functions, program)?;
+    func::emit_toplevel_function(&llvm_context, &module, &builder, &functions, program)?;
+    func::emit_main(&llvm_context, &module, &builder)?;
 
     module
         .verify()
@@ -120,7 +130,7 @@ pub fn compile(program: &KirProgram, opts: &BuildOptions) -> Result<PathBuf, Cod
     let obj_path = opts.out_dir.join("keel_program.o");
     let bin_path = opts.out_dir.join("keel_program");
     link::emit_object(&machine, &module, &obj_path)?;
-    link::link_binary(&obj_path, &bin_path)?;
+    link::link_binary(&obj_path, &bin_path, &opts.runtime_link_args)?;
 
     Ok(bin_path)
 }

--- a/crates/keel-codegen/src/link.rs
+++ b/crates/keel-codegen/src/link.rs
@@ -22,9 +22,21 @@ pub(crate) fn emit_object(
 }
 
 /// Links `obj` into an executable at `bin` via the system `cc` driver.
-pub(crate) fn link_binary(obj: &Path, bin: &Path) -> Result<(), CodegenError> {
+///
+/// `extra_args` carries whatever the caller needs beyond the object file
+/// itself — e.g. `libkeel_rt.a`'s path plus its `native-static-libs` (see
+/// `BuildOptions::runtime_link_args`). `keel-codegen` never hardcodes that
+/// list itself: it's platform-specific (macOS system frameworks vs. glibc's
+/// `-ldl -lpthread`, …) and the caller is expected to derive it (e.g. via
+/// `rustc --print native-static-libs`), not guess it.
+pub(crate) fn link_binary(
+    obj: &Path,
+    bin: &Path,
+    extra_args: &[String],
+) -> Result<(), CodegenError> {
     let output = Command::new("cc")
         .arg(obj)
+        .args(extra_args)
         .arg("-o")
         .arg(bin)
         .output()

--- a/crates/keel-codegen/src/stmt.rs
+++ b/crates/keel-codegen/src/stmt.rs
@@ -230,10 +230,14 @@ fn emit_return<'ctx>(
     fcx: &mut FuncCtx<'ctx, '_>,
     value: Option<&keel_kir::ir::Expr>,
 ) -> Result<(), CodegenError> {
-    if fcx.is_toplevel_in_main {
-        return Err(CodegenError::Unsupported(
-            "`return` in top-level code (M1 walking-skeleton scope — put it in a task)".to_string(),
-        ));
+    if fcx.is_toplevel {
+        // `keel_kir`'s lowering never gives `toplevel` a `return <value>`
+        // (its KIR return type is always Unit), so `value` is always `None`
+        // here — a bare `return` in top-level code means "stop now, exit 0".
+        debug_assert!(value.is_none());
+        let zero = fcx.context.i32_type().const_zero();
+        fcx.builder.build_return(Some(&zero)).map_err(llvm_err)?;
+        return Ok(());
     }
     match value {
         Some(e) => {

--- a/crates/keel-codegen/tests/control_flow_and_calls.rs
+++ b/crates/keel-codegen/tests/control_flow_and_calls.rs
@@ -11,6 +11,9 @@ use std::process::Command;
 
 use keel_codegen::{BuildOptions, CodegenError};
 
+#[path = "support/mod.rs"]
+mod support;
+
 fn compile_and_run(source: &str) -> i32 {
     let (program, _named) =
         keel_syntax::parse_source(source, "t.keel").expect("fixture must parse");
@@ -19,6 +22,7 @@ fn compile_and_run(source: &str) -> i32 {
     let out_dir = tempfile::tempdir().expect("create temp out dir");
     let opts = BuildOptions {
         out_dir: out_dir.path().to_path_buf(),
+        runtime_link_args: support::runtime_link_args().clone(),
     };
     let bin = keel_codegen::compile(&kir, &opts).expect("compile must succeed");
 
@@ -34,6 +38,7 @@ fn compile_err(source: &str) -> CodegenError {
     let out_dir = tempfile::tempdir().expect("create temp out dir");
     let opts = BuildOptions {
         out_dir: out_dir.path().to_path_buf(),
+        runtime_link_args: support::runtime_link_args().clone(),
     };
     keel_codegen::compile(&kir, &opts).expect_err("compile must be rejected")
 }
@@ -213,15 +218,14 @@ classify(-5) + sum_upto(5) + sum_range(5) + quadruple(3)
 }
 
 #[test]
-fn return_in_top_level_code_is_still_rejected() {
+fn bare_return_in_top_level_code_exits_zero() {
     // Real top-level statements always lower to a Unit-returning function
-    // (keel-kir forces this); `main`'s exit-code convention only handles a
-    // bare trailing `int` expression, not `return` — see func.rs.
-    let err = compile_err("return\n");
-    assert!(
-        matches!(err, CodegenError::Unsupported(ref msg) if msg.contains("top-level")),
-        "unexpected error: {err}"
-    );
+    // (keel-kir forces this), so a bare top-level `return` never carries a
+    // value — `keel_user_toplevel` treats it as "stop now, exit 0" (see
+    // func.rs's module doc; issue #134 made toplevel a real function with
+    // its own exit-code convention instead of inlining into `main`).
+    let code = compile_and_run("return\n5\n");
+    assert_eq!(code, 0);
 }
 
 #[test]

--- a/crates/keel-codegen/tests/support/mod.rs
+++ b/crates/keel-codegen/tests/support/mod.rs
@@ -1,0 +1,96 @@
+//! Shared test helper: the `cc` arguments needed to link a compiled binary
+//! (whose `main` calls `keel_rt_start`) against `libkeel_rt.a`.
+//!
+//! `keel-codegen` itself never depends on `keel-rt-ffi` (see `BuildOptions::
+//! runtime_link_args`'s doc) — it's a sibling crate whose only connection to
+//! codegen is the `keel_rt_start` symbol resolved at link time. This helper
+//! builds it via `cargo build -p keel-rt-ffi` (no Cargo dependency edge
+//! needed) and derives the platform-specific native libs a Rust staticlib
+//! needs via `rustc --print native-static-libs`, rather than hardcoding a
+//! list that would silently be wrong on the `build-backend` CI job's Linux
+//! runner.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::OnceLock;
+
+pub fn runtime_link_args() -> &'static Vec<String> {
+    static ARGS: OnceLock<Vec<String>> = OnceLock::new();
+    ARGS.get_or_init(|| {
+        let mut args = vec![build_keel_rt_ffi_archive().to_string_lossy().into_owned()];
+        args.extend(native_static_libs());
+        args
+    })
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crates/keel-codegen has a parent (crates/)")
+        .parent()
+        .expect("crates/ has a parent (the workspace root)")
+        .to_path_buf()
+}
+
+fn build_keel_rt_ffi_archive() -> PathBuf {
+    let output = Command::new("cargo")
+        .current_dir(workspace_root())
+        .args([
+            "build",
+            "-p",
+            "keel-rt-ffi",
+            "--lib",
+            "--message-format=json",
+        ])
+        .output()
+        .expect("spawn `cargo build -p keel-rt-ffi`");
+    assert!(
+        output.status.success(),
+        "building keel-rt-ffi failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        let Ok(msg) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        if msg.get("reason").and_then(serde_json::Value::as_str) != Some("compiler-artifact") {
+            continue;
+        }
+        let Some(filenames) = msg.get("filenames").and_then(serde_json::Value::as_array) else {
+            continue;
+        };
+        for name in filenames {
+            if let Some(s) = name.as_str()
+                && s.ends_with(".a")
+            {
+                return PathBuf::from(s);
+            }
+        }
+    }
+    panic!("`cargo build -p keel-rt-ffi` did not report a `.a` artifact");
+}
+
+fn native_static_libs() -> Vec<String> {
+    let output = Command::new("cargo")
+        .current_dir(workspace_root())
+        .args([
+            "rustc",
+            "-p",
+            "keel-rt-ffi",
+            "--lib",
+            "-q",
+            "--",
+            "--print",
+            "native-static-libs",
+        ])
+        .output()
+        .expect("spawn `cargo rustc -p keel-rt-ffi`");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    for line in stderr.lines() {
+        if let Some((_, rest)) = line.split_once("native-static-libs:") {
+            return rest.split_whitespace().map(str::to_string).collect();
+        }
+    }
+    panic!("`cargo rustc -p keel-rt-ffi -- --print native-static-libs` gave no list:\n{stderr}");
+}

--- a/crates/keel-codegen/tests/support/mod.rs
+++ b/crates/keel-codegen/tests/support/mod.rs
@@ -19,6 +19,7 @@ pub fn runtime_link_args() -> &'static Vec<String> {
     ARGS.get_or_init(|| {
         let mut args = vec![build_keel_rt_ffi_archive().to_string_lossy().into_owned()];
         args.extend(native_static_libs());
+        eprintln!("keel-codegen tests: runtime link args: {args:?}");
         args
     })
 }
@@ -87,10 +88,15 @@ fn native_static_libs() -> Vec<String> {
         .output()
         .expect("spawn `cargo rustc -p keel-rt-ffi`");
     let stderr = String::from_utf8_lossy(&output.stderr);
-    for line in stderr.lines() {
-        if let Some((_, rest)) = line.split_once("native-static-libs:") {
-            return rest.split_whitespace().map(str::to_string).collect();
-        }
+    // Read the rest of `stderr` as one blob rather than line-by-line: rustc's
+    // diagnostic renderer can wrap a long native-static-libs list across
+    // multiple physical lines (this list is much longer on Linux's glibc
+    // than on macOS), and splitting on `.lines()` would silently drop
+    // whatever landed on the continuation line. `split_whitespace` treats
+    // the wrap's newline like any other separator, so this is safe either
+    // way — it's the last thing `--print` emits, nothing structured follows.
+    if let Some((_, rest)) = stderr.split_once("native-static-libs:") {
+        return rest.split_whitespace().map(str::to_string).collect();
     }
     panic!("`cargo rustc -p keel-rt-ffi -- --print native-static-libs` gave no list:\n{stderr}");
 }

--- a/crates/keel-codegen/tests/support/mod.rs
+++ b/crates/keel-codegen/tests/support/mod.rs
@@ -36,6 +36,7 @@ fn workspace_root() -> PathBuf {
 fn build_keel_rt_ffi_archive() -> PathBuf {
     let output = Command::new("cargo")
         .current_dir(workspace_root())
+        .env("CARGO_TERM_COLOR", "never")
         .args([
             "build",
             "-p",
@@ -75,12 +76,18 @@ fn build_keel_rt_ffi_archive() -> PathBuf {
 fn native_static_libs() -> Vec<String> {
     let output = Command::new("cargo")
         .current_dir(workspace_root())
+        // `CARGO_TERM_COLOR=always` (as CI sets globally) makes rustc wrap
+        // the last token of this diagnostic in an ANSI reset code (e.g.
+        // `-lc\x1b[0m`), which `cc`/`ld` then can't resolve as a library
+        // name — force color off regardless of the inherited environment.
+        .env("CARGO_TERM_COLOR", "never")
         .args([
             "rustc",
             "-p",
             "keel-rt-ffi",
             "--lib",
             "-q",
+            "--color=never",
             "--",
             "--print",
             "native-static-libs",

--- a/crates/keel-codegen/tests/walking_skeleton.rs
+++ b/crates/keel-codegen/tests/walking_skeleton.rs
@@ -12,6 +12,9 @@ use std::process::Command;
 
 use keel_codegen::{BuildOptions, CodegenError};
 
+#[path = "support/mod.rs"]
+mod support;
+
 fn compile_and_run(source: &str) -> (i32, tempfile::TempDir) {
     let (program, _named) =
         keel_syntax::parse_source(source, "t.keel").expect("fixture must parse");
@@ -20,6 +23,7 @@ fn compile_and_run(source: &str) -> (i32, tempfile::TempDir) {
     let out_dir = tempfile::tempdir().expect("create temp out dir");
     let opts = BuildOptions {
         out_dir: out_dir.path().to_path_buf(),
+        runtime_link_args: support::runtime_link_args().clone(),
     };
     let bin = keel_codegen::compile(&kir, &opts).expect("compile must succeed");
 
@@ -38,6 +42,7 @@ fn compile_err(source: &str) -> CodegenError {
     let out_dir = tempfile::tempdir().expect("create temp out dir");
     let opts = BuildOptions {
         out_dir: out_dir.path().to_path_buf(),
+        runtime_link_args: support::runtime_link_args().clone(),
     };
     keel_codegen::compile(&kir, &opts).expect_err("compile must be rejected")
 }

--- a/crates/keel-rt-ffi/Cargo.toml
+++ b/crates/keel-rt-ffi/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "keel-rt-ffi"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Runtime linkage for keel-codegen-compiled binaries: boots the same RuntimeContext/tokio/event-loop the interpreter uses today."
+publish = false
+
+[lib]
+name = "keel_rt"
+crate-type = ["staticlib", "rlib"]
+
+[lints]
+workspace = true
+
+[dependencies]
+keel-runtime = { path = "../keel-runtime" }
+keel-syntax = { path = "../keel-syntax" }
+tokio = { workspace = true }
+miette = { workspace = true }
+parking_lot = { workspace = true }

--- a/crates/keel-rt-ffi/src/host.rs
+++ b/crates/keel-rt-ffi/src/host.rs
@@ -1,0 +1,189 @@
+//! `CompiledHost` — the `Host` implementation backing `keel-codegen`-compiled
+//! binaries, mirroring `Interpreter`'s role in the tree-walking path (see
+//! `designs/llvm-compilation.md` §2.7). Compiled code has no closures, tasks,
+//! or agents of its own to dispatch back into (that's still the
+//! interpreter's job for anything this milestone doesn't compile), so most
+//! methods are unreachable for now and `todo!()` — they gain real bodies as
+//! later issues wire specific namespace calls through `keel_rt_call_ns`
+//! (#135) and beyond.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+
+use keel_runtime::interpreter::host::{Host, HostFuture, LiveAgents};
+use keel_runtime::interpreter::value::Value;
+use keel_runtime::interpreter::{BuiltinFn, CallArgValue, Event, Namespace};
+use keel_runtime::runtime::context::RuntimeContext;
+use keel_syntax::ast::{LambdaBody, LambdaParam, TaskDecl};
+use parking_lot::Mutex;
+use tokio::sync::mpsc;
+
+/// `Host` implementation for compiled binaries. Holds the same
+/// `RuntimeContext` (env, clock, LLM, file system, …) the interpreter uses;
+/// everything else a compiled program needs is either resolved at compile
+/// time (direct `CallTarget::Fn` calls never reach `Host`) or not yet
+/// supported (namespace dispatch beyond #135, agents, closures).
+pub struct CompiledHost {
+    runtime: Arc<RuntimeContext>,
+    live_agents: LiveAgents,
+}
+
+impl CompiledHost {
+    pub fn new(runtime: Arc<RuntimeContext>) -> Self {
+        Self {
+            runtime,
+            live_agents: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+}
+
+impl Host for CompiledHost {
+    fn runtime(&self) -> &Arc<RuntimeContext> {
+        &self.runtime
+    }
+
+    fn call_closure<'a>(
+        &'a mut self,
+        _params: &'a [LambdaParam],
+        _body: &'a LambdaBody,
+        _args: Vec<CallArgValue>,
+    ) -> HostFuture<'a, Value> {
+        todo!("compiled programs have no closures to dispatch back into (M1 scope)")
+    }
+
+    fn call_task<'a>(
+        &'a mut self,
+        _name: &'a str,
+        _decl: &'a TaskDecl,
+        _args: Vec<CallArgValue>,
+    ) -> HostFuture<'a, Value> {
+        todo!("compiled tasks are called directly via CallTarget::Fn, never through Host")
+    }
+
+    fn find_impl_task(&self, _value: &Value, _method: &str) -> Option<Arc<TaskDecl>> {
+        todo!("impl method dispatch is not compiled yet")
+    }
+
+    fn call_namespace_method<'a>(
+        &'a mut self,
+        _ns: &'a str,
+        _method: &'a str,
+        _args: Vec<CallArgValue>,
+    ) -> HostFuture<'a, Value> {
+        todo!("namespace dispatch lands in issue #135 (keel_rt_call_ns)")
+    }
+
+    fn start_agent<'a>(&'a mut self, _name: &'a str) -> HostFuture<'a, ()> {
+        todo!("agents are not compiled yet")
+    }
+
+    fn stop_agent<'a>(&'a mut self, _name: &'a str) -> HostFuture<'a, ()> {
+        todo!("agents are not compiled yet")
+    }
+
+    fn enqueue_event(&self, _event: Event) -> miette::Result<()> {
+        todo!("event dispatch is not compiled yet")
+    }
+
+    fn live_agents(&self) -> &LiveAgents {
+        &self.live_agents
+    }
+
+    fn current_agent_name(&self) -> Option<String> {
+        None
+    }
+
+    fn require_agent_context(&self, caller: &str) -> miette::Result<(String, String)> {
+        todo!("{caller}: agent context is not compiled yet")
+    }
+
+    fn current_memory_attr(&self) -> Option<String> {
+        None
+    }
+
+    fn current_model(&self) -> String {
+        "default".to_string()
+    }
+
+    fn current_provider(&self) -> Option<String> {
+        None
+    }
+
+    fn installed_provider(&self) -> Option<String> {
+        None
+    }
+
+    fn set_installed_provider(&mut self, _type_name: String) {
+        todo!("ai.install is not compiled yet")
+    }
+
+    fn provider_is_active(&self, _type_name: &str) -> bool {
+        false
+    }
+
+    fn push_active_provider(&mut self, _type_name: String) {
+        todo!("user-authored providers are not compiled yet")
+    }
+
+    fn pop_active_provider(&mut self, _type_name: &str) {
+        todo!("user-authored providers are not compiled yet")
+    }
+
+    fn current_max_tokens(&self) -> Option<u32> {
+        None
+    }
+
+    fn current_role(&self) -> Option<String> {
+        None
+    }
+
+    fn current_rules(&self) -> Vec<String> {
+        Vec::new()
+    }
+
+    fn enum_types(&self) -> &HashMap<String, Vec<String>> {
+        todo!("enum type registry is not compiled yet")
+    }
+
+    fn struct_types(&self) -> &HashMap<String, Vec<(String, String)>> {
+        todo!("struct type registry is not compiled yet")
+    }
+
+    fn background_event_tx(&self) -> mpsc::Sender<Event> {
+        todo!("event infrastructure is not compiled yet")
+    }
+
+    fn active_http_servers(&self) -> &Arc<AtomicU64> {
+        todo!("Http.serve is not compiled yet")
+    }
+
+    fn register_closure(
+        &mut self,
+        _agent_name: String,
+        _params: Vec<LambdaParam>,
+        _body: LambdaBody,
+    ) -> u64 {
+        todo!("closures are not compiled yet")
+    }
+
+    fn spawn_closure<'a>(
+        &'a mut self,
+        _params: Vec<LambdaParam>,
+        _body: LambdaBody,
+    ) -> HostFuture<'a, u64> {
+        todo!("Async.spawn is not compiled yet")
+    }
+
+    fn insert_global(&mut self, _name: String, _value: Value) {
+        todo!("prelude installation is not compiled yet")
+    }
+
+    fn register_namespace(&mut self, _ns: Namespace) {
+        todo!("prelude installation is not compiled yet")
+    }
+
+    fn register_top_fn(&mut self, _name: &str, _f: BuiltinFn) {
+        todo!("prelude installation is not compiled yet")
+    }
+}

--- a/crates/keel-rt-ffi/src/lib.rs
+++ b/crates/keel-rt-ffi/src/lib.rs
@@ -1,0 +1,13 @@
+//! `keel-rt-ffi` — the runtime-linkage layer for `keel-codegen`-compiled
+//! binaries (`designs/llvm-compilation.md` §2.2, §2.6). Builds to a static
+//! library (`libkeel_rt.a`) that a compiled program's linked binary embeds;
+//! never links LLVM.
+//!
+//! Entry point: [`keel_rt_start`], called from the `main` that `keel-codegen`
+//! emits.
+
+pub mod host;
+mod scheduler;
+
+pub use host::CompiledHost;
+pub use scheduler::keel_rt_start;

--- a/crates/keel-rt-ffi/src/scheduler.rs
+++ b/crates/keel-rt-ffi/src/scheduler.rs
@@ -1,0 +1,44 @@
+//! `keel_rt_start` — the handshake between a `keel-codegen`-linked binary's
+//! `main` and the Keel runtime. Boots a tokio runtime, constructs the same
+//! `RuntimeContext` the interpreter uses, and calls back into the compiled
+//! program's `keel_user_toplevel` (emitted by `keel-codegen`).
+
+use std::sync::Arc;
+
+use keel_runtime::runtime::context::RuntimeContext;
+
+use crate::host::CompiledHost;
+
+unsafe extern "C" {
+    /// Emitted by `keel-codegen` for every compiled program (`func.rs`'s
+    /// `emit_toplevel_function`). Returns the M1 exit-code-convention value.
+    fn keel_user_toplevel() -> i32;
+}
+
+/// Called from the linked binary's `main`. Boots tokio + `RuntimeContext`,
+/// then runs the compiled program's top-level code to completion.
+///
+/// # Safety
+///
+/// Must only be called once, from `main`, before any other keel-rt-ffi entry
+/// point — it owns process-wide startup (the tokio runtime).
+#[unsafe(no_mangle)]
+pub extern "C" fn keel_rt_start() -> i32 {
+    let tokio_rt = match tokio::runtime::Runtime::new() {
+        Ok(rt) => rt,
+        Err(e) => {
+            eprintln!("keel: failed to start async runtime: {e}");
+            return 1;
+        }
+    };
+
+    tokio_rt.block_on(async {
+        let runtime = RuntimeContext::native();
+        let _host = CompiledHost::new(Arc::clone(&runtime));
+
+        // SAFETY: `keel_user_toplevel` is emitted by keel-codegen for every
+        // compiled program; the object this crate is statically linked into
+        // always defines it.
+        unsafe { keel_user_toplevel() }
+    })
+}

--- a/crates/keel-rt-ffi/tests/handshake.rs
+++ b/crates/keel-rt-ffi/tests/handshake.rs
@@ -1,0 +1,16 @@
+//! Exit criterion for issue #134, isolated from `keel-codegen`/LLVM entirely:
+//! `keel_rt_start` boots tokio, constructs `RuntimeContext`/`CompiledHost`,
+//! and calls back into `keel_user_toplevel`, propagating its return value.
+//! In a real compiled binary that symbol is emitted by `keel-codegen`; here
+//! it's a plain mock linked into this test binary, so this test only proves
+//! the runtime handshake — `keel-codegen`'s own tests prove the link step.
+
+#[unsafe(no_mangle)]
+pub extern "C" fn keel_user_toplevel() -> i32 {
+    42
+}
+
+#[test]
+fn keel_rt_start_boots_and_runs_the_compiled_toplevel() {
+    assert_eq!(keel_rt::keel_rt_start(), 42);
+}


### PR DESCRIPTION
## Summary

- New `keel-rt-ffi` crate: `keel_rt_start` boots a tokio runtime + the same `RuntimeContext` the interpreter uses, then calls back into the compiled program's top-level function (`keel_user_toplevel`). Depends only on `keel-runtime`/`keel-syntax` — never LLVM.
- `CompiledHost` implements the `Host` trait backing that boot sequence; most methods are stubbed with `todo!()` since compiled code has no closures/tasks/agents of its own yet.
- `keel-codegen` now compiles `toplevel` to a real `keel_user_toplevel` function (instead of inlining it into `main`), and emits a trivial `main` that just calls `keel_rt_start` and returns its result. The M1 "bare `int` expression -> exit code" convention now lives on `keel_user_toplevel` itself.
- `BuildOptions` gained `runtime_link_args` so the caller supplies whatever `cc` needs to link against `libkeel_rt.a` (its path + platform-specific `native-static-libs`) — `keel-codegen` stays agnostic of `keel-rt-ffi` by name.
- Lifted the previous "`return` in top-level code is rejected" restriction: since `toplevel` is a real function now, a bare `return` there just means "exit 0."

Closes #134.

## Test plan

- [x] `keel-rt-ffi`'s own test (`tests/handshake.rs`) proves the tokio/RuntimeContext/CompiledHost boot handshake with a mock `keel_user_toplevel`, no LLVM involved.
- [x] All 16 existing `keel-codegen` exit-code tests pass unchanged against the new `main -> keel_rt_start -> keel_user_toplevel` path (now actually linking `libkeel_rt.a`).
- [x] `cargo test` (default, LLVM-free) and `cargo test --workspace --features build-backend` both green locally.
- [x] `cargo clippy --all-targets -- -D warnings` (default) and `cargo clippy --workspace --all-targets --features build-backend -- -D warnings` both clean.
- [x] Confirmed `cargo build` (root, default features) stays LLVM-free.