### PR TITLE
Wire namespace method calls through to the same runtime closures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1504,6 +1504,7 @@ dependencies = [
 name = "keel-rt-ffi"
 version = "0.2.4"
 dependencies = [
+ "keel-catalog",
  "keel-runtime",
  "keel-syntax",
  "miette",

--- a/crates/keel-catalog/src/lib.rs
+++ b/crates/keel-catalog/src/lib.rs
@@ -15,4 +15,7 @@ pub use providers::{
     BUILTIN_LLM_PROVIDERS, builtin_provider_prefix, is_builtin_llm_provider,
     provider_attribute_error,
 };
-pub use specs::{catalog, catalog_method, module_requires_capability, namespace_id};
+pub use specs::{
+    catalog, catalog_method, method_by_id, module_requires_capability, namespace_by_id,
+    namespace_id,
+};

--- a/crates/keel-catalog/src/specs/mod.rs
+++ b/crates/keel-catalog/src/specs/mod.rs
@@ -112,6 +112,26 @@ pub fn namespace_id(namespace: &str) -> Option<u16> {
         .map(|(_, id)| *id)
 }
 
+/// Reverse of [`namespace_id`] — the namespace name for a stable id.
+///
+/// Consumed by `keel-rt-ffi`'s `keel_rt_call_ns`, which only receives numeric
+/// ids across the FFI boundary and needs the name to dispatch through the
+/// existing (name-keyed) `Namespace.methods` registry.
+pub fn namespace_by_id(ns_id: u16) -> Option<&'static str> {
+    NAMESPACE_IDS
+        .iter()
+        .find(|(_, id)| *id == ns_id)
+        .map(|(name, _)| *name)
+}
+
+/// Reverse of [`BuiltinMethod::method_id`] — the method name for a
+/// `(namespace, method_id)` pair. See [`namespace_by_id`].
+pub fn method_by_id(namespace: &str, method_id: u16) -> Option<&'static str> {
+    catalog()
+        .find(|m| m.namespace == namespace && m.method_id == method_id)
+        .map(|m| m.name)
+}
+
 /// Modules whose entry points exercise authority over the world outside the
 /// process — network, filesystem, subprocesses, external services, ambient
 /// secrets, humans, and LLMs. Only these require an `@tools` capability.

--- a/crates/keel-codegen/src/expr.rs
+++ b/crates/keel-codegen/src/expr.rs
@@ -54,8 +54,11 @@ pub(crate) fn emit_expr<'ctx>(
         } => emit_binop(fcx, *op, left, right),
         Expr::UnOp { op, operand, .. } => emit_unop(fcx, *op, operand),
         Expr::Call {
-            target, args, ty, ..
-        } => emit_call(fcx, *target, args, *ty),
+            target,
+            args,
+            ty,
+            span,
+        } => emit_call(fcx, *target, args, *ty, *span),
     }
 }
 
@@ -64,11 +67,13 @@ fn emit_call<'ctx>(
     target: CallTarget,
     args: &[Expr],
     ty: KirType,
+    span: keel_kir::span_table::SpanId,
 ) -> Result<BasicValueEnum<'ctx>, CodegenError> {
-    let CallTarget::Fn(func_id) = target else {
-        return Err(CodegenError::Unsupported(
-            "namespace method calls (issue #135)".to_string(),
-        ));
+    let func_id = match target {
+        CallTarget::Fn(id) => id,
+        CallTarget::Ns { ns_id, method_id } => {
+            return crate::ns_call::emit_ns_call(fcx, ns_id, method_id, args, span);
+        }
     };
     let callee = fcx.functions[func_id]
         .expect("declare_functions declares every non-toplevel FuncId before any body is emitted");

--- a/crates/keel-codegen/src/func.rs
+++ b/crates/keel-codegen/src/func.rs
@@ -44,6 +44,7 @@ pub(crate) fn llvm_err(e: impl std::fmt::Display) -> CodegenError {
 /// Per-function codegen state, shared by every statement/expression walker.
 pub(crate) struct FuncCtx<'ctx, 'a> {
     pub(crate) context: &'ctx Context,
+    pub(crate) module: &'a Module<'ctx>,
     pub(crate) builder: &'a Builder<'ctx>,
     /// The LLVM function currently being emitted into — needed to attach
     /// new basic blocks (`if`/`while`/`for` wiring).
@@ -91,6 +92,7 @@ pub(crate) fn declare_functions<'ctx>(
 /// Emits `func`'s body into its already-declared `function_value`.
 pub(crate) fn emit_function<'ctx>(
     context: &'ctx Context,
+    module: &Module<'ctx>,
     builder: &Builder<'ctx>,
     functions: &[Option<FunctionValue<'ctx>>],
     func: &KirFunction,
@@ -101,6 +103,7 @@ pub(crate) fn emit_function<'ctx>(
 
     let mut fcx = FuncCtx {
         context,
+        module,
         builder,
         function: function_value,
         functions,
@@ -144,6 +147,7 @@ pub(crate) fn emit_toplevel_function<'ctx>(
     let toplevel = &program.functions[program.toplevel];
     let mut fcx = FuncCtx {
         context,
+        module,
         builder,
         function: toplevel_fn,
         functions,

--- a/crates/keel-codegen/src/lib.rs
+++ b/crates/keel-codegen/src/lib.rs
@@ -20,6 +20,7 @@ mod expr;
 mod func;
 mod layout;
 mod link;
+mod ns_call;
 mod stmt;
 
 use std::path::PathBuf;
@@ -112,6 +113,7 @@ pub fn compile(program: &KirProgram, opts: &BuildOptions) -> Result<PathBuf, Cod
         let function_value = functions[id].expect("declared above");
         func::emit_function(
             &llvm_context,
+            &module,
             &builder,
             &functions,
             kir_func,

--- a/crates/keel-codegen/src/ns_call.rs
+++ b/crates/keel-codegen/src/ns_call.rs
@@ -1,0 +1,235 @@
+//! `CallTarget::Ns` codegen: boxes each argument into a `KeelBox` (via the
+//! `keel_box_*` FFI helpers `keel-rt-ffi` exports) and calls the one
+//! generic `keel_rt_call_ns` dispatch entry point
+//! (`designs/llvm-compilation.md` §2.7). `ns_id`/`method_id` were already
+//! resolved and validated against the catalog at KIR-lowering time
+//! (`keel-kir`'s `lower_ns_call`) — codegen just has to get the two structs'
+//! ABI shapes byte-for-byte identical to `keel-rt-ffi`'s `#[repr(C)]`
+//! definitions (`abi::keel_box_*`, `ns_dispatch::KeelRes`).
+//!
+//! M1 only wires `Unit`-returning methods (`io.show`, `log.*` — enforced by
+//! `keel-kir` rejecting any other result type for now), so the returned
+//! `KeelRes` is built with the right calling convention but never inspected:
+//! there is no `try`/`catch` lowering yet to branch on `is_err`.
+
+use inkwell::AddressSpace;
+use inkwell::module::Module;
+use inkwell::types::FunctionType;
+use inkwell::values::{
+    BasicMetadataValueEnum, BasicValueEnum, FunctionValue, PointerValue, ValueKind,
+};
+
+use keel_kir::ir::Expr;
+use keel_kir::types::KirType;
+
+use crate::CodegenError;
+use crate::expr::emit_expr;
+use crate::func::FuncCtx;
+
+fn llvm_err(e: impl std::fmt::Display) -> CodegenError {
+    CodegenError::Llvm(e.to_string())
+}
+
+/// Returns `module`'s existing declaration of `name`, or declares one with
+/// `make_ty()`. Every `CallTarget::Ns` site in a program shares these few
+/// runtime-provided functions, so this avoids redeclaring (and LLVM
+/// silently renaming) them per call site.
+fn declare_or_get<'ctx>(
+    module: &Module<'ctx>,
+    name: &str,
+    make_ty: impl FnOnce() -> FunctionType<'ctx>,
+) -> FunctionValue<'ctx> {
+    module
+        .get_function(name)
+        .unwrap_or_else(|| module.add_function(name, make_ty(), None))
+}
+
+/// Calls a `keel_box_*` helper (always returns a non-null `KeelBox`, never
+/// void) and extracts the returned pointer.
+fn call_box_fn<'ctx>(
+    fcx: &FuncCtx<'ctx, '_>,
+    f: FunctionValue<'ctx>,
+    args: &[BasicMetadataValueEnum<'ctx>],
+) -> Result<PointerValue<'ctx>, CodegenError> {
+    let call = fcx.builder.build_call(f, args, "box").map_err(llvm_err)?;
+    match call.try_as_basic_value() {
+        ValueKind::Basic(v) => Ok(v.into_pointer_value()),
+        ValueKind::Instruction(_) => unreachable!("keel_box_* always returns a KeelBox pointer"),
+    }
+}
+
+fn emit_box_arg<'ctx>(
+    fcx: &FuncCtx<'ctx, '_>,
+    arg: &Expr,
+) -> Result<PointerValue<'ctx>, CodegenError> {
+    let ptr_type = fcx.context.ptr_type(AddressSpace::default());
+    match arg.ty() {
+        KirType::Str => {
+            let Expr::ConstStr(s) = arg else {
+                return Err(CodegenError::Unsupported(
+                    "non-constant `str` argument to a namespace call (M1 scope: `str` has no \
+                     locals or operations yet, only literals)"
+                        .to_string(),
+                ));
+            };
+            emit_box_str_const(fcx, s)
+        }
+        KirType::I64 => {
+            let v = emit_expr(fcx, arg)?.into_int_value();
+            let f = declare_or_get(fcx.module, "keel_box_int", || {
+                ptr_type.fn_type(&[fcx.context.i64_type().into()], false)
+            });
+            call_box_fn(fcx, f, &[v.into()])
+        }
+        KirType::F64 => {
+            let v = emit_expr(fcx, arg)?.into_float_value();
+            let f = declare_or_get(fcx.module, "keel_box_float", || {
+                ptr_type.fn_type(&[fcx.context.f64_type().into()], false)
+            });
+            call_box_fn(fcx, f, &[v.into()])
+        }
+        KirType::Bool => {
+            let v = emit_expr(fcx, arg)?.into_int_value();
+            // `keel_box_bool` takes a `u8` (see abi/mod.rs) — Bool is `i1` on
+            // the LLVM side (layout.rs), so widen it first.
+            let v8 = fcx
+                .builder
+                .build_int_z_extend(v, fcx.context.i8_type(), "bool_to_u8")
+                .map_err(llvm_err)?;
+            let f = declare_or_get(fcx.module, "keel_box_bool", || {
+                ptr_type.fn_type(&[fcx.context.i8_type().into()], false)
+            });
+            call_box_fn(fcx, f, &[v8.into()])
+        }
+        KirType::Unit => Err(CodegenError::Unsupported(
+            "unit-typed argument to a namespace call".to_string(),
+        )),
+    }
+}
+
+fn emit_box_str_const<'ctx>(
+    fcx: &FuncCtx<'ctx, '_>,
+    s: &str,
+) -> Result<PointerValue<'ctx>, CodegenError> {
+    let bytes = s.as_bytes();
+    let const_arr = fcx.context.const_string(bytes, false);
+    let arr_ty = fcx.context.i8_type().array_type(bytes.len() as u32);
+
+    // LLVM auto-uniquifies colliding global names (appends `.N`), so every
+    // string-literal call site can share this one literal name.
+    let global = fcx.module.add_global(arr_ty, None, "str_const");
+    global.set_initializer(&const_arr);
+    global.set_constant(true);
+    let ptr = global.as_pointer_value();
+    let len = fcx.context.i64_type().const_int(bytes.len() as u64, false);
+
+    let ptr_type = fcx.context.ptr_type(AddressSpace::default());
+    let f = declare_or_get(fcx.module, "keel_box_str", || {
+        ptr_type.fn_type(&[ptr_type.into(), fcx.context.i64_type().into()], false)
+    });
+    call_box_fn(fcx, f, &[ptr.into(), len.into()])
+}
+
+/// Emits a `CallTarget::Ns { ns_id, method_id }` call site: boxes every
+/// argument, builds the `args`/`arg_names` arrays `keel_rt_call_ns` expects,
+/// and calls it. `arg_names` is always all-null — `keel-kir`'s
+/// `lower_ns_call` already rejects named arguments to stdlib calls, so no
+/// compiled call site can produce one yet.
+pub(crate) fn emit_ns_call<'ctx>(
+    fcx: &FuncCtx<'ctx, '_>,
+    ns_id: u16,
+    method_id: u16,
+    args: &[Expr],
+    span_id: u32,
+) -> Result<BasicValueEnum<'ctx>, CodegenError> {
+    let ptr_type = fcx.context.ptr_type(AddressSpace::default());
+    let i16_type = fcx.context.i16_type();
+    let i32_type = fcx.context.i32_type();
+    let i8_type = fcx.context.i8_type();
+
+    let boxed: Vec<PointerValue<'ctx>> = args
+        .iter()
+        .map(|arg| emit_box_arg(fcx, arg))
+        .collect::<Result<_, _>>()?;
+
+    let nargs = u32::try_from(boxed.len()).expect("KIR call arg count fits u32");
+    let array_ty = ptr_type.array_type(nargs.max(1));
+    let args_alloca = fcx
+        .builder
+        .build_alloca(array_ty, "ns_args")
+        .map_err(llvm_err)?;
+    let names_alloca = fcx
+        .builder
+        .build_alloca(array_ty, "ns_arg_names")
+        .map_err(llvm_err)?;
+
+    for (i, ptr) in boxed.iter().enumerate() {
+        let idx = i32_type.const_int(i as u64, false);
+        // SAFETY: `idx` is always in bounds — it ranges over `boxed`, whose
+        // length is exactly `array_ty`'s element count (or less, when the
+        // `.max(1)` padding above allocated one unused slot for `nargs == 0`).
+        let slot = unsafe {
+            fcx.builder
+                .build_gep(
+                    array_ty,
+                    args_alloca,
+                    &[i32_type.const_zero(), idx],
+                    "arg_slot",
+                )
+                .map_err(llvm_err)?
+        };
+        fcx.builder.build_store(slot, *ptr).map_err(llvm_err)?;
+
+        // SAFETY: see above.
+        let name_slot = unsafe {
+            fcx.builder
+                .build_gep(
+                    array_ty,
+                    names_alloca,
+                    &[i32_type.const_zero(), idx],
+                    "name_slot",
+                )
+                .map_err(llvm_err)?
+        };
+        fcx.builder
+            .build_store(name_slot, ptr_type.const_null())
+            .map_err(llvm_err)?;
+    }
+
+    let keel_res_ty = fcx
+        .context
+        .struct_type(&[i8_type.into(), ptr_type.into()], false);
+    let keel_rt_call_ns = declare_or_get(fcx.module, "keel_rt_call_ns", || {
+        keel_res_ty.fn_type(
+            &[
+                i16_type.into(),
+                i16_type.into(),
+                ptr_type.into(),
+                ptr_type.into(),
+                i32_type.into(),
+                i32_type.into(),
+            ],
+            false,
+        )
+    });
+
+    fcx.builder
+        .build_call(
+            keel_rt_call_ns,
+            &[
+                i16_type.const_int(u64::from(ns_id), false).into(),
+                i16_type.const_int(u64::from(method_id), false).into(),
+                args_alloca.into(),
+                names_alloca.into(),
+                i32_type.const_int(u64::from(nargs), false).into(),
+                i32_type.const_int(u64::from(span_id), false).into(),
+            ],
+            "ns_call",
+        )
+        .map_err(llvm_err)?;
+
+    // M1 only wires Unit-returning methods (enforced by keel-kir's
+    // lower_ns_call), so the caller (expr::emit_call) never inspects this —
+    // same convention as a CallTarget::Fn void call.
+    Ok(fcx.context.bool_type().const_zero().into())
+}

--- a/crates/keel-codegen/tests/control_flow_and_calls.rs
+++ b/crates/keel-codegen/tests/control_flow_and_calls.rs
@@ -9,7 +9,7 @@
 
 use std::process::Command;
 
-use keel_codegen::{BuildOptions, CodegenError};
+use keel_codegen::BuildOptions;
 
 #[path = "support/mod.rs"]
 mod support;
@@ -28,19 +28,6 @@ fn compile_and_run(source: &str) -> i32 {
 
     let run = Command::new(&bin).output().expect("run compiled binary");
     run.status.code().expect("process exited via a signal")
-}
-
-fn compile_err(source: &str) -> CodegenError {
-    let (program, _named) =
-        keel_syntax::parse_source(source, "t.keel").expect("fixture must parse");
-    let kir = keel_kir::lower(&program, "t.keel").expect("fixture must lower to KIR");
-
-    let out_dir = tempfile::tempdir().expect("create temp out dir");
-    let opts = BuildOptions {
-        out_dir: out_dir.path().to_path_buf(),
-        runtime_link_args: support::runtime_link_args().clone(),
-    };
-    keel_codegen::compile(&kir, &opts).expect_err("compile must be rejected")
 }
 
 #[test]
@@ -228,12 +215,6 @@ fn bare_return_in_top_level_code_exits_zero() {
     assert_eq!(code, 0);
 }
 
-#[test]
-fn namespace_call_is_still_rejected() {
-    // CallTarget::Ns dispatch lands in #135 (keel_rt_call_ns).
-    let err = compile_err("use std/io\n\nio.show(\"hi\")\n");
-    assert!(
-        matches!(err, CodegenError::Unsupported(ref msg) if msg.contains("namespace method")),
-        "unexpected error: {err}"
-    );
-}
+// CallTarget::Ns dispatch (io.show/log.* wired through keel_rt_call_ns) is
+// covered by tests/namespace_calls.rs, which also proves byte-identical
+// output against the interpreter — the exit criterion for issue #135.

--- a/crates/keel-codegen/tests/namespace_calls.rs
+++ b/crates/keel-codegen/tests/namespace_calls.rs
@@ -1,0 +1,81 @@
+//! Exit criterion for issue #135: a compiled program calling a namespace
+//! method produces byte-identical output to the interpreter running the
+//! same source — proving `CallTarget::Ns` codegen reaches the exact same
+//! `Namespace.methods` closure via `keel_rt_call_ns`/`CompiledHost`, not a
+//! separately-written compiled-path reimplementation that could drift.
+
+use std::process::Command;
+
+use keel_codegen::BuildOptions;
+
+#[path = "support/mod.rs"]
+mod support;
+
+fn compile_and_run(source: &str) -> std::process::Output {
+    let (program, _named) =
+        keel_syntax::parse_source(source, "t.keel").expect("fixture must parse");
+    let kir = keel_kir::lower(&program, "t.keel").expect("fixture must lower to KIR");
+
+    let out_dir = tempfile::tempdir().expect("create temp out dir");
+    let opts = BuildOptions {
+        out_dir: out_dir.path().to_path_buf(),
+        runtime_link_args: support::runtime_link_args().clone(),
+    };
+    let bin = keel_codegen::compile(&kir, &opts).expect("compile must succeed");
+    Command::new(&bin).output().expect("run compiled binary")
+}
+
+#[test]
+fn io_show_matches_the_interpreter_byte_for_byte() {
+    let source = "use std/io\n\nio.show(\"hello\")\n";
+
+    let compiled = compile_and_run(source);
+    let interpreted = support::run_interpreter(source);
+
+    assert_eq!(
+        String::from_utf8_lossy(&compiled.stdout),
+        String::from_utf8_lossy(&interpreted.stdout),
+        "compiled stdout must match the interpreter's"
+    );
+    assert!(
+        compiled.stdout.ends_with(b"hello\n"),
+        "expected io.show's output on stdout, got: {:?}",
+        String::from_utf8_lossy(&compiled.stdout)
+    );
+}
+
+#[test]
+fn log_info_matches_the_interpreter_byte_for_byte() {
+    let source = "use std/log\n\nlog.info(\"started\")\n";
+
+    let compiled = compile_and_run(source);
+    let interpreted = support::run_interpreter(source);
+
+    assert_eq!(
+        String::from_utf8_lossy(&compiled.stderr),
+        String::from_utf8_lossy(&interpreted.stderr),
+        "compiled stderr must match the interpreter's (log.* writes to stderr)"
+    );
+    assert!(
+        compiled.stderr.ends_with(b"[info] started\n"),
+        "expected log.info's output on stderr, got: {:?}",
+        String::from_utf8_lossy(&compiled.stderr)
+    );
+}
+
+#[test]
+fn multiple_namespace_calls_in_one_program_all_run() {
+    let source = "use std/io\nuse std/log\n\nio.show(\"hello\")\nlog.info(\"started\")\n";
+
+    let compiled = compile_and_run(source);
+    let interpreted = support::run_interpreter(source);
+
+    assert_eq!(
+        String::from_utf8_lossy(&compiled.stdout),
+        String::from_utf8_lossy(&interpreted.stdout)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&compiled.stderr),
+        String::from_utf8_lossy(&interpreted.stderr)
+    );
+}

--- a/crates/keel-codegen/tests/support/mod.rs
+++ b/crates/keel-codegen/tests/support/mod.rs
@@ -11,7 +11,7 @@
 //! runner.
 
 use std::path::PathBuf;
-use std::process::Command;
+use std::process::{Command, Output};
 use std::sync::OnceLock;
 
 pub fn runtime_link_args() -> &'static Vec<String> {
@@ -22,6 +22,67 @@ pub fn runtime_link_args() -> &'static Vec<String> {
         eprintln!("keel-codegen tests: runtime link args: {args:?}");
         args
     })
+}
+
+/// Runs `source` through the real interpreter (the `keel` binary, `keel run`)
+/// and returns its captured output — the independent, ground-truth
+/// comparison for "the compiled program's stdout is byte-identical to the
+/// interpreter's" tests. `KEEL_LLM=mock` matches this workspace's normal
+/// test convention even though these fixtures don't call `ai.*`.
+///
+/// Only `namespace_calls.rs` uses this (the other test binaries that
+/// `#[path]`-include this same module don't) — `allow(dead_code)` since each
+/// `tests/*.rs` file compiles its own copy of `support/mod.rs`.
+#[allow(dead_code)]
+pub fn run_interpreter(source: &str) -> Output {
+    let keel_bin = build_keel_binary();
+    let source_file = tempfile::Builder::new()
+        .suffix(".keel")
+        .tempfile()
+        .expect("create temp source file");
+    std::fs::write(source_file.path(), source).expect("write temp source");
+
+    Command::new(&keel_bin)
+        .arg("run")
+        .arg(source_file.path())
+        .env("KEEL_LLM", "mock")
+        .output()
+        .expect("spawn `keel run`")
+}
+
+#[allow(dead_code)]
+fn build_keel_binary() -> PathBuf {
+    let output = Command::new("cargo")
+        .current_dir(workspace_root())
+        .env("CARGO_TERM_COLOR", "never")
+        .args([
+            "build",
+            "-p",
+            "keel-lang",
+            "--bin",
+            "keel",
+            "--message-format=json",
+        ])
+        .output()
+        .expect("spawn `cargo build -p keel-lang --bin keel`");
+    assert!(
+        output.status.success(),
+        "building the `keel` binary failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        let Ok(msg) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        if msg.get("reason").and_then(serde_json::Value::as_str) != Some("compiler-artifact") {
+            continue;
+        }
+        if let Some(exe) = msg.get("executable").and_then(serde_json::Value::as_str) {
+            return PathBuf::from(exe);
+        }
+    }
+    panic!("`cargo build -p keel-lang --bin keel` did not report an executable artifact");
 }
 
 fn workspace_root() -> PathBuf {

--- a/crates/keel-rt-ffi/Cargo.toml
+++ b/crates/keel-rt-ffi/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["staticlib", "rlib"]
 workspace = true
 
 [dependencies]
+keel-catalog = { path = "../keel-catalog" }
 keel-runtime = { path = "../keel-runtime" }
 keel-syntax = { path = "../keel-syntax" }
 tokio = { workspace = true }

--- a/crates/keel-rt-ffi/src/abi/mod.rs
+++ b/crates/keel-rt-ffi/src/abi/mod.rs
@@ -1,0 +1,80 @@
+//! `KeelBox` — the dynamic-value ABI type generated code and `keel_rt_call_ns`
+//! exchange (`designs/llvm-compilation.md` §2.4).
+//!
+//! **`KeelBox` is literally the interpreter's `Value`, behind an opaque,
+//! reference-counted pointer** (`Arc<Value>::into_raw`) — not a separate
+//! reimplementation. This is deliberate: `dynamic` semantics stay identical
+//! between engines by construction, and marshalling at the namespace
+//! boundary is a cheap wrap/unwrap instead of a structural conversion.
+//!
+//! M1 only needs to *construct* a `KeelBox` from a compile-time scalar
+//! constant (to pass as a namespace-call argument) and read one back (the
+//! call's return value) — never a mutable, first-class `KeelStr` with its
+//! own concat/slice operations, since KIR has no `str` locals or operations
+//! yet (every `str` value in M1 is a literal flowing straight into a
+//! `dynamic`-typed namespace-call parameter). A standalone `KeelStr` type
+//! lands with M2's string operations; `keel_box_str` covers this milestone.
+//!
+//! Retain/release live in [`rc`].
+
+pub mod rc;
+
+use std::slice;
+use std::sync::Arc;
+
+use keel_runtime::interpreter::value::Value;
+
+/// Boxes an `int` constant. Returns a strong (+1) reference the caller owns
+/// and must eventually pass to [`rc::keel_box_release`].
+#[unsafe(no_mangle)]
+pub extern "C" fn keel_box_int(v: i64) -> *const Value {
+    Arc::into_raw(Arc::new(Value::Integer(v)))
+}
+
+/// Boxes a `float` constant. See [`keel_box_int`] for ownership.
+#[unsafe(no_mangle)]
+pub extern "C" fn keel_box_float(v: f64) -> *const Value {
+    Arc::into_raw(Arc::new(Value::Float(v)))
+}
+
+/// Boxes a `bool` constant (`0` = false, nonzero = true). See [`keel_box_int`]
+/// for ownership.
+#[unsafe(no_mangle)]
+pub extern "C" fn keel_box_bool(v: u8) -> *const Value {
+    Arc::into_raw(Arc::new(Value::Bool(v != 0)))
+}
+
+/// Boxes a UTF-8 string constant, copying `len` bytes starting at `ptr` into
+/// an owned `Value::String`. See [`keel_box_int`] for ownership.
+///
+/// # Safety
+///
+/// `ptr` must be valid for reads of `len` bytes, and those bytes must be
+/// valid UTF-8 (always true for a `keel-codegen`-emitted string-literal
+/// global — this is not a user-facing conversion boundary).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn keel_box_str(ptr: *const u8, len: usize) -> *const Value {
+    let bytes = unsafe { slice::from_raw_parts(ptr, len) };
+    let s = std::str::from_utf8(bytes)
+        .expect("keel-codegen only emits valid-UTF-8 string-literal globals")
+        .to_string();
+    Arc::into_raw(Arc::new(Value::String(s)))
+}
+
+/// Reads a `KeelBox`'s value without consuming the caller's reference —
+/// used to marshal namespace-call arguments (`const KeelBox**`, i.e.
+/// borrowed) into owned `Value`s.
+///
+/// # Safety
+///
+/// `ptr` must be a live `KeelBox` (an `Arc<Value>::into_raw` pointer whose
+/// strong count has not yet dropped to zero).
+pub(crate) unsafe fn borrow(ptr: *const Value) -> Value {
+    unsafe { &*ptr }.clone()
+}
+
+/// Boxes an owned `Value` (e.g. a namespace method's return value) as a
+/// fresh `KeelBox`, mirroring [`keel_box_int`]'s ownership convention.
+pub(crate) fn boxed(v: Value) -> *const Value {
+    Arc::into_raw(Arc::new(v))
+}

--- a/crates/keel-rt-ffi/src/abi/rc.rs
+++ b/crates/keel-rt-ffi/src/abi/rc.rs
@@ -1,0 +1,38 @@
+//! Retain/release for [`super`]'s `KeelBox` (`Arc<Value>` behind an opaque
+//! pointer). Generated code calls these at ordinary RC discipline points —
+//! `keel_retain` when a box is stored somewhere that outlives the call that
+//! produced it, `keel_release` once done with it.
+//!
+//! M1 does not yet emit `keel_retain`/`keel_release` around `CallTarget::Ns`
+//! call sites (`keel-codegen`'s `emit_call`): every argument box is
+//! constructed immediately before the call and never stored, and the
+//! returned payload is discarded (M1 only wires `Unit`-returning methods).
+//! Both leak for the process's lifetime, which is harmless for M1's
+//! short-lived compiled fixtures — emitting the matching release calls is
+//! left to the milestone that gives compiled programs long-lived `dynamic`
+//! values worth freeing.
+
+use keel_runtime::interpreter::value::Value;
+use std::sync::Arc;
+
+/// Increments a `KeelBox`'s strong count without taking ownership.
+///
+/// # Safety
+///
+/// `ptr` must be a live `KeelBox` (see [`super::keel_box_int`]'s ownership
+/// convention).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn keel_retain(ptr: *const Value) {
+    unsafe { Arc::increment_strong_count(ptr) }
+}
+
+/// Drops one strong reference to a `KeelBox`, freeing it if this was the
+/// last one.
+///
+/// # Safety
+///
+/// `ptr` must be a live `KeelBox` the caller has not already released.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn keel_release(ptr: *const Value) {
+    drop(unsafe { Arc::from_raw(ptr) });
+}

--- a/crates/keel-rt-ffi/src/host.rs
+++ b/crates/keel-rt-ffi/src/host.rs
@@ -3,9 +3,11 @@
 //! `designs/llvm-compilation.md` §2.7). Compiled code has no closures, tasks,
 //! or agents of its own to dispatch back into (that's still the
 //! interpreter's job for anything this milestone doesn't compile), so most
-//! methods are unreachable for now and `todo!()` — they gain real bodies as
-//! later issues wire specific namespace calls through `keel_rt_call_ns`
-//! (#135) and beyond.
+//! methods are unreachable for now and `todo!()`. Namespace-method dispatch
+//! (`call_namespace_method`, `register_namespace`) is real: it reuses the
+//! exact same `Namespace` closures the interpreter installs, via
+//! `keel_runtime::runtime::namespaces::install` — the "23 namespaces for
+//! free" seam §2.7 describes.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -20,21 +22,26 @@ use parking_lot::Mutex;
 use tokio::sync::mpsc;
 
 /// `Host` implementation for compiled binaries. Holds the same
-/// `RuntimeContext` (env, clock, LLM, file system, …) the interpreter uses;
-/// everything else a compiled program needs is either resolved at compile
-/// time (direct `CallTarget::Fn` calls never reach `Host`) or not yet
-/// supported (namespace dispatch beyond #135, agents, closures).
+/// `RuntimeContext` (env, clock, LLM, file system, …) the interpreter uses,
+/// plus every stdlib namespace's method closures (installed at construction
+/// time, same as `Interpreter::new`). Everything else a compiled program
+/// needs is either resolved at compile time (direct `CallTarget::Fn` calls
+/// never reach `Host`) or not yet supported (agents, closures, tasks-by-name).
 pub struct CompiledHost {
     runtime: Arc<RuntimeContext>,
     live_agents: LiveAgents,
+    namespaces: HashMap<String, Namespace>,
 }
 
 impl CompiledHost {
     pub fn new(runtime: Arc<RuntimeContext>) -> Self {
-        Self {
+        let mut host = Self {
             runtime,
             live_agents: Arc::new(Mutex::new(HashMap::new())),
-        }
+            namespaces: HashMap::new(),
+        };
+        keel_runtime::runtime::namespaces::install(&mut host);
+        host
     }
 }
 
@@ -67,11 +74,28 @@ impl Host for CompiledHost {
 
     fn call_namespace_method<'a>(
         &'a mut self,
-        _ns: &'a str,
-        _method: &'a str,
-        _args: Vec<CallArgValue>,
+        ns: &'a str,
+        method: &'a str,
+        args: Vec<CallArgValue>,
     ) -> HostFuture<'a, Value> {
-        todo!("namespace dispatch lands in issue #135 (keel_rt_call_ns)")
+        // `@tools` capability gating (`Interpreter::call_namespace_method`,
+        // `call.rs`) is deliberately skipped here: it only ever applies
+        // inside an agent's turn, and compiled programs can't compile an
+        // agent yet (M3), so there is no context to gate. Revisit once
+        // agents land — enforcement must ride this same path per §2.7.
+        let Some(namespace) = self.namespaces.get(ns) else {
+            return Box::pin(async move {
+                Err(miette::miette!(
+                    "`{ns}` is not a registered stdlib namespace"
+                ))
+            });
+        };
+        let Some(closure) = namespace.methods.get(method).cloned() else {
+            return Box::pin(
+                async move { Err(miette::miette!("`{ns}` has no method `{method}`")) },
+            );
+        };
+        Box::pin(async move { closure(self, args).await })
     }
 
     fn start_agent<'a>(&'a mut self, _name: &'a str) -> HostFuture<'a, ()> {
@@ -179,8 +203,8 @@ impl Host for CompiledHost {
         todo!("prelude installation is not compiled yet")
     }
 
-    fn register_namespace(&mut self, _ns: Namespace) {
-        todo!("prelude installation is not compiled yet")
+    fn register_namespace(&mut self, ns: Namespace) {
+        self.namespaces.insert(ns.name.clone(), ns);
     }
 
     fn register_top_fn(&mut self, _name: &str, _f: BuiltinFn) {

--- a/crates/keel-rt-ffi/src/lib.rs
+++ b/crates/keel-rt-ffi/src/lib.rs
@@ -6,8 +6,11 @@
 //! Entry point: [`keel_rt_start`], called from the `main` that `keel-codegen`
 //! emits.
 
+pub mod abi;
 pub mod host;
+pub mod ns_dispatch;
 mod scheduler;
 
 pub use host::CompiledHost;
+pub use ns_dispatch::{KeelRes, keel_rt_call_ns};
 pub use scheduler::keel_rt_start;

--- a/crates/keel-rt-ffi/src/ns_dispatch.rs
+++ b/crates/keel-rt-ffi/src/ns_dispatch.rs
@@ -1,0 +1,83 @@
+//! `keel_rt_call_ns` — the one generic namespace-method dispatch entry point
+//! `keel-codegen` compiles every `CallTarget::Ns` call site into
+//! (`designs/llvm-compilation.md` §2.7). `ns_id`/`method_id` are resolved
+//! back to names via `keel-catalog` (the same table KIR lowering assigned
+//! them from), the boxed args are unwrapped to owned `Value`s, and the call
+//! runs through `CompiledHost::call_namespace_method` — the exact same
+//! `Namespace.methods` closure the interpreter would run. All 23 namespaces
+//! work this way with zero per-namespace codegen.
+
+use std::ffi::c_char;
+
+use keel_runtime::interpreter::CallArgValue;
+use keel_runtime::interpreter::value::Value;
+
+use crate::abi;
+use crate::scheduler::block_on_namespace_call;
+
+/// The compiled analogue of `Result<Value>`: `is_err == 0` means `payload`
+/// is a `KeelBox` holding the call's return value; nonzero means `payload`
+/// is a `KeelBox` holding a `Value::String` error message.
+///
+/// M1 does not lower `try`/`catch`/`raise`, so no generated code branches on
+/// `is_err` yet — every namespace method this milestone wires
+/// (`io.show`, `log.*`) never actually returns an error in practice, so this
+/// is "a real return convention to build on" (per issue #135's scope) rather
+/// than a fully consumed one. A future milestone that lowers `try`/`catch`
+/// is what starts reading `is_err`.
+#[repr(C)]
+pub struct KeelRes {
+    pub is_err: u8,
+    pub payload: *const Value,
+}
+
+/// # Safety
+///
+/// `args` and `arg_names` must each be valid for `nargs` reads; every
+/// `args[i]` must be a live `KeelBox` (see `abi::keel_box_int`'s ownership
+/// convention) that this call borrows, not consumes. Each `arg_names[i]` is
+/// either null (positional) or a valid, NUL-terminated C string — M1 never
+/// emits named-argument calls, so `keel-codegen` always passes all-null, but
+/// the shape matches Keel's named-argument semantics for when it does.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn keel_rt_call_ns(
+    ns_id: u16,
+    method_id: u16,
+    args: *const *const Value,
+    arg_names: *const *const c_char,
+    nargs: u32,
+    _span_id: u32,
+) -> KeelRes {
+    // `ns_id`/`method_id` came from keel-kir's lowering, which only ever
+    // assigns pairs it already resolved against this exact catalog — a
+    // lookup miss here is a codegen/lowering bug, not a user-facing error.
+    let ns = keel_catalog::namespace_by_id(ns_id)
+        .unwrap_or_else(|| panic!("keel_rt_call_ns: no namespace registered for ns_id {ns_id}"));
+    let method = keel_catalog::method_by_id(ns, method_id).unwrap_or_else(|| {
+        panic!("keel_rt_call_ns: no method registered for {ns}'s method_id {method_id}")
+    });
+
+    let mut call_args = Vec::with_capacity(nargs as usize);
+    for i in 0..nargs as usize {
+        // SAFETY: caller's contract (see this fn's doc).
+        let value = unsafe { abi::borrow(*args.add(i)) };
+        let name_ptr = unsafe { *arg_names.add(i) };
+        let name = (!name_ptr.is_null()).then(|| {
+            unsafe { std::ffi::CStr::from_ptr(name_ptr) }
+                .to_string_lossy()
+                .into_owned()
+        });
+        call_args.push(CallArgValue { name, value });
+    }
+
+    match block_on_namespace_call(ns, method, call_args) {
+        Ok(value) => KeelRes {
+            is_err: 0,
+            payload: abi::boxed(value),
+        },
+        Err(report) => KeelRes {
+            is_err: 1,
+            payload: abi::boxed(Value::String(report.to_string())),
+        },
+    }
+}

--- a/crates/keel-rt-ffi/src/scheduler.rs
+++ b/crates/keel-rt-ffi/src/scheduler.rs
@@ -1,11 +1,24 @@
 //! `keel_rt_start` — the handshake between a `keel-codegen`-linked binary's
 //! `main` and the Keel runtime. Boots a tokio runtime, constructs the same
-//! `RuntimeContext` the interpreter uses, and calls back into the compiled
-//! program's `keel_user_toplevel` (emitted by `keel-codegen`).
+//! `RuntimeContext`/`CompiledHost` the interpreter's namespace closures run
+//! against, and calls back into the compiled program's top-level function
+//! (`keel_user_toplevel`, emitted by `keel-codegen`).
+//!
+//! `keel_user_toplevel` is ordinary synchronous compiled code (LLVM has no
+//! async), so it's called directly here — *not* wrapped in `block_on` — so
+//! that a `CallTarget::Ns` site inside it can reach back into the runtime
+//! via [`block_on_namespace_call`] with a plain, non-nested `Handle::block_on`
+//! rather than needing `block_in_place`. The tokio runtime and `CompiledHost`
+//! live in a thread-local for the duration of that call chain; M1 has no
+//! agents/spawned tasks yet, so everything runs on this one thread.
 
-use std::sync::Arc;
+use std::cell::RefCell;
 
+use keel_runtime::interpreter::CallArgValue;
+use keel_runtime::interpreter::host::Host;
+use keel_runtime::interpreter::value::Value;
 use keel_runtime::runtime::context::RuntimeContext;
+use tokio::runtime::{Handle, Runtime};
 
 use crate::host::CompiledHost;
 
@@ -13,6 +26,10 @@ unsafe extern "C" {
     /// Emitted by `keel-codegen` for every compiled program (`func.rs`'s
     /// `emit_toplevel_function`). Returns the M1 exit-code-convention value.
     fn keel_user_toplevel() -> i32;
+}
+
+thread_local! {
+    static CONTEXT: RefCell<Option<(CompiledHost, Handle)>> = const { RefCell::new(None) };
 }
 
 /// Called from the linked binary's `main`. Boots tokio + `RuntimeContext`,
@@ -24,7 +41,7 @@ unsafe extern "C" {
 /// point — it owns process-wide startup (the tokio runtime).
 #[unsafe(no_mangle)]
 pub extern "C" fn keel_rt_start() -> i32 {
-    let tokio_rt = match tokio::runtime::Runtime::new() {
+    let tokio_rt = match Runtime::new() {
         Ok(rt) => rt,
         Err(e) => {
             eprintln!("keel: failed to start async runtime: {e}");
@@ -32,13 +49,38 @@ pub extern "C" fn keel_rt_start() -> i32 {
         }
     };
 
-    tokio_rt.block_on(async {
-        let runtime = RuntimeContext::native();
-        let _host = CompiledHost::new(Arc::clone(&runtime));
+    let host = CompiledHost::new(RuntimeContext::native());
+    let handle = tokio_rt.handle().clone();
+    CONTEXT.with(|c| *c.borrow_mut() = Some((host, handle)));
 
-        // SAFETY: `keel_user_toplevel` is emitted by keel-codegen for every
-        // compiled program; the object this crate is statically linked into
-        // always defines it.
-        unsafe { keel_user_toplevel() }
+    // SAFETY: `keel_user_toplevel` is emitted by keel-codegen for every
+    // compiled program; the object this crate is statically linked into
+    // always defines it.
+    let code = unsafe { keel_user_toplevel() };
+
+    CONTEXT.with(|c| c.borrow_mut().take());
+    code
+}
+
+/// Dispatches a namespace-method call through the current thread's
+/// `CompiledHost`, blocking this (synchronous, LLVM-emitted) call site until
+/// the async namespace closure completes. Used by [`crate::ns_dispatch::
+/// keel_rt_call_ns`].
+///
+/// # Panics
+///
+/// If called from a thread `keel_rt_start` never ran on.
+pub(crate) fn block_on_namespace_call(
+    ns: &str,
+    method: &str,
+    args: Vec<CallArgValue>,
+) -> miette::Result<Value> {
+    CONTEXT.with(|c| {
+        let mut binding = c.borrow_mut();
+        let (host, handle) = binding
+            .as_mut()
+            .expect("keel_rt_call_ns invoked on a thread keel_rt_start never ran on");
+        let handle = handle.clone();
+        handle.block_on(host.call_namespace_method(ns, method, args))
     })
 }

--- a/crates/keel-rt-ffi/tests/full_ns_call.rs
+++ b/crates/keel-rt-ffi/tests/full_ns_call.rs
@@ -1,0 +1,31 @@
+//! Exercises the exact path `keel-codegen` will generate for a
+//! `CallTarget::Ns` call site: `keel_rt_start` boots the runtime, the
+//! (mock) compiled toplevel boxes a string constant via `keel_box_str` and
+//! calls `keel_rt_call_ns` with `io.show`'s real `(ns_id, method_id)`
+//! resolved from `keel-catalog`, exactly as `keel-kir`'s lowering would.
+//! `keel-codegen`'s own tests prove the LLVM side actually emits this same
+//! call shape; this proves the runtime side accepts it end to end with no
+//! LLVM involved.
+
+use keel_rt::ns_dispatch::keel_rt_call_ns;
+
+#[unsafe(no_mangle)]
+pub extern "C" fn keel_user_toplevel() -> i32 {
+    let ns_id = keel_catalog::namespace_id("io").expect("io is a registered namespace");
+    let method_id = keel_catalog::catalog_method("io", "show")
+        .expect("io.show is a registered method")
+        .method_id;
+
+    let msg = "hello from full_ns_call";
+    let boxed = unsafe { keel_rt::abi::keel_box_str(msg.as_ptr(), msg.len()) };
+    let args = [boxed];
+    let arg_names: [*const std::ffi::c_char; 1] = [std::ptr::null()];
+
+    let res = unsafe { keel_rt_call_ns(ns_id, method_id, args.as_ptr(), arg_names.as_ptr(), 1, 0) };
+    i32::from(res.is_err)
+}
+
+#[test]
+fn keel_rt_call_ns_dispatches_io_show_end_to_end() {
+    assert_eq!(keel_rt::keel_rt_start(), 0, "io.show must not error");
+}

--- a/crates/keel-rt-ffi/tests/namespace_dispatch.rs
+++ b/crates/keel-rt-ffi/tests/namespace_dispatch.rs
@@ -1,0 +1,54 @@
+//! Proves the `Host`-seam reuse in isolation from codegen/LLVM: a
+//! hand-built `CompiledHost` dispatches `io.show`/`log.info` through the
+//! exact same namespace closures the interpreter uses, with no LLVM
+//! involved. `keel-codegen`'s own tests (issue #135) prove that the
+//! generated `CallTarget::Ns` call sites actually reach this same path.
+
+use keel_rt::CompiledHost;
+use keel_runtime::interpreter::CallArgValue;
+use keel_runtime::interpreter::host::Host;
+use keel_runtime::interpreter::value::Value;
+use keel_runtime::runtime::context::RuntimeContext;
+
+fn arg(v: Value) -> CallArgValue {
+    CallArgValue {
+        name: None,
+        value: v,
+    }
+}
+
+#[tokio::test]
+async fn io_show_reaches_the_same_closure_the_interpreter_uses() {
+    let mut host = CompiledHost::new(RuntimeContext::native());
+    let result = host
+        .call_namespace_method("io", "show", vec![arg(Value::String("hello".to_string()))])
+        .await;
+    assert_eq!(result.unwrap(), Value::None);
+}
+
+#[tokio::test]
+async fn log_info_reaches_the_same_closure_the_interpreter_uses() {
+    let mut host = CompiledHost::new(RuntimeContext::native());
+    let result = host
+        .call_namespace_method(
+            "log",
+            "info",
+            vec![arg(Value::String("started".to_string()))],
+        )
+        .await;
+    assert_eq!(result.unwrap(), Value::None);
+}
+
+#[tokio::test]
+async fn unknown_namespace_is_a_catchable_error_not_a_panic() {
+    let mut host = CompiledHost::new(RuntimeContext::native());
+    let result = host.call_namespace_method("nope", "show", vec![]).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn unknown_method_is_a_catchable_error_not_a_panic() {
+    let mut host = CompiledHost::new(RuntimeContext::native());
+    let result = host.call_namespace_method("io", "nope", vec![]).await;
+    assert!(result.is_err());
+}

--- a/crates/keel-runtime/src/runtime/namespaces/mod.rs
+++ b/crates/keel-runtime/src/runtime/namespaces/mod.rs
@@ -32,7 +32,14 @@ pub(crate) mod uuid;
 // tables moved there too; `namespace()` installs the matching executable
 // implementations below, cross-checked against the catalog in tests.
 
-pub(crate) fn install(host: &mut dyn Host) {
+/// Registers every stdlib namespace's method closures on `host` via
+/// [`Host::register_namespace`]. Registration only inserts each namespace
+/// into `host`'s own registry — it never calls a closure — so this is safe
+/// to run against any `Host` implementation, including one whose other
+/// methods aren't implemented yet (`keel-rt-ffi`'s `CompiledHost`, which
+/// reuses this exact set of closures per `designs/llvm-compilation.md`
+/// §2.7 instead of re-implementing 23 namespaces for the compiled path).
+pub fn install(host: &mut dyn Host) {
     for namespace in namespaces() {
         host.register_namespace(namespace);
     }


### PR DESCRIPTION
## Summary

- `keel-rt-ffi` gains a minimal `KeelBox` ABI (`src/abi/`) — an RC'd wrapper around the interpreter's own `Value` type (not a reimplementation), with `keel_box_int/float/bool/str` constructors and `keel_retain`/`keel_release`.
- `keel_rt_call_ns(ns_id, method_id, args, arg_names, nargs, span_id)` (`src/ns_dispatch.rs`) is the one generic dispatch entry point every compiled `CallTarget::Ns` call site routes through — resolves the numeric ids back to names via `keel-catalog`, marshals args, and dispatches through `CompiledHost::call_namespace_method`.
- `CompiledHost` now holds a real namespace registry, installed the same way `Interpreter`'s is (`keel_runtime::runtime::namespaces::install`, now `pub`) — so compiled programs reuse the *exact same* `io`/`log`/etc. closures the interpreter runs, not a separate implementation that could drift.
- `keel-codegen`'s `CallTarget::Ns` call sites (previously rejected) now box their arguments and call `keel_rt_call_ns` instead.
- Added `keel_catalog::namespace_by_id`/`method_by_id` (reverse of the existing `namespace_id`/`method_id` lookups) for the numeric-id-to-name resolution `keel_rt_call_ns` needs.

Scalar arguments (int/float/bool/str) are supported. Only `Unit`-returning methods are wired end-to-end for now — there's no `try`/`catch` lowering yet to consume a call's error result, so the `KeelRes` result-ABI shape exists (right calling convention) but isn't inspected by generated code.

Closes #135.

## Test plan

- [x] `keel-rt-ffi/tests/namespace_dispatch.rs` — `CompiledHost` reaches `io.show`/`log.info` through the real registry, with zero LLVM.
- [x] `keel-rt-ffi/tests/full_ns_call.rs` — the exact `keel_rt_call_ns` call shape codegen will emit, exercised from a mock compiled toplevel.
- [x] `keel-codegen/tests/namespace_calls.rs` — the issue's exit criterion: a compiled program calling `io.show`/`log.info` produces **byte-identical stdout/stderr to the interpreter**, verified by running both on the same source and diffing.
- [x] All pre-existing `keel-codegen` tests (including the previously-obsolete "namespace calls are rejected" test, now removed) still pass.
- [x] `cargo test` (default, LLVM-free) and `cargo test --workspace --features build-backend` both green locally.
- [x] `cargo clippy --all-targets -- -D warnings` (default) and `cargo clippy --workspace --all-targets --features build-backend -- -D warnings` both clean.