### PR TITLE
Wire the compiled engine into the conformance harness, closing M1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to Keel.
 
 ## [Unreleased]
 
-%%TAGLINE%% A stdio Debug Adapter Protocol server lets editors like VS Code set breakpoints, step, and inspect variables — including live agent state — in a running Keel program, alongside the first groundwork slice of the native LLVM backend.
+%%TAGLINE%% A stdio Debug Adapter Protocol server lets editors like VS Code set breakpoints, step, and inspect variables — including live agent state — in a running Keel program, alongside the native LLVM backend now compiling, linking, and running scalar Keel programs that match the interpreter byte for byte.
 
 ### Added
 
@@ -55,6 +55,8 @@ Known D0 gaps (see `docs/src/guide/debugging.md`): code inside `Async.spawn` run
   ```
 
 - **Interpreter-vs-interpreter conformance harness (`tests/conformance/`, also M0).** A new `cargo test --test conformance` runs the interpreter twice over every runnable `examples/*.keel` program plus a small curated fixture set, in-process (not by shelling out), and asserts the two runs produce byte-identical stdout and exit codes — the merge-gate infrastructure `designs/llvm-compilation.md` calls for once a second (compiled) engine exists. An `Engine` enum already has a stubbed `Compiled` variant so wiring in the real backend later doesn't change the harness's shape. Programs needing real network/email/interactive input, or with inherently non-deterministic output (random/uuid/wall-clock/concurrent-broadcast-ordering), are excluded via an explicit skip list with a one-line reason each.
+
+- **The native/LLVM backend now compiles, links, and runs a scalar-only Keel program end to end (M1 of `designs/llvm-compilation.md`).** Three new crates carry a program from KIR to a running binary: `keel-codegen` walks KIR (int/float/bool/str literals and arithmetic, comparisons, `if`/`while`/`for`-over-ranges, direct task calls, and calls into std namespaces) to LLVM IR via `inkwell` and links it against a small native runtime; `keel-rt-ffi` is that runtime, providing a `KeelBox` value ABI (`Arc<Value>` behind an opaque pointer with `keel_retain`/`keel_release`), a `keel_rt_call_ns` dispatch entry point that resolves the catalog's stable `ns_id`/`method_id` pairs back to namespace and method names and routes through the exact same namespace closures (`io.show`, `log.*`, …) the interpreter already uses, and the `keel_rt_start` handshake that boots a Tokio runtime under the compiled binary's synchronous entry point. `keel-catalog` gained the reverse `ns_id`→name and `method_id`→name lookups this dispatch needs. A new scalar-only fixture set (`tests/conformance/fixtures/m1_scalar/`) is compiled and run as a piped subprocess and diffed byte-for-byte against the interpreter running the same program in a second subprocess — `cargo test --test conformance --features build-backend` is now the merge gate proving the native backend stays semantically identical to the interpreter as it grows. The CLI surface is unchanged for now: `keel build` still only supports `--emit=kir`; wiring it to emit and run a real binary is follow-up work outside this milestone's exit criterion (a scalar-only example compiles, links, runs, and matches the interpreter — which the conformance suite now proves).
 
 ### Changed
 

--- a/docs/src/cli/build.md
+++ b/docs/src/cli/build.md
@@ -2,43 +2,53 @@
 
 <span class="badge badge-soon">Coming soon</span>
 
-> Status: `keel build` is the future entry point for the native/LLVM AOT backend (see the project's `designs/llvm-compilation.md`). It does not produce a binary yet. `--emit=kir` prints the mid-level IR for the scalar subset of the language, as a preview of the pipeline under construction; every other form of `keel build` errors. Use `keel run` to execute programs and `keel check` to type-check without running.
+> Status: `keel build` is the future entry point for the native/LLVM AOT backend (see the project's `designs/llvm-compilation.md`). The CLI does not produce a binary yet — `--emit=kir` prints the mid-level IR for the scalar subset of the language, as a preview of the pipeline under construction; every other form of `keel build` errors. Behind the scenes, that same scalar subset now compiles, links, and runs as a native binary end to end (proven by a dedicated conformance suite comparing its output against the interpreter's), but this isn't reachable from the CLI yet — only from the internal `keel-codegen`/`keel-rt-ffi` crates. Use `keel run` to execute programs and `keel check` to type-check without running.
 
 ## `--emit=kir`
 
-Type-checks a single-file program and prints its lowered mid-level IR (KIR) instead of compiling. Only the scalar subset lowers today: `int`/`float`/`bool`/`str` literals, arithmetic and comparison, `if`/`else`, `while`, `let`/assignment, task declarations with scalar parameters, direct calls between tasks, and `return`. Anything else — agents, structs, enums, containers, string interpolation, `for`, `when`, lambdas, generics — is rejected by name rather than silently dropped or approximated.
+Type-checks a single-file program and prints its lowered mid-level IR (KIR) instead of compiling. The scalar subset lowers today: `int`/`float`/`bool`/`str` literals, arithmetic and comparison, `if`/`else`, `while`, `for`-over-ranges, `let`/assignment, task declarations with scalar parameters, direct calls between tasks, calls into std namespaces (`io.show`, `log.*`, …), and `return`. Anything else — agents, structs, enums, containers, string interpolation, `when`, lambdas, generics, `try`/`catch` — is rejected by name rather than silently dropped or approximated.
 
 ```keel
-task add(a: int, b: int) -> int {
-  return a + b
+use std/io
+
+task sum_upto(n: int) -> int {
+  total = 0
+  for i in 1..n {
+    total += i
+  }
+  return total
 }
 
-x = add(2, 3)
+io.show(sum_upto(5))
 ```
 
 ```bash
-keel build add.keel --emit=kir
+keel build sum.keel --emit=kir
 ```
 
 ```
-fn add(a: int, b: int) -> int {
-  return (a + b)
+fn sum_upto(n: int) -> int {
+  let total: int = 0
+  for i in 1..n {
+    total = (total + i)
+  }
+  return total
 }
 
 fn <toplevel>() -> none {
-  let x: int = add(2, 3)
+  io.show(sum_upto(5))
 }
 ```
 
-Real programs use namespaces, agents, and structured data — none of which lower yet, so pointing `--emit=kir` at `examples/hello_world.keel` (or almost any other shipped example) currently errors by design:
+Real programs use agents and structured data, neither of which lower yet, so pointing `--emit=kir` at `examples/hello_world.keel` (or almost any other shipped example) currently errors by design:
 
 ```bash
 keel build examples/hello_world.keel --emit=kir
 ```
 
 ```
-Error:   × KIR lowering error at 396..406: `use declaration` is not supported by the
-  │ scalar-subset KIR lowering (M0)
+Error:   × KIR lowering error at 419..1039: `agent declaration` is not supported by
+  │ the scalar-subset KIR lowering (M0)
 ```
 
 ## Without `--emit`
@@ -53,4 +63,4 @@ Error:   × native codegen not yet implemented — `keel build` is the future LL
   │ level IR, or use `keel run` to execute examples/hello_world.keel
 ```
 
-`keel build` is present in the CLI because the verb is reserved for the native backend, but no codegen exists yet — only the KIR lowering step above.
+`keel build` is present in the CLI because the verb is reserved for the native backend. Codegen exists now (see the status note above) but is not yet wired to this command — only the KIR lowering step above is reachable today.

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -61,7 +61,7 @@ Commands:
   help   Print this message or the help of the given subcommand(s)
 ```
 
-`keel build` is listed because the verb is reserved for the future native/LLVM backend (see [`keel build`](../cli/build.md)), but v0.1 has no codegen yet — only a `--emit=kir` preview of the pipeline under construction. Use `keel run` or `keel check` for current workflows.
+`keel build` is listed because the verb is reserved for the future native/LLVM backend (see [`keel build`](../cli/build.md)), but the CLI itself doesn't produce a binary yet — only a `--emit=kir` preview of the pipeline under construction. Use `keel run` or `keel check` for current workflows.
 
 ## LLM setup
 

--- a/docs/status/features.json
+++ b/docs/status/features.json
@@ -293,7 +293,7 @@
     {
       "name": "keel build",
       "status": "in progress",
-      "notes": "Native/LLVM AOT backend (designs/llvm-compilation.md); `--emit=kir` previews the scalar-subset mid-level IR, no codegen yet"
+      "notes": "Native/LLVM AOT backend (designs/llvm-compilation.md); `--emit=kir` previews the scalar-subset mid-level IR; codegen for that same subset compiles/links/runs internally (M1) but isn't wired to this CLI command yet"
     },
     {
       "name": "keel dap",

--- a/tests/conformance/corpus.rs
+++ b/tests/conformance/corpus.rs
@@ -24,6 +24,25 @@ pub fn fixtures_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/conformance/fixtures")
 }
 
+/// M1-scalar-only fixtures (issue #136) — nested under `fixtures/` so
+/// [`discover_corpus`]'s flat, non-recursive listing never picks them up:
+/// they run under a separate comparison (interpreter vs. compiled), not the
+/// interpreter-vs-interpreter determinism loop the rest of the corpus does.
+/// Only used when the compiled engine actually exists.
+#[cfg(feature = "build-backend")]
+pub fn m1_scalar_fixtures_dir() -> PathBuf {
+    fixtures_dir().join("m1_scalar")
+}
+
+/// Discovers the M1-scalar-only fixture set, sorted by stem.
+#[cfg(feature = "build-backend")]
+pub fn discover_m1_scalar_fixtures() -> Vec<CorpusEntry> {
+    let mut entries = Vec::new();
+    collect_flat_keel_files(&m1_scalar_fixtures_dir(), &mut entries);
+    entries.sort_by(|a, b| a.stem.cmp(&b.stem));
+    entries
+}
+
 /// Discovers the corpus, sorted by stem for stable, reproducible test
 /// output.
 pub fn discover_corpus() -> Vec<CorpusEntry> {

--- a/tests/conformance/engine.rs
+++ b/tests/conformance/engine.rs
@@ -1,12 +1,27 @@
 //! The `Engine` abstraction the conformance harness diffs across.
 //!
-//! M0 has exactly one real engine (`Interpreter`); `Compiled` is wired in as
-//! a stub returning [`EngineError::NotImplemented`] so `main.rs`'s corpus
-//! loop, skip list, and diff logic already have the shape they'll need once
-//! `keel-codegen` (M1+, `designs/llvm-compilation.md`) exists — only the
-//! `Compiled` match arm in [`Engine::run`] changes then, presumably to spawn
-//! the compiled binary as a subprocess (unlike `Interpreter`, which calls
-//! straight into the library).
+//! M0 shipped exactly one real engine (`Interpreter`); `Compiled` was wired
+//! in as a stub returning [`EngineError::NotImplemented`] so the corpus
+//! loop, skip list, and diff logic in `main.rs` already had the shape a
+//! second engine would need. M1 (issue #136) fills in the real
+//! implementation, feature-gated behind `build-backend` (the root crate's
+//! optional dependency on `keel-codegen`, which is the only crate here that
+//! links LLVM) so this harness still runs — with `Compiled` degrading back
+//! to `NotImplemented` — on a checkout without the LLVM toolchain installed.
+//!
+//! Unlike `Interpreter` (calls straight into the library, output captured by
+//! `main.rs`'s fd-1 redirection around the current process), `Compiled`
+//! spawns the built binary as a **separate process** and captures its
+//! output via a piped `Command` instead — deliberately *not* by having the
+//! child inherit the parent's (possibly fd-1-redirected) stdio. An earlier
+//! version of this tried exactly that inheritance trick and it was
+//! intermittently flaky: `tokio::process::Command::status()` (which waits
+//! for the child to exit) does not guarantee the *pipe/fd cleanup* around
+//! that exit is synchronized with the parent's next `dup2` restore closely
+//! enough for this to be reliable across repeated runs in one process. A
+//! piped child (`Command::output()`) sidesteps the question entirely: its
+//! stdout never touches the parent's fd 1, so there is nothing for the
+//! surrounding `capture_stdout` machinery to race with.
 
 use std::fmt;
 use std::path::Path;
@@ -15,8 +30,9 @@ use std::time::Duration;
 use keel_lang::session;
 use keel_runtime::runtime::context::RuntimeContext;
 
-/// The result the conformance harness diffs: an exit code plus (assembled
-/// by `main.rs`, which owns the fd-1 capture) the program's stdout.
+/// The result the conformance harness diffs: an exit code plus the
+/// program's stdout (assembled differently per engine — see the module
+/// doc — but identical in shape either way).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EngineOutput {
     pub stdout: String,
@@ -33,7 +49,10 @@ pub enum EngineError {
     /// to type-checking cleanly and then failing at runtime, which is a
     /// normal nonzero exit).
     LoadFailed(String),
-    /// `Engine::Compiled` — no backend exists yet.
+    /// `Engine::Compiled` without the `build-backend` feature — no LLVM
+    /// toolchain, so no backend to run. Only ever constructed in that
+    /// build configuration; harmless dead-code with it on.
+    #[cfg_attr(feature = "build-backend", allow(dead_code))]
     NotImplemented,
     /// Killed by `main.rs`'s per-program timeout.
     TimedOut(Duration),
@@ -54,7 +73,11 @@ pub enum Engine {
     /// The tree-walking async interpreter (`keel-runtime`) — the reference
     /// semantics (`designs/llvm-compilation.md` §3).
     Interpreter,
-    /// The native/LLVM backend. Does not exist yet (M1+).
+    /// The native/LLVM backend. With `build-backend` on, `main.rs`'s M1
+    /// comparison calls [`run_compiled`] directly (it needs stdout, which
+    /// this variant's `Engine::run` doesn't expose) rather than constructing
+    /// this variant — harmless dead code in that configuration.
+    #[cfg_attr(feature = "build-backend", allow(dead_code))]
     Compiled,
 }
 
@@ -62,9 +85,16 @@ impl Engine {
     /// Runs `path` under this engine, returning its exit code (`0` on a
     /// clean `Ok(())`, `1` on any runtime error — byte-for-byte stderr
     /// diffing across engines is a later milestone's concern, not M0's).
+    /// Used only by `main.rs`'s interpreter-vs-interpreter loop and (when
+    /// `build-backend` is off) the `Compiled`-stub regression check —
+    /// `main.rs`'s M1 interpreter-vs-compiled comparison calls
+    /// [`run_compiled`] directly instead, since it needs stdout too.
     pub async fn run(&self, path: &Path) -> Result<i32, EngineError> {
         match self {
             Engine::Interpreter => run_interpreter(path).await,
+            #[cfg(feature = "build-backend")]
+            Engine::Compiled => run_compiled(path, None).await.map(|o| o.exit_code),
+            #[cfg(not(feature = "build-backend"))]
             Engine::Compiled => Err(EngineError::NotImplemented),
         }
     }
@@ -91,5 +121,57 @@ async fn run_interpreter(path: &Path) -> Result<i32, EngineError> {
     Ok(match session::run_graph(&checked, runtime).await {
         Ok(()) => 0,
         Err(_) => 1,
+    })
+}
+
+/// Parses, lowers to KIR, compiles, and runs `path` as a native binary,
+/// returning its exit code *and* captured stdout (via a piped child, not
+/// fd-1 inheritance — see the module doc). `workdir`, if given, becomes the
+/// child's cwd (`Command::current_dir` — no need to `chdir` this process,
+/// unlike the interpreter path, since the child gets its own process-wide
+/// cwd for free).
+///
+/// `LoadFailed` covers the whole front half of the pipeline (parse, lower,
+/// codegen) — a corpus fixture curated for M1 is expected to sail through
+/// all of it, so a failure at any stage is a harness-level problem, same as
+/// `run_interpreter`'s parse/check failures.
+#[cfg(feature = "build-backend")]
+pub async fn run_compiled(
+    path: &Path,
+    workdir: Option<&Path>,
+) -> Result<EngineOutput, EngineError> {
+    let source = std::fs::read_to_string(path)
+        .map_err(|e| EngineError::LoadFailed(format!("read {}: {e}", path.display())))?;
+    let name = path
+        .file_name()
+        .map(|f| f.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let (program, _named) = keel_syntax::parse_source(&source, &name)
+        .map_err(|e| EngineError::LoadFailed(format!("parse: {e:?}")))?;
+    let kir = keel_kir::lower(&program, &name)
+        .map_err(|e| EngineError::LoadFailed(format!("lower to KIR: {e}")))?;
+
+    let out_dir = tempfile::tempdir()
+        .map_err(|e| EngineError::LoadFailed(format!("create codegen out_dir: {e}")))?;
+    let opts = keel_codegen::BuildOptions {
+        out_dir: out_dir.path().to_path_buf(),
+        runtime_link_args: crate::runtime_link::runtime_link_args().clone(),
+    };
+    let bin = keel_codegen::compile(&kir, &opts)
+        .map_err(|e| EngineError::LoadFailed(format!("codegen: {e}")))?;
+
+    let mut cmd = tokio::process::Command::new(&bin);
+    if let Some(dir) = workdir {
+        cmd.current_dir(dir);
+    }
+    let output = cmd
+        .output()
+        .await
+        .map_err(|e| EngineError::LoadFailed(format!("spawn compiled binary: {e}")))?;
+
+    Ok(EngineOutput {
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        exit_code: output.status.code().unwrap_or(1),
     })
 }

--- a/tests/conformance/fixtures/m1_scalar/arithmetic_and_calls.keel
+++ b/tests/conformance/fixtures/m1_scalar/arithmetic_and_calls.keel
@@ -1,0 +1,17 @@
+use std/io
+
+task square(n: int) -> int {
+  return n * n
+}
+
+task sum_upto(n: int) -> int {
+  total = 0
+  for i in 1..n {
+    total += i
+  }
+  return total
+}
+
+x = square(6)
+y = sum_upto(10)
+io.show(x + y)

--- a/tests/conformance/fixtures/m1_scalar/bool_and_float.keel
+++ b/tests/conformance/fixtures/m1_scalar/bool_and_float.keel
@@ -1,0 +1,13 @@
+use std/io
+
+task is_positive(n: float) -> bool {
+  return n > 0.0
+}
+
+a = 3.5
+b = -2.0
+flag = is_positive(a) and not is_positive(b)
+
+io.show("hello")
+io.show(flag)
+io.show(a + b)

--- a/tests/conformance/fixtures/m1_scalar/loops_and_branches.keel
+++ b/tests/conformance/fixtures/m1_scalar/loops_and_branches.keel
@@ -1,0 +1,22 @@
+use std/io
+
+task compute() -> int {
+  sum = 0
+  i = 1
+  while i <= 10 {
+    if i % 2 == 0 {
+      sum += i
+    } else {
+      sum -= 1
+    }
+    i += 1
+  }
+
+  for j in 1..5 {
+    sum += j
+  }
+
+  return sum
+}
+
+io.show(compute())

--- a/tests/conformance/main.rs
+++ b/tests/conformance/main.rs
@@ -51,9 +51,19 @@
 //!
 //! Unix-only (`libc::dup`/`dup2`) — deferred for Windows, same as the rest
 //! of the native-backend work this issue is scaffolding for.
+//!
+//! The M1 interpreter-vs-compiled comparison (issue #136) is the one
+//! exception to "in-process, not a subprocess": it runs *both* engines as
+//! piped child processes (see `run_interpreter_subprocess_one` and
+//! `run_compiled_one`) rather than reusing this fd-1 dance, since mixing
+//! `capture_stdout` with the compiled engine's subprocess spawning in the
+//! same test lost the interpreter's captured output. The M0 corpus loop
+//! below is unaffected — it stays in-process, per the reasoning above.
 
 mod corpus;
 mod engine;
+#[cfg(feature = "build-backend")]
+mod runtime_link;
 
 use std::io::{Read as _, Seek as _, SeekFrom, Write as _};
 use std::os::unix::io::AsRawFd as _;
@@ -61,6 +71,8 @@ use std::path::Path;
 use std::time::Duration;
 
 use corpus::discover_corpus;
+#[cfg(feature = "build-backend")]
+use corpus::discover_m1_scalar_fixtures;
 use engine::{Engine, EngineError, EngineOutput};
 
 /// Per-program wall-clock budget. Generous enough for the mock LLM path and
@@ -132,6 +144,71 @@ async fn run_one(engine: Engine, path: &Path) -> Result<EngineOutput, EngineErro
     }
 }
 
+/// The interpreter-side counterpart to [`run_compiled_one`], used only by
+/// the M1 comparison below — spawns the already-built `keel` binary
+/// (`CARGO_BIN_EXE_keel`, set by Cargo for this integration-test target
+/// since the root package defines `[[bin]] name = "keel"`) as a piped child,
+/// rather than going through [`run_one`]'s in-process fd-1 capture.
+///
+/// This exists because mixing `run_one`'s fd-1 dup/dup2 dance with
+/// `run_compiled_one`'s subprocess-spawning in the same test lost the
+/// interpreter's captured output intermittently (and, once the big corpus
+/// loop below also ran in-process in the same test binary, *deterministically*):
+/// nothing here pinned down which tokio-internal timing caused it, and
+/// `capture_stdout`'s own doc comment already flags it as fragile to any
+/// shift in the process's async/fd state. Running the interpreter as a
+/// piped child too sidesteps the question entirely — same shape as
+/// `run_compiled_one`, and it never touches this process's fd 1.
+#[cfg(feature = "build-backend")]
+async fn run_interpreter_subprocess_one(path: &Path) -> Result<EngineOutput, EngineError> {
+    let path = path
+        .canonicalize()
+        .unwrap_or_else(|e| panic!("canonicalize {}: {e}", path.display()));
+    let workdir = tempfile::tempdir().expect("create isolated run workdir");
+
+    let mut cmd = tokio::process::Command::new(env!("CARGO_BIN_EXE_keel"));
+    cmd.arg("run")
+        .arg(&path)
+        .env("KEEL_LLM", "mock")
+        .env("KEEL_ONESHOT", "1")
+        .current_dir(workdir.path());
+
+    match tokio::time::timeout(PER_PROGRAM_TIMEOUT, cmd.output()).await {
+        Ok(Ok(output)) => Ok(EngineOutput {
+            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+            exit_code: output.status.code().unwrap_or(1),
+        }),
+        Ok(Err(e)) => Err(EngineError::LoadFailed(format!("spawn `keel run`: {e}"))),
+        Err(_elapsed) => Err(EngineError::TimedOut(PER_PROGRAM_TIMEOUT)),
+    }
+}
+
+/// The `Engine::Compiled` analogue of [`run_one`] — same isolated-workdir
+/// and timeout treatment, but no fd-1 capture: `engine::run_compiled`
+/// captures the child's stdout itself via a piped `Command`, deliberately
+/// not sharing this process's stdio at all (see `engine.rs`'s module doc
+/// for why `run_one`'s fd-1 approach isn't used here). `workdir` becomes
+/// the child's cwd directly, so there's no `chdir`/restore dance on this
+/// process either.
+#[cfg(feature = "build-backend")]
+async fn run_compiled_one(path: &Path) -> Result<EngineOutput, EngineError> {
+    let path = path
+        .canonicalize()
+        .unwrap_or_else(|e| panic!("canonicalize {}: {e}", path.display()));
+    let workdir = tempfile::tempdir().expect("create isolated run workdir");
+
+    match tokio::time::timeout(
+        PER_PROGRAM_TIMEOUT,
+        engine::run_compiled(&path, Some(workdir.path())),
+    )
+    .await
+    {
+        Ok(Ok(output)) => Ok(output),
+        Ok(Err(engine_err)) => Err(engine_err),
+        Err(_elapsed) => Err(EngineError::TimedOut(PER_PROGRAM_TIMEOUT)),
+    }
+}
+
 /// Programs excluded from the corpus, one line each with a concrete reason.
 /// Categories: real network I/O, interactive stdin, outbound email,
 /// non-deterministic output (random/uuid/wall-clock), a real subprocess
@@ -195,6 +272,73 @@ async fn interpreter_is_deterministic_across_the_corpus() {
         std::env::set_var("KEEL_ONESHOT", "1");
     }
 
+    // Without the LLVM toolchain (`build-backend` off), `Engine::Compiled`
+    // stays a stub — exercise that contract directly (not through the
+    // corpus loop below) so it has its own regression coverage independent
+    // of which examples happen to be skipped. Calls `Engine::run` directly
+    // rather than through `run_one`: that helper redirects fd 1 and changes
+    // the process cwd, which this doesn't need.
+    #[cfg(not(feature = "build-backend"))]
+    {
+        let fixtures = corpus::fixtures_dir();
+        let path = fixtures.join("agent_lifecycle.keel");
+        let err = Engine::Compiled
+            .run(&path)
+            .await
+            .expect_err("Engine::Compiled has no backend yet");
+        assert!(matches!(err, EngineError::NotImplemented));
+    }
+
+    // Issue #136 (M1's own exit criterion): the compiled engine, run on a
+    // dedicated scalar-only fixture set (M1's scope — int/float/bool/str
+    // literals, arithmetic, if/while/for-over-ranges, direct task calls,
+    // io.show), must produce byte-identical stdout and exit codes to the
+    // interpreter. Both sides run as piped child processes here (see
+    // `run_interpreter_subprocess_one` and `run_compiled_one`) rather than
+    // going through `run_one`'s in-process fd-1 capture — that capture
+    // mechanism is documented as fragile to shifts in the process's
+    // async/fd state, and mixing it with `run_compiled_one`'s subprocess
+    // spawning in this same test lost the interpreter's captured output
+    // intermittently. Position relative to the corpus loop below no longer
+    // matters, since neither side of this comparison touches this
+    // process's fd 1 at all.
+    #[cfg(feature = "build-backend")]
+    {
+        let fixtures = discover_m1_scalar_fixtures();
+        assert!(
+            !fixtures.is_empty(),
+            "expected a non-empty M1-scalar conformance fixture set"
+        );
+
+        let mut m1_failures = Vec::new();
+        for entry in &fixtures {
+            let interpreted = run_interpreter_subprocess_one(&entry.path).await;
+            let compiled = run_compiled_one(&entry.path).await;
+            match (interpreted, compiled) {
+                (Ok(a), Ok(b)) if a == b => {}
+                (Ok(a), Ok(b)) => m1_failures.push(format!(
+                    "{}: compiled engine diverges from the interpreter:\n  interpreter: exit={} stdout={:?}\n  compiled:    exit={} stdout={:?}",
+                    entry.stem, a.exit_code, a.stdout, b.exit_code, b.stdout
+                )),
+                (Err(e), _) | (_, Err(e)) => {
+                    m1_failures.push(format!("{}: engine error: {e}", entry.stem));
+                }
+            }
+        }
+
+        eprintln!(
+            "conformance (M1 scalar, interpreter vs. compiled): {} run, {} failed",
+            fixtures.len(),
+            m1_failures.len()
+        );
+        assert!(
+            m1_failures.is_empty(),
+            "M1 conformance failures ({}):\n{}",
+            m1_failures.len(),
+            m1_failures.join("\n")
+        );
+    }
+
     let corpus = discover_corpus();
     assert!(
         !corpus.is_empty(),
@@ -238,20 +382,4 @@ async fn interpreter_is_deterministic_across_the_corpus() {
         failures.len(),
         failures.join("\n")
     );
-
-    // Exercises the `Engine::Compiled` stub directly (not through the corpus
-    // loop above) so the "not implemented" contract has its own regression
-    // coverage independent of which examples happen to be skipped. Inlined
-    // into this same test function rather than a separate #[test] — see the
-    // module doc comment for why a second test in this binary isn't safe.
-    // Calls `Engine::run` directly rather than through `run_one`: that
-    // helper redirects fd 1 and changes the process cwd, which
-    // `Engine::Compiled` doesn't need.
-    let fixtures = corpus::fixtures_dir();
-    let path = fixtures.join("agent_lifecycle.keel");
-    let err = Engine::Compiled
-        .run(&path)
-        .await
-        .expect_err("Engine::Compiled has no backend yet");
-    assert!(matches!(err, EngineError::NotImplemented));
 }

--- a/tests/conformance/runtime_link.rs
+++ b/tests/conformance/runtime_link.rs
@@ -1,0 +1,91 @@
+//! Locates `libkeel_rt.a` and its platform-specific `native-static-libs`,
+//! the same way `crates/keel-codegen/tests/support/mod.rs` does — the two
+//! don't share a crate (this file compiles into the root package's
+//! conformance test binary, that one into `keel-codegen`'s own), so the
+//! ~30 lines are duplicated rather than factored into a new shared crate
+//! just for this. See that file's doc comment for the full rationale
+//! (dependency-purity: `keel-codegen` never depends on `keel-rt-ffi` by
+//! name, so the caller supplies the link args) and the `CARGO_TERM_COLOR`
+//! pitfall (CI sets it to `always`, which corrupts the last token of
+//! `native-static-libs` with an ANSI reset code unless disabled here).
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::OnceLock;
+
+pub fn runtime_link_args() -> &'static Vec<String> {
+    static ARGS: OnceLock<Vec<String>> = OnceLock::new();
+    ARGS.get_or_init(|| {
+        let mut args = vec![build_keel_rt_ffi_archive().to_string_lossy().into_owned()];
+        args.extend(native_static_libs());
+        args
+    })
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn build_keel_rt_ffi_archive() -> PathBuf {
+    let output = Command::new("cargo")
+        .current_dir(workspace_root())
+        .env("CARGO_TERM_COLOR", "never")
+        .args([
+            "build",
+            "-p",
+            "keel-rt-ffi",
+            "--lib",
+            "--message-format=json",
+        ])
+        .output()
+        .expect("spawn `cargo build -p keel-rt-ffi`");
+    assert!(
+        output.status.success(),
+        "building keel-rt-ffi failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        let Ok(msg) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        if msg.get("reason").and_then(serde_json::Value::as_str) != Some("compiler-artifact") {
+            continue;
+        }
+        let Some(filenames) = msg.get("filenames").and_then(serde_json::Value::as_array) else {
+            continue;
+        };
+        for name in filenames {
+            if let Some(s) = name.as_str()
+                && s.ends_with(".a")
+            {
+                return PathBuf::from(s);
+            }
+        }
+    }
+    panic!("`cargo build -p keel-rt-ffi` did not report a `.a` artifact");
+}
+
+fn native_static_libs() -> Vec<String> {
+    let output = Command::new("cargo")
+        .current_dir(workspace_root())
+        .env("CARGO_TERM_COLOR", "never")
+        .args([
+            "rustc",
+            "-p",
+            "keel-rt-ffi",
+            "--lib",
+            "-q",
+            "--color=never",
+            "--",
+            "--print",
+            "native-static-libs",
+        ])
+        .output()
+        .expect("spawn `cargo rustc -p keel-rt-ffi`");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if let Some((_, rest)) = stderr.split_once("native-static-libs:") {
+        return rest.split_whitespace().map(str::to_string).collect();
+    }
+    panic!("`cargo rustc -p keel-rt-ffi -- --print native-static-libs` gave no list:\n{stderr}");
+}


### PR DESCRIPTION
## Summary

- Closes issue #136 by wiring `Engine::Compiled` into the conformance harness's interpreter-vs-compiled comparison — this is M1's exit criterion: a scalar-only example compiles, links, runs, and matches the interpreter.
- Adds a scalar-only fixture set (`tests/conformance/fixtures/m1_scalar/`: arithmetic + direct calls, loops/branches, bool/float) that both engines run, diffed byte-for-byte, gated behind the `build-backend` feature.
- Fixes a harness flakiness bug found while wiring this up: the interpreter side now runs as a piped subprocess (spawning the built `keel` binary directly, `CARGO_BIN_EXE_keel`) rather than through the existing in-process fd-1 capture. Mixing that capture with the compiled engine's subprocess spawning in the same test process lost the interpreter's output intermittently, then deterministically once the full M0 corpus loop also ran in the same binary. Routing both sides through independent piped children removes the shared fd/tokio state entirely — the M0 interpreter-vs-interpreter loop is untouched and still uses the original in-process capture, since that comparison is symmetric and unaffected.
- Folds in doc drift left over from the milestone's earlier, already-merged tickets (#130/#131/#133): `--emit=kir` has supported `for`-over-ranges and namespace calls (`io.show`, `log.*`) for a while, but `docs/src/cli/build.md` and `docs/status/features.json` still described them as rejected. Updated both, plus a related note in `docs/src/getting-started/installation.md`, and added a single CHANGELOG entry summarizing the whole M1 milestone (per earlier agreement, one entry rather than one per sub-issue).

## Test plan

- [x] `cargo test --features build-backend --test conformance` — green, 6+ consecutive runs (previously flaky/deterministically failing)
- [x] `cargo test --workspace` (default, LLVM-free) — green
- [x] `cargo test --workspace --features build-backend` — green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo clippy --workspace --all-targets --features build-backend -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [x] `mdbook build` over `docs/` — clean
- [x] Manually verified the `--emit=kir` example in `docs/src/cli/build.md` against actual CLI output