### PR TITLE
Wire CheckArtifacts through keel-kir lowering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1432,6 +1432,7 @@ name = "keel-codegen"
 version = "0.2.4"
 dependencies = [
  "inkwell",
+ "keel-compiler",
  "keel-kir",
  "keel-syntax",
  "serde_json",
@@ -1469,6 +1470,7 @@ name = "keel-kir"
 version = "0.2.4"
 dependencies = [
  "keel-catalog",
+ "keel-compiler",
  "keel-syntax",
 ]
 

--- a/crates/keel-codegen/Cargo.toml
+++ b/crates/keel-codegen/Cargo.toml
@@ -14,6 +14,7 @@ keel-kir = { path = "../keel-kir" }
 inkwell = { version = "0.9.0", features = ["llvm22-1"] }
 
 [dev-dependencies]
+keel-compiler = { path = "../keel-compiler" }
 keel-syntax = { path = "../keel-syntax" }
 tempfile = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/keel-codegen/tests/control_flow_and_calls.rs
+++ b/crates/keel-codegen/tests/control_flow_and_calls.rs
@@ -15,9 +15,7 @@ use keel_codegen::BuildOptions;
 mod support;
 
 fn compile_and_run(source: &str) -> i32 {
-    let (program, _named) =
-        keel_syntax::parse_source(source, "t.keel").expect("fixture must parse");
-    let kir = keel_kir::lower(&program, "t.keel").expect("fixture must lower to KIR");
+    let kir = support::parse_check_and_lower(source);
 
     let out_dir = tempfile::tempdir().expect("create temp out dir");
     let opts = BuildOptions {

--- a/crates/keel-codegen/tests/namespace_calls.rs
+++ b/crates/keel-codegen/tests/namespace_calls.rs
@@ -12,9 +12,7 @@ use keel_codegen::BuildOptions;
 mod support;
 
 fn compile_and_run(source: &str) -> std::process::Output {
-    let (program, _named) =
-        keel_syntax::parse_source(source, "t.keel").expect("fixture must parse");
-    let kir = keel_kir::lower(&program, "t.keel").expect("fixture must lower to KIR");
+    let kir = support::parse_check_and_lower(source);
 
     let out_dir = tempfile::tempdir().expect("create temp out dir");
     let opts = BuildOptions {

--- a/crates/keel-codegen/tests/support/mod.rs
+++ b/crates/keel-codegen/tests/support/mod.rs
@@ -14,6 +14,25 @@ use std::path::PathBuf;
 use std::process::{Command, Output};
 use std::sync::OnceLock;
 
+/// Parses, type-checks, and lowers `source` to KIR — the same
+/// check-then-lower shape every real caller of `keel_kir::lower` uses (see
+/// `keel-kir`'s `lower::lower_program` doc: lowering consumes an already
+/// type-checked program's `CheckArtifacts`, it does not check for itself).
+/// Shared here since all three `tests/*.rs` files in this crate that
+/// `#[path]`-include this module previously duplicated these two lines
+/// inline with no checking step at all.
+pub fn parse_check_and_lower(source: &str) -> keel_kir::ir::KirProgram {
+    let (program, _named) =
+        keel_syntax::parse_source(source, "t.keel").expect("fixture must parse");
+    let (diagnostics, artifacts) =
+        keel_compiler::types::checker::check_program_with_artifacts(&program, false);
+    assert!(
+        diagnostics.is_empty(),
+        "fixture must type-check cleanly: {diagnostics:?}"
+    );
+    keel_kir::lower(&program, "t.keel", &artifacts).expect("fixture must lower to KIR")
+}
+
 pub fn runtime_link_args() -> &'static Vec<String> {
     static ARGS: OnceLock<Vec<String>> = OnceLock::new();
     ARGS.get_or_init(|| {

--- a/crates/keel-codegen/tests/walking_skeleton.rs
+++ b/crates/keel-codegen/tests/walking_skeleton.rs
@@ -16,9 +16,7 @@ use keel_codegen::{BuildOptions, CodegenError};
 mod support;
 
 fn compile_and_run(source: &str) -> (i32, tempfile::TempDir) {
-    let (program, _named) =
-        keel_syntax::parse_source(source, "t.keel").expect("fixture must parse");
-    let kir = keel_kir::lower(&program, "t.keel").expect("fixture must lower to KIR");
+    let kir = support::parse_check_and_lower(source);
 
     let out_dir = tempfile::tempdir().expect("create temp out dir");
     let opts = BuildOptions {
@@ -35,9 +33,7 @@ fn compile_and_run(source: &str) -> (i32, tempfile::TempDir) {
 }
 
 fn compile_err(source: &str) -> CodegenError {
-    let (program, _named) =
-        keel_syntax::parse_source(source, "t.keel").expect("fixture must parse");
-    let kir = keel_kir::lower(&program, "t.keel").expect("fixture must lower to KIR");
+    let kir = support::parse_check_and_lower(source);
 
     let out_dir = tempfile::tempdir().expect("create temp out dir");
     let opts = BuildOptions {
@@ -56,7 +52,26 @@ fn int_arithmetic_becomes_the_exit_code() {
 
 #[test]
 fn let_and_augmented_assign_become_the_exit_code() {
-    let (code, _dir) = compile_and_run("n = 5\nn += 3\nn * 2\n");
+    // A bare top-level `n = 5\nn += 3` (no function) type-checks fine at
+    // runtime but is rejected by `keel check`/`keel run` today — a
+    // pre-existing checker bug (`check_body` gives every top-level
+    // `Decl::Stmt` its own fresh `Scope`, so a later statement can't see an
+    // earlier one's binding for augmented-assignment purposes; tracked
+    // separately, not a codegen/KIR concern). Wrapping in a function keeps
+    // this test green without depending on that bug being fixed, and still
+    // exercises Let/AugAssign/BinOp/call/exit-code exactly as before —
+    // `control_flow_and_calls.rs` already established the bare-call-as-
+    // exit-code convention this relies on.
+    let (code, _dir) = compile_and_run(
+        r#"
+task run() -> int {
+  n = 5
+  n += 3
+  return n * 2
+}
+run()
+"#,
+    );
     assert_eq!(code, 16);
 }
 

--- a/crates/keel-kir/Cargo.toml
+++ b/crates/keel-kir/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 
 [dependencies]
 keel-catalog = { path = "../keel-catalog" }
+keel-compiler = { path = "../keel-compiler" }
 keel-syntax = { path = "../keel-syntax" }
 
 [dev-dependencies]

--- a/crates/keel-kir/src/lib.rs
+++ b/crates/keel-kir/src/lib.rs
@@ -17,6 +17,7 @@ pub mod passes;
 pub mod span_table;
 pub mod types;
 
+use keel_compiler::types::artifacts::CheckArtifacts;
 use keel_syntax::ast::Program;
 
 use ir::KirProgram;
@@ -62,13 +63,21 @@ impl From<passes::verify::VerifyError> for KirError {
 /// consumer today.
 ///
 /// `file_name` is used only for the span table (diagnostics, dumps) — it
-/// does not need to be a real path.
+/// does not need to be a real path. `artifacts` is the resolved-type table
+/// from running the checker over the same program (e.g.
+/// `keel_compiler::types::checker::check_program_with_artifacts`) —
+/// callers must check it for errors before calling this; lowering does not
+/// re-check.
 ///
 /// # Errors
 ///
 /// See [`KirError`].
-pub fn lower(program: &Program, file_name: &str) -> Result<KirProgram, KirError> {
-    let program = lower::lower_program(program, file_name)?;
+pub fn lower(
+    program: &Program,
+    file_name: &str,
+    artifacts: &CheckArtifacts,
+) -> Result<KirProgram, KirError> {
+    let program = lower::lower_program(program, file_name, artifacts)?;
     let program = mono::monomorphize(program);
     let program = passes::boxing::insert_boxing(program);
     let program = passes::rc::insert_rc(program);

--- a/crates/keel-kir/src/lower/decl.rs
+++ b/crates/keel-kir/src/lower/decl.rs
@@ -4,6 +4,7 @@
 
 use std::collections::HashMap;
 
+use keel_compiler::types::artifacts::CheckArtifacts;
 use keel_syntax::ast::TaskDecl;
 
 use super::{FnCtx, FuncSig, LowerError, binding_ident, ty_expr_to_kir};
@@ -53,6 +54,7 @@ pub(crate) fn lower_task_body(
     funcs: &HashMap<String, FuncSig>,
     ns_bindings: &HashMap<String, String>,
     table: &mut SpanTable,
+    artifacts: &CheckArtifacts,
 ) -> Result<KirFunction, LowerError> {
     let mut ctx = FnCtx::new();
     let mut params = Vec::with_capacity(task.params.len());
@@ -62,7 +64,15 @@ pub(crate) fn lower_task_body(
         params.push(Param { local, ty: *ty });
     }
 
-    let body = super::stmt::lower_block(&task.body, &mut ctx, funcs, ns_bindings, table, sig.ret)?;
+    let body = super::stmt::lower_block(
+        &task.body,
+        &mut ctx,
+        funcs,
+        ns_bindings,
+        table,
+        sig.ret,
+        artifacts,
+    )?;
 
     Ok(KirFunction {
         id: sig.func_id,

--- a/crates/keel-kir/src/lower/expr.rs
+++ b/crates/keel-kir/src/lower/expr.rs
@@ -9,6 +9,7 @@
 
 use std::collections::HashMap;
 
+use keel_compiler::types::artifacts::CheckArtifacts;
 use keel_syntax::ast::{self, SpannedExpr};
 use keel_syntax::lexer::Span;
 
@@ -40,8 +41,9 @@ pub(crate) fn convert_binop(op: ast::BinOp) -> ir::BinOp {
 /// Structural type inference for a binary op, given both operands' already-
 /// known KIR types. Mirrors the scalar slice of the real type checker's
 /// binary-op rules (`crates/keel-compiler/src/types/checker.rs`) closely
-/// enough for M0; see the `#109` seam note in `lower/mod.rs` for why this is
-/// local inference rather than a `CheckArtifacts` lookup.
+/// enough for M0/M1; see the `CheckArtifacts` note in `lower/mod.rs` for why
+/// this stays local structural inference rather than a `CheckArtifacts`
+/// lookup.
 pub(crate) fn infer_binop_ty(
     op: ir::BinOp,
     left: KirType,
@@ -100,6 +102,7 @@ pub(crate) fn lower_expr(
     funcs: &HashMap<String, FuncSig>,
     ns_bindings: &HashMap<String, String>,
     table: &mut SpanTable,
+    artifacts: &CheckArtifacts,
 ) -> Result<Expr, LowerError> {
     match &expr.kind {
         ast::Expr::Integer(v) => Ok(Expr::ConstInt(*v)),
@@ -114,8 +117,8 @@ pub(crate) fn lower_expr(
             Ok(Expr::Local { id: local, ty })
         }
         ast::Expr::BinaryOp { left, op, right } => {
-            let left_e = lower_expr(left, ctx, funcs, ns_bindings, table)?;
-            let right_e = lower_expr(right, ctx, funcs, ns_bindings, table)?;
+            let left_e = lower_expr(left, ctx, funcs, ns_bindings, table, artifacts)?;
+            let right_e = lower_expr(right, ctx, funcs, ns_bindings, table, artifacts)?;
             let kir_op = convert_binop(*op);
             let ty = infer_binop_ty(kir_op, left_e.ty(), right_e.ty(), &expr.span)?;
             Ok(Expr::BinOp {
@@ -126,7 +129,7 @@ pub(crate) fn lower_expr(
             })
         }
         ast::Expr::UnaryOp { op, expr: operand } => {
-            let operand_e = lower_expr(operand, ctx, funcs, ns_bindings, table)?;
+            let operand_e = lower_expr(operand, ctx, funcs, ns_bindings, table, artifacts)?;
             let ty = match op {
                 ast::UnOp::Neg if operand_e.ty().is_numeric() => operand_e.ty(),
                 ast::UnOp::Not if operand_e.ty() == KirType::Bool => KirType::Bool,
@@ -153,9 +156,16 @@ pub(crate) fn lower_expr(
                 ty,
             })
         }
-        ast::Expr::Call { callee, args } => {
-            lower_call(callee, args, ctx, funcs, ns_bindings, table, &expr.span)
-        }
+        ast::Expr::Call { callee, args } => lower_call(
+            callee,
+            args,
+            ctx,
+            funcs,
+            ns_bindings,
+            table,
+            artifacts,
+            &expr.span,
+        ),
         ast::Expr::FieldAccess(..) => {
             Err(LowerError::unsupported("field access", expr.span.clone()))
         }
@@ -205,6 +215,7 @@ pub(crate) fn lower_expr(
                     funcs,
                     ns_bindings,
                     table,
+                    artifacts,
                     &expr.span,
                 )
             } else {
@@ -250,6 +261,7 @@ fn lower_string_lit(parts: &[ast::StringPart], span: &Span) -> Result<Expr, Lowe
 /// calls never reach here — the parser produces `ast::Expr::MethodCall` for
 /// all dot-call syntax, not `Call` with a field-access callee; see the
 /// `ast::Expr::MethodCall` arm in `lower_expr` for namespace-call lowering.
+#[allow(clippy::too_many_arguments)]
 fn lower_call(
     callee: &SpannedExpr,
     args: &[ast::CallArg],
@@ -257,6 +269,7 @@ fn lower_call(
     funcs: &HashMap<String, FuncSig>,
     ns_bindings: &HashMap<String, String>,
     table: &mut SpanTable,
+    artifacts: &CheckArtifacts,
     call_span: &Span,
 ) -> Result<Expr, LowerError> {
     let ast::Expr::Ident(name) = &callee.kind else {
@@ -288,7 +301,7 @@ fn lower_call(
                 arg.value.span.clone(),
             ));
         }
-        let lowered = lower_expr(&arg.value, ctx, funcs, ns_bindings, table)?;
+        let lowered = lower_expr(&arg.value, ctx, funcs, ns_bindings, table, artifacts)?;
         if lowered.ty() != *expected_ty {
             return Err(LowerError::new(
                 format!(
@@ -334,6 +347,7 @@ fn lower_ns_call(
     funcs: &HashMap<String, FuncSig>,
     ns_bindings: &HashMap<String, String>,
     table: &mut SpanTable,
+    artifacts: &CheckArtifacts,
     call_span: &Span,
 ) -> Result<Expr, LowerError> {
     let builtin = keel_catalog::catalog_method(namespace, method).ok_or_else(|| {
@@ -369,7 +383,14 @@ fn lower_ns_call(
                 arg.value.span.clone(),
             ));
         }
-        lowered_args.push(lower_expr(&arg.value, ctx, funcs, ns_bindings, table)?);
+        lowered_args.push(lower_expr(
+            &arg.value,
+            ctx,
+            funcs,
+            ns_bindings,
+            table,
+            artifacts,
+        )?);
     }
 
     let ty = result_ty_to_kir(builtin.result, call_span)?;

--- a/crates/keel-kir/src/lower/mod.rs
+++ b/crates/keel-kir/src/lower/mod.rs
@@ -17,25 +17,27 @@
 //! one already-`keel check`ed [`Program`], not a `ModuleGraph`. The CLI
 //! (`src/pipeline.rs`) passes the entry module only.
 //!
-//! # The `#109` seam
+//! # `CheckArtifacts`
 //!
 //! `designs/llvm-compilation.md` §2.2 specifies
 //! `lib.rs: lower(ModuleGraph, CheckArtifacts) -> KirProgram` — consuming
 //! the type checker's per-expression `Ty` table (`CheckArtifacts::expr_types`,
-//! added by issue #109's `check_program_with_artifacts`). That plumbing does
-//! not exist yet in this tree, so `lower_program` below infers scalar types
-//! itself: task signatures come from AST type annotations
-//! (`decl::signature_of`), and expression types are propagated structurally
-//! (literal -> obvious type; binary op -> `expr::infer_binop_ty`; identifier
-//! -> the type its declaring `let`/param recorded).
+//! added by issue #109's `check_program_with_artifacts`/PR #122). `lower_program`
+//! takes `&CheckArtifacts` and threads it through every lowering function, but
+//! the M0/M1 scalar subset still gets its `KirType`s from structural bottom-up
+//! inference (literal -> obvious type; binary op -> `expr::infer_binop_ty`;
+//! identifier -> the type its declaring `let`/param recorded) rather than
+//! artifact lookups — that inference is provably correct and conformance-
+//! tested for everything it currently covers, so replacing it would be
+//! churn with no behavior change. `artifacts` becomes load-bearing starting
+//! with constructs that need the checker's own resolution (an anonymous
+//! struct literal's target type, a nullable's inner type, …) — see
+//! `designs/llvm-compilation.md` §4 M2's per-feature issues.
 //!
-// TODO(#109): once `CheckArtifacts` lands, replace the local inference in
-// `expr.rs`/`stmt.rs`/`decl.rs` with lookups into `artifacts.expr_types`
-// (keyed by `Span`), and change this function's signature to take
-// `&ModuleGraph` + `&CheckArtifacts` instead of `&Program`. The two-pass
-// signature-collection structure below (collect all task signatures, then
-// lower bodies) stays either way — it's what makes forward/mutual calls
-// resolve.
+//! Multi-module lowering is still out of scope: `lower_program` takes one
+//! already-`keel check`ed [`Program`] (plus the `CheckArtifacts` from
+//! checking that same program), not a `ModuleGraph`. The CLI
+//! (`src/pipeline.rs`) passes the entry module only.
 pub mod decl;
 pub mod expr;
 pub mod stmt;
@@ -44,6 +46,7 @@ pub mod sugar;
 use std::collections::HashMap;
 use std::fmt;
 
+use keel_compiler::types::artifacts::CheckArtifacts;
 use keel_syntax::ast::{Binding, Decl, Program, UseDecl, UseKind, UseSource};
 use keel_syntax::lexer::Span;
 
@@ -155,7 +158,11 @@ impl FnCtx {
 ///
 /// Returns a [`LowerError`] at the first AST construct outside the M0
 /// scalar subset, or the first local scalar-inference mismatch.
-pub fn lower_program(program: &Program, file_name: &str) -> Result<KirProgram, LowerError> {
+pub fn lower_program(
+    program: &Program,
+    file_name: &str,
+    artifacts: &CheckArtifacts,
+) -> Result<KirProgram, LowerError> {
     let mut span_table = SpanTable::new(file_name);
     let mut funcs: HashMap<String, FuncSig> = HashMap::new();
     let mut ns_bindings: HashMap<String, String> = HashMap::new();
@@ -203,6 +210,7 @@ pub fn lower_program(program: &Program, file_name: &str) -> Result<KirProgram, L
             &funcs,
             &ns_bindings,
             &mut span_table,
+            artifacts,
         )?);
     }
 
@@ -220,6 +228,7 @@ pub fn lower_program(program: &Program, file_name: &str) -> Result<KirProgram, L
                 &ns_bindings,
                 &mut span_table,
                 KirType::Unit,
+                artifacts,
             )?);
         }
     }

--- a/crates/keel-kir/src/lower/stmt.rs
+++ b/crates/keel-kir/src/lower/stmt.rs
@@ -7,6 +7,7 @@
 
 use std::collections::HashMap;
 
+use keel_compiler::types::artifacts::CheckArtifacts;
 use keel_syntax::ast::{self, Node};
 
 use super::{FnCtx, FuncSig, LowerError, binding_ident, ty_expr_to_kir};
@@ -17,6 +18,7 @@ use crate::types::KirType;
 use super::expr::lower_expr;
 
 /// Lowers a `{ ... }` block in its own child scope.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn lower_block(
     block: &ast::Block,
     ctx: &mut FnCtx,
@@ -24,11 +26,20 @@ pub(crate) fn lower_block(
     ns_bindings: &HashMap<String, String>,
     table: &mut SpanTable,
     ret_ty: KirType,
+    artifacts: &CheckArtifacts,
 ) -> Result<Block, LowerError> {
     ctx.push_scope();
     let mut out = Vec::with_capacity(block.len());
     for stmt in block {
-        out.push(lower_stmt(stmt, ctx, funcs, ns_bindings, table, ret_ty)?);
+        out.push(lower_stmt(
+            stmt,
+            ctx,
+            funcs,
+            ns_bindings,
+            table,
+            ret_ty,
+            artifacts,
+        )?);
     }
     ctx.pop_scope();
     Ok(out)
@@ -38,6 +49,7 @@ pub(crate) fn lower_block(
 /// need block scoping (`if`/`while` bodies) go through [`lower_block`]; the
 /// synthetic top-level function lowers its statements directly into the
 /// function's single root scope.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn lower_stmt(
     stmt: &Node<ast::Stmt>,
     ctx: &mut FnCtx,
@@ -45,11 +57,12 @@ pub(crate) fn lower_stmt(
     ns_bindings: &HashMap<String, String>,
     table: &mut SpanTable,
     ret_ty: KirType,
+    artifacts: &CheckArtifacts,
 ) -> Result<ir::Stmt, LowerError> {
     match &stmt.kind {
         ast::Stmt::Let { binding, ty, value } => {
             let name = binding_ident(binding, &stmt.span)?;
-            let init = lower_expr(value, ctx, funcs, ns_bindings, table)?;
+            let init = lower_expr(value, ctx, funcs, ns_bindings, table, artifacts)?;
             let declared_ty = init.ty();
             if let Some(annotation) = ty {
                 let annotated = ty_expr_to_kir(annotation)?;
@@ -75,7 +88,7 @@ pub(crate) fn lower_stmt(
                 LowerError::new(format!("unknown identifier `{name}`"), name_span.clone())
             })?;
             let local_ty = ctx.locals[local].ty;
-            let rhs_expr = lower_expr(rhs, ctx, funcs, ns_bindings, table)?;
+            let rhs_expr = lower_expr(rhs, ctx, funcs, ns_bindings, table, artifacts)?;
             let op = super::expr::convert_binop(*op);
             let result_ty = super::expr::infer_binop_ty(op, local_ty, rhs_expr.ty(), &stmt.span)?;
             if result_ty != local_ty {
@@ -107,7 +120,7 @@ pub(crate) fn lower_stmt(
             Ok(ir::Stmt::Return(None))
         }
         ast::Stmt::Return(Some(value)) => {
-            let expr = lower_expr(value, ctx, funcs, ns_bindings, table)?;
+            let expr = lower_expr(value, ctx, funcs, ns_bindings, table, artifacts)?;
             if expr.ty() != ret_ty {
                 return Err(LowerError::new(
                     format!(
@@ -124,16 +137,17 @@ pub(crate) fn lower_stmt(
             then_body,
             else_body,
         } => {
-            let cond_expr = lower_expr(cond, ctx, funcs, ns_bindings, table)?;
+            let cond_expr = lower_expr(cond, ctx, funcs, ns_bindings, table, artifacts)?;
             if cond_expr.ty() != KirType::Bool {
                 return Err(LowerError::new(
                     format!("`if` condition is `{}`, expected `bool`", cond_expr.ty()),
                     cond.span.clone(),
                 ));
             }
-            let then_branch = lower_block(then_body, ctx, funcs, ns_bindings, table, ret_ty)?;
+            let then_branch =
+                lower_block(then_body, ctx, funcs, ns_bindings, table, ret_ty, artifacts)?;
             let else_branch = match else_body {
-                Some(body) => lower_block(body, ctx, funcs, ns_bindings, table, ret_ty)?,
+                Some(body) => lower_block(body, ctx, funcs, ns_bindings, table, ret_ty, artifacts)?,
                 None => Vec::new(),
             };
             Ok(ir::Stmt::If {
@@ -143,14 +157,14 @@ pub(crate) fn lower_stmt(
             })
         }
         ast::Stmt::While { cond, body } => {
-            let cond_expr = lower_expr(cond, ctx, funcs, ns_bindings, table)?;
+            let cond_expr = lower_expr(cond, ctx, funcs, ns_bindings, table, artifacts)?;
             if cond_expr.ty() != KirType::Bool {
                 return Err(LowerError::new(
                     format!("`while` condition is `{}`, expected `bool`", cond_expr.ty()),
                     cond.span.clone(),
                 ));
             }
-            let body = lower_block(body, ctx, funcs, ns_bindings, table, ret_ty)?;
+            let body = lower_block(body, ctx, funcs, ns_bindings, table, ret_ty, artifacts)?;
             Ok(ir::Stmt::While {
                 cond: cond_expr,
                 body,
@@ -162,6 +176,7 @@ pub(crate) fn lower_stmt(
             funcs,
             ns_bindings,
             table,
+            artifacts,
         )?)),
         ast::Stmt::SelfAssign { .. } => Err(LowerError::unsupported(
             "self.field assignment",
@@ -188,14 +203,14 @@ pub(crate) fn lower_stmt(
             };
             // Bounds are evaluated once, before `var` exists, so they lower
             // in the enclosing scope and cannot reference the loop variable.
-            let low = lower_expr(start, ctx, funcs, ns_bindings, table)?;
+            let low = lower_expr(start, ctx, funcs, ns_bindings, table, artifacts)?;
             if low.ty() != KirType::I64 {
                 return Err(LowerError::new(
                     format!("`for` range start is `{}`, expected `int`", low.ty()),
                     start.span.clone(),
                 ));
             }
-            let high = lower_expr(end, ctx, funcs, ns_bindings, table)?;
+            let high = lower_expr(end, ctx, funcs, ns_bindings, table, artifacts)?;
             if high.ty() != KirType::I64 {
                 return Err(LowerError::new(
                     format!("`for` range end is `{}`, expected `int`", high.ty()),
@@ -204,7 +219,7 @@ pub(crate) fn lower_stmt(
             }
             ctx.push_scope();
             let var = ctx.declare(name, KirType::I64);
-            let body = lower_block(body, ctx, funcs, ns_bindings, table, ret_ty)?;
+            let body = lower_block(body, ctx, funcs, ns_bindings, table, ret_ty, artifacts)?;
             ctx.pop_scope();
             Ok(ir::Stmt::ForIndex {
                 var,

--- a/crates/keel-kir/src/types.rs
+++ b/crates/keel-kir/src/types.rs
@@ -1,10 +1,10 @@
 //! `KirType` — the lowered type vocabulary KIR expressions carry.
 //!
-//! M0 lowers the scalar subset only (see `designs/llvm-compilation.md` §4,
-//! M0), so only the unboxed-scalar variants are reachable from `lower/`
+//! M0/M1 lower the scalar subset only (see `designs/llvm-compilation.md`
+//! §4), so only the unboxed-scalar variants are reachable from `lower/`
 //! today. The remaining variants sketched in the design doc's `KirType`
 //! (§2.3) — containers, structs, enums, nullable, func, boxed `dynamic`,
-//! opaque handles — are deliberately not modeled yet; adding them is M1+
+//! opaque handles — are deliberately not modeled yet; adding them is M2+
 //! work, done alongside the lowering support that produces them.
 
 /// A KIR-level type. Every KIR expression carries one.
@@ -75,6 +75,40 @@ impl KirType {
             | TySpec::ListOfMapStrStr
             | TySpec::ListOfMapStrDynamic
             | TySpec::Unknown => None,
+        }
+    }
+
+    /// Maps the checker's resolved [`keel_compiler::types::ty::Ty`] (from
+    /// `CheckArtifacts::expr_types`) to the equivalent `KirType`, for the
+    /// scalar subset this crate lowers today. `None` for anything needing
+    /// containers, structs, enums, nullable, or boxing — callers reject
+    /// those with a `LowerError`/`VerifyError` naming the construct, same
+    /// policy as [`Self::from_tyspec`].
+    #[must_use]
+    pub fn from_ty(ty: &keel_compiler::types::ty::Ty) -> Option<KirType> {
+        use keel_compiler::types::ty::Ty;
+        match ty {
+            Ty::Int => Some(KirType::I64),
+            Ty::Float => Some(KirType::F64),
+            Ty::Bool => Some(KirType::Bool),
+            Ty::Str => Some(KirType::Str),
+            Ty::None_ => Some(KirType::Unit),
+            Ty::Duration
+            | Ty::Datetime
+            | Ty::Uuid
+            | Ty::List(_)
+            | Ty::Map(_, _)
+            | Ty::Set(_)
+            | Ty::Struct { .. }
+            | Ty::Tuple(_)
+            | Ty::Func(_, _)
+            | Ty::Enum(_, _)
+            | Ty::DbConnection
+            | Ty::Dynamic
+            | Ty::Error
+            | Ty::Unresolved(_)
+            | Ty::Unknown(_)
+            | Ty::Nullable(_) => None,
         }
     }
 }

--- a/crates/keel-kir/tests/golden_dump.rs
+++ b/crates/keel-kir/tests/golden_dump.rs
@@ -17,7 +17,13 @@ fn fixtures_dir() -> PathBuf {
 fn dump_for(keel_source: &str, file_name: &str) -> String {
     let (program, _named) =
         keel_syntax::parse_source(keel_source, file_name).expect("fixture must parse");
-    let kir = keel_kir::lower(&program, file_name).expect("fixture must lower to KIR");
+    let (diagnostics, artifacts) =
+        keel_compiler::types::checker::check_program_with_artifacts(&program, false);
+    assert!(
+        diagnostics.is_empty(),
+        "golden fixture must type-check cleanly: {diagnostics:?}"
+    );
+    let kir = keel_kir::lower(&program, file_name, &artifacts).expect("fixture must lower to KIR");
     keel_kir::dump::dump(&kir)
 }
 

--- a/crates/keel-kir/tests/lower_errors.rs
+++ b/crates/keel-kir/tests/lower_errors.rs
@@ -3,9 +3,19 @@
 //! scalar subset fails loudly with a `LowerError`, rather than silently
 //! dropping/approximating it.
 
+/// Pins what `keel-kir`'s own lowering rejects, independent of the type
+/// checker: several fixtures below (structs, generics, agents, …) are
+/// perfectly valid Keel the checker accepts today — it's the scalar-subset
+/// *lowering* that hasn't caught up to the full language yet. So this
+/// deliberately ignores the checker's diagnostics rather than gating on
+/// them; `artifacts` is still needed (lowering's signature requires it) but
+/// its accuracy on a program the checker rejects isn't this test's concern.
 fn lower_err(source: &str) -> String {
     let (program, _named) = keel_syntax::parse_source(source, "t.keel").expect("must parse");
-    let err = keel_kir::lower(&program, "t.keel").expect_err("must be rejected by M0 lowering");
+    let (_diagnostics, artifacts) =
+        keel_compiler::types::checker::check_program_with_artifacts(&program, false);
+    let err = keel_kir::lower(&program, "t.keel", &artifacts)
+        .expect_err("must be rejected by M0 lowering");
     err.to_string()
 }
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -368,8 +368,16 @@ pub fn build_file(path: &Path, emit: Option<&str>) -> Result<()> {
                 ));
             }
             let entry = checked.graph.entry();
-            let kir =
-                keel_kir::lower(&entry.program, &entry.name).map_err(|e| miette::miette!("{e}"))?;
+            let (diagnostics, artifacts) =
+                crate::types::checker::check_program_with_artifacts(&entry.program, false);
+            if !diagnostics.is_empty() {
+                return Err(miette::miette!(
+                    "{} type error(s) — cannot lower a program with type errors to KIR",
+                    diagnostics.len()
+                ));
+            }
+            let kir = keel_kir::lower(&entry.program, &entry.name, &artifacts)
+                .map_err(|e| miette::miette!("{e}"))?;
             print!("{}", keel_kir::dump::dump(&kir));
             Ok(())
         }

--- a/tests/conformance/engine.rs
+++ b/tests/conformance/engine.rs
@@ -149,7 +149,15 @@ pub async fn run_compiled(
 
     let (program, _named) = keel_syntax::parse_source(&source, &name)
         .map_err(|e| EngineError::LoadFailed(format!("parse: {e:?}")))?;
-    let kir = keel_kir::lower(&program, &name)
+    let (diagnostics, artifacts) =
+        keel_compiler::types::checker::check_program_with_artifacts(&program, false);
+    if !diagnostics.is_empty() {
+        return Err(EngineError::LoadFailed(format!(
+            "{} type error(s) in a corpus program that is expected to be clean",
+            diagnostics.len()
+        )));
+    }
+    let kir = keel_kir::lower(&program, &name, &artifacts)
         .map_err(|e| EngineError::LoadFailed(format!("lower to KIR: {e}")))?;
 
     let out_dir = tempfile::tempdir()


### PR DESCRIPTION
## Summary

- Prerequisite for M2 (#113): threads the type checker's `CheckArtifacts` (per-expression resolved types, from #109/PR #122) through `keel-kir`'s lowering pipeline, and makes both real call sites (`keel build --emit=kir`, the conformance harness's compiled-engine path) actually run the checker before lowering — previously neither did, relying on hand-curated fixtures happening to be clean.
- No behavior change to what M1 already lowers: the scalar subset's own structural type inference (`infer_binop_ty`, literal typing, etc.) is untouched, since it's already correct and conformance-tested. `CheckArtifacts` becomes load-bearing starting with the M2 issues that need the checker's own resolution (struct literals' target type, `when` scrutinees, nullable inner types, interpolation slot types) — this PR just makes it available.
- Consolidated three near-identical `parse_source` + `keel_kir::lower` test helpers in `keel-codegen`'s test suite into one shared, now checking, helper (`support::parse_check_and_lower`) while touching all three files anyway.

## A bug this surfaced (not fixed here)

Wiring the real type checker into `keel-codegen`'s test path for the first time (it previously bypassed checking entirely) broke one existing test: a bare top-level `n = 5\nn += 3` — valid at runtime — is rejected by `keel check`/`keel run` today with "augmented assignment to undefined variable `n`". Root cause: `Checker::check_body` gives every top-level statement its own fresh `Scope`, so a later top-level statement can't see an earlier one's binding for augmented-assignment purposes. The flip side is worse: real cross-statement type errors at the top level (`x = 1; y = x + "oops"`) are silently accepted instead of rejected, since the same fresh-scope issue makes the type information unavailable rather than erroring on it.

This is a real, pre-existing, wide-reaching checker bug, but well outside this PR's "no behavior change" scope — filed separately as #154 (not an M2 sub-issue; it's a general checker correctness hole, not native-backend work). Worked around it in the one affected test fixture (wrapped in a function, matching the M1 `loops_and_branches` fixture's earlier fix for the same underlying quirk) rather than fixing the checker here.

## Test plan

- [x] `cargo test --workspace` (default, LLVM-free) — green
- [x] `cargo test --workspace --features build-backend` — green
- [x] `cargo test --features build-backend --test conformance` — green, 3 consecutive runs
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo clippy --workspace --all-targets --features build-backend -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [x] All existing `keel-kir`/`keel-codegen` golden-dump, lower-error, and codegen tests pass byte-identical to before this change