### PR TITLE
keel-kir + keel-codegen: named structs end to end

### DIFF
--- a/crates/keel-codegen/src/expr.rs
+++ b/crates/keel-codegen/src/expr.rs
@@ -1,12 +1,11 @@
 //! Expression codegen: literals, locals, arithmetic/comparison/logical
-//! binary ops, unary `-`/`not`, and direct `CallTarget::Fn` calls between
-//! compiled Keel functions. `str` literals and `CallTarget::Ns` (namespace
-//! dispatch) are rejected — see `layout.rs` and issue #135.
+//! binary ops, unary `-`/`not`, direct `CallTarget::Fn` calls between
+//! compiled Keel functions, and M2's named-struct construction/field access.
 
-use inkwell::values::{BasicMetadataValueEnum, BasicValueEnum, ValueKind};
-use inkwell::{FloatPredicate, IntPredicate};
+use inkwell::values::{BasicMetadataValueEnum, BasicValueEnum, PointerValue, ValueKind};
+use inkwell::{AddressSpace, FloatPredicate, IntPredicate};
 
-use keel_kir::ir::{BinOp, CallTarget, Expr, UnOp};
+use keel_kir::ir::{BinOp, CallTarget, Expr, StructId, UnOp};
 use keel_kir::types::KirType;
 
 use crate::CodegenError;
@@ -38,15 +37,13 @@ pub(crate) fn emit_expr<'ctx>(
             .bool_type()
             .const_int(u64::from(*v), false)
             .into()),
-        Expr::ConstStr(_) => Err(CodegenError::Unsupported(
-            "str literal (issue #135)".to_string(),
-        )),
+        Expr::ConstStr(s) => Ok(crate::ns_call::emit_box_str_const(fcx, s)?.into()),
         Expr::Local { id, .. } => {
             let ptr = *fcx
                 .locals
                 .get(id)
                 .expect("verified KIR: local declared before use (passes::verify)");
-            let ty = layout::llvm_type(fcx.context, expr.ty())?;
+            let ty = layout::llvm_type(fcx.context, fcx.program, expr.ty())?;
             fcx.builder.build_load(ty, ptr, "load").map_err(llvm_err)
         }
         Expr::BinOp {
@@ -59,7 +56,82 @@ pub(crate) fn emit_expr<'ctx>(
             ty,
             span,
         } => emit_call(fcx, *target, args, *ty, *span),
+        Expr::MakeStruct { struct_id, fields } => emit_make_struct(fcx, *struct_id, fields),
+        Expr::FieldGet {
+            base,
+            field_index,
+            ty,
+        } => emit_field_get(fcx, base, *field_index, *ty),
     }
+}
+
+/// Allocates a fresh heap struct (via `malloc`, leaked for process lifetime
+/// — same precedent M1 set for `KeelBox` retain/release, see
+/// `keel-rt-ffi`'s `abi/rc.rs` doc) and stores every field through a `GEP`.
+/// `layout::llvm_type`/`struct_layout_type` already reject an all-scalar
+/// struct (by-value codegen isn't wired up), so every `struct_id` reaching
+/// here is heap-typed.
+fn emit_make_struct<'ctx>(
+    fcx: &FuncCtx<'ctx, '_>,
+    struct_id: StructId,
+    fields: &[Expr],
+) -> Result<BasicValueEnum<'ctx>, CodegenError> {
+    let layout_ty = layout::struct_layout_type(fcx.context, fcx.program, struct_id)?;
+    let size = layout_ty
+        .size_of()
+        .expect("a struct built from sized field types always has a known size");
+
+    let ptr_type = fcx.context.ptr_type(AddressSpace::default());
+    let malloc_fn = crate::ns_call::declare_or_get(fcx.module, "malloc", || {
+        ptr_type.fn_type(&[fcx.context.i64_type().into()], false)
+    });
+    let call = fcx
+        .builder
+        .build_call(malloc_fn, &[size.into()], "struct_alloc")
+        .map_err(llvm_err)?;
+    let ptr = match call.try_as_basic_value() {
+        ValueKind::Basic(v) => v.into_pointer_value(),
+        ValueKind::Instruction(_) => unreachable!("malloc returns a pointer, never void"),
+    };
+
+    for (i, field) in fields.iter().enumerate() {
+        let value = emit_expr(fcx, field)?;
+        let field_index = u32::try_from(i).expect("struct field count fits u32");
+        let field_ptr = fcx
+            .builder
+            .build_struct_gep(layout_ty, ptr, field_index, "field_ptr")
+            .map_err(llvm_err)?;
+        fcx.builder
+            .build_store(field_ptr, value)
+            .map_err(llvm_err)?;
+    }
+
+    Ok(ptr.into())
+}
+
+fn emit_field_get<'ctx>(
+    fcx: &FuncCtx<'ctx, '_>,
+    base: &Expr,
+    field_index: usize,
+    ty: KirType,
+) -> Result<BasicValueEnum<'ctx>, CodegenError> {
+    let KirType::Struct(struct_id) = base.ty() else {
+        return Err(CodegenError::Llvm(format!(
+            "field-get base is {} — keel-kir's verify pass should have rejected this",
+            base.ty()
+        )));
+    };
+    let base_ptr: PointerValue = emit_expr(fcx, base)?.into_pointer_value();
+    let layout_ty = layout::struct_layout_type(fcx.context, fcx.program, struct_id)?;
+    let field_index = u32::try_from(field_index).expect("struct field count fits u32");
+    let field_ptr = fcx
+        .builder
+        .build_struct_gep(layout_ty, base_ptr, field_index, "field_ptr")
+        .map_err(llvm_err)?;
+    let field_llvm_ty = layout::llvm_type(fcx.context, fcx.program, ty)?;
+    fcx.builder
+        .build_load(field_llvm_ty, field_ptr, "field_load")
+        .map_err(llvm_err)
 }
 
 fn emit_call<'ctx>(
@@ -218,9 +290,10 @@ fn emit_binop<'ctx>(
             Ok(result)
         }
         KirType::Str => Err(CodegenError::Unsupported(
-            "str concatenation/comparison (issue #135)".to_string(),
+            "str concatenation/comparison (string interpolation lands in a later M2 issue)"
+                .to_string(),
         )),
-        KirType::Unit => Err(unreachable_combo(op, operand_ty)),
+        KirType::Unit | KirType::Struct(_) => Err(unreachable_combo(op, operand_ty)),
     }
 }
 

--- a/crates/keel-codegen/src/func.rs
+++ b/crates/keel-codegen/src/func.rs
@@ -46,6 +46,9 @@ pub(crate) struct FuncCtx<'ctx, 'a> {
     pub(crate) context: &'ctx Context,
     pub(crate) module: &'a Module<'ctx>,
     pub(crate) builder: &'a Builder<'ctx>,
+    /// The whole program — needed by `layout::llvm_type`/`struct_layout_type`
+    /// to resolve a `KirType::Struct`'s field layout.
+    pub(crate) program: &'a KirProgram,
     /// The LLVM function currently being emitted into — needed to attach
     /// new basic blocks (`if`/`while`/`for` wiring).
     pub(crate) function: FunctionValue<'ctx>,
@@ -78,11 +81,13 @@ pub(crate) fn declare_functions<'ctx>(
         let param_types = func
             .params
             .iter()
-            .map(|p| crate::layout::llvm_type(context, p.ty).map(Into::into))
+            .map(|p| crate::layout::llvm_type(context, program, p.ty).map(Into::into))
             .collect::<Result<Vec<_>, _>>()?;
         let fn_type = match func.ret {
             KirType::Unit => context.void_type().fn_type(&param_types, false),
-            other => crate::layout::llvm_type(context, other)?.fn_type(&param_types, false),
+            other => {
+                crate::layout::llvm_type(context, program, other)?.fn_type(&param_types, false)
+            }
         };
         functions[id] = Some(module.add_function(&func.name, fn_type, None));
     }
@@ -95,6 +100,7 @@ pub(crate) fn emit_function<'ctx>(
     module: &Module<'ctx>,
     builder: &Builder<'ctx>,
     functions: &[Option<FunctionValue<'ctx>>],
+    program: &KirProgram,
     func: &KirFunction,
     function_value: FunctionValue<'ctx>,
 ) -> Result<(), CodegenError> {
@@ -105,6 +111,7 @@ pub(crate) fn emit_function<'ctx>(
         context,
         module,
         builder,
+        program,
         function: function_value,
         functions,
         is_toplevel: false,
@@ -112,7 +119,7 @@ pub(crate) fn emit_function<'ctx>(
     };
 
     for (i, param) in func.params.iter().enumerate() {
-        let ty = crate::layout::llvm_type(context, param.ty)?;
+        let ty = crate::layout::llvm_type(context, program, param.ty)?;
         let ptr = builder
             .build_alloca(ty, &format!("local.{}", param.local))
             .map_err(llvm_err)?;
@@ -149,6 +156,7 @@ pub(crate) fn emit_toplevel_function<'ctx>(
         context,
         module,
         builder,
+        program,
         function: toplevel_fn,
         functions,
         is_toplevel: true,

--- a/crates/keel-codegen/src/layout.rs
+++ b/crates/keel-codegen/src/layout.rs
@@ -1,18 +1,27 @@
-//! `KirType` -> LLVM type. M1 walking-skeleton scope: `I64`/`F64`/`Bool`
-//! only, per `designs/llvm-compilation.md` §1.1's lowering table — `Str`
-//! (needs the `KeelStr` runtime ABI) and `Unit` (has no LLVM *value*
-//! representation; call sites branch on it directly, see `func.rs`) are not
-//! representable as a [`BasicTypeEnum`] and are rejected here.
+//! `KirType` -> LLVM type, per `designs/llvm-compilation.md` §1.1's
+//! lowering table. `Unit` has no LLVM *value* representation (call sites
+//! branch on it directly, see `func.rs`) and is rejected here. `Str` is
+//! always `ptr` — every `str` value is a boxed `*const Value` (`KeelBox`,
+//! built via `keel_box_str`; see `expr.rs`'s `ConstStr` codegen), the same
+//! representation `keel_rt_call_ns` already expects for call arguments,
+//! there is no separate unboxed `KeelStr` in this implementation. A named
+//! struct (`KirType::Struct`) is `ptr` too, when it has a heap field
+//! (`StructLayout::is_heap`) — an all-scalar struct would be a by-value
+//! LLVM aggregate, but that path isn't wired up yet (every M2 fixture uses
+//! a struct with at least one `str` field).
 
+use inkwell::AddressSpace;
 use inkwell::context::Context;
 use inkwell::types::BasicTypeEnum;
 
+use keel_kir::ir::KirProgram;
 use keel_kir::types::KirType;
 
 use crate::CodegenError;
 
 pub(crate) fn llvm_type<'ctx>(
     context: &'ctx Context,
+    program: &KirProgram,
     ty: KirType,
 ) -> Result<BasicTypeEnum<'ctx>, CodegenError> {
     match ty {
@@ -22,8 +31,34 @@ pub(crate) fn llvm_type<'ctx>(
         KirType::Unit => Err(CodegenError::Unsupported(
             "none (Unit) has no LLVM value representation".to_string(),
         )),
-        KirType::Str => Err(CodegenError::Unsupported(
-            "str (needs the KeelStr runtime ABI, issue #135)".to_string(),
-        )),
+        KirType::Str => Ok(context.ptr_type(AddressSpace::default()).into()),
+        KirType::Struct(id) => {
+            if program.structs[id].is_heap(program) {
+                Ok(context.ptr_type(AddressSpace::default()).into())
+            } else {
+                Err(CodegenError::Unsupported(format!(
+                    "all-scalar struct `{}` (by-value aggregate codegen isn't wired up yet — \
+                     every M2 fixture uses a struct with at least one heap field)",
+                    program.structs[id].name
+                )))
+            }
+        }
     }
+}
+
+/// The struct's field layout as a real LLVM struct type — used to compute
+/// its heap allocation size and to `GEP` into its fields by index. This is
+/// *not* the struct's own `KirType` representation (always `ptr`, a heap
+/// struct is never passed by value) — it's the shape the pointer points at.
+pub(crate) fn struct_layout_type<'ctx>(
+    context: &'ctx Context,
+    program: &KirProgram,
+    struct_id: keel_kir::ir::StructId,
+) -> Result<inkwell::types::StructType<'ctx>, CodegenError> {
+    let field_types = program.structs[struct_id]
+        .fields
+        .iter()
+        .map(|(_, ty)| llvm_type(context, program, *ty))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(context.struct_type(&field_types, false))
 }

--- a/crates/keel-codegen/src/lib.rs
+++ b/crates/keel-codegen/src/lib.rs
@@ -116,6 +116,7 @@ pub fn compile(program: &KirProgram, opts: &BuildOptions) -> Result<PathBuf, Cod
             &module,
             &builder,
             &functions,
+            program,
             kir_func,
             function_value,
         )?;

--- a/crates/keel-codegen/src/ns_call.rs
+++ b/crates/keel-codegen/src/ns_call.rs
@@ -31,10 +31,10 @@ fn llvm_err(e: impl std::fmt::Display) -> CodegenError {
 }
 
 /// Returns `module`'s existing declaration of `name`, or declares one with
-/// `make_ty()`. Every `CallTarget::Ns` site in a program shares these few
-/// runtime-provided functions, so this avoids redeclaring (and LLVM
-/// silently renaming) them per call site.
-fn declare_or_get<'ctx>(
+/// `make_ty()`. Every call site needing a given runtime-provided (or, for
+/// `malloc`, libc-provided) function shares this one declaration, so this
+/// avoids redeclaring (and LLVM silently renaming) it per call site.
+pub(crate) fn declare_or_get<'ctx>(
     module: &Module<'ctx>,
     name: &str,
     make_ty: impl FnOnce() -> FunctionType<'ctx>,
@@ -64,16 +64,12 @@ fn emit_box_arg<'ctx>(
 ) -> Result<PointerValue<'ctx>, CodegenError> {
     let ptr_type = fcx.context.ptr_type(AddressSpace::default());
     match arg.ty() {
-        KirType::Str => {
-            let Expr::ConstStr(s) = arg else {
-                return Err(CodegenError::Unsupported(
-                    "non-constant `str` argument to a namespace call (M1 scope: `str` has no \
-                     locals or operations yet, only literals)"
-                        .to_string(),
-                ));
-            };
-            emit_box_str_const(fcx, s)
-        }
+        // Every `str` value is already a boxed `*const Value` (`KeelBox`) by
+        // construction (`expr::emit_expr`'s `ConstStr`/`FieldGet`/etc. — see
+        // `layout.rs`'s module doc), so no extra boxing is needed here,
+        // unlike the scalar cases below (which store an unboxed LLVM
+        // primitive and box it fresh at this call boundary).
+        KirType::Str => Ok(emit_expr(fcx, arg)?.into_pointer_value()),
         KirType::I64 => {
             let v = emit_expr(fcx, arg)?.into_int_value();
             let f = declare_or_get(fcx.module, "keel_box_int", || {
@@ -104,10 +100,15 @@ fn emit_box_arg<'ctx>(
         KirType::Unit => Err(CodegenError::Unsupported(
             "unit-typed argument to a namespace call".to_string(),
         )),
+        KirType::Struct(_) => Err(CodegenError::Unsupported(
+            "struct-typed argument to a namespace call (marshaling a struct into a boxed \
+             Value::Struct is a later-M2/M3 concern — see designs/llvm-compilation.md §2.4)"
+                .to_string(),
+        )),
     }
 }
 
-fn emit_box_str_const<'ctx>(
+pub(crate) fn emit_box_str_const<'ctx>(
     fcx: &FuncCtx<'ctx, '_>,
     s: &str,
 ) -> Result<PointerValue<'ctx>, CodegenError> {

--- a/crates/keel-codegen/src/stmt.rs
+++ b/crates/keel-codegen/src/stmt.rs
@@ -42,7 +42,7 @@ fn emit_stmt<'ctx>(
     match stmt {
         Stmt::Let { local, init } => {
             let value = expr::emit_expr(fcx, init)?;
-            let ty = layout::llvm_type(fcx.context, init.ty())?;
+            let ty = layout::llvm_type(fcx.context, fcx.program, init.ty())?;
             let ptr = fcx
                 .builder
                 .build_alloca(ty, &format!("local.{local}"))

--- a/crates/keel-codegen/tests/structs.rs
+++ b/crates/keel-codegen/tests/structs.rs
@@ -1,0 +1,94 @@
+//! Exit criterion for issue #145: a program declaring a named struct,
+//! building it via a literal (in an annotated `let`), producing an updated
+//! copy via spread-update (in `return` position), and reading fields back
+//! compiles, links, and matches the interpreter byte-for-byte —
+//! `examples/struct_spread_update.keel`'s shape (structs with `str` fields,
+//! so this also exercises the heap-struct allocation/field-GEP path, not
+//! just an all-scalar aggregate).
+
+use std::process::Command;
+
+use keel_codegen::BuildOptions;
+
+#[path = "support/mod.rs"]
+mod support;
+
+fn compile_and_run(source: &str) -> std::process::Output {
+    let kir = support::parse_check_and_lower(source);
+
+    let out_dir = tempfile::tempdir().expect("create temp out dir");
+    let opts = BuildOptions {
+        out_dir: out_dir.path().to_path_buf(),
+        runtime_link_args: support::runtime_link_args().clone(),
+    };
+    let bin = keel_codegen::compile(&kir, &opts).expect("compile must succeed");
+    Command::new(&bin).output().expect("run compiled binary")
+}
+
+const ORDER_SOURCE: &str = r#"
+use std/io
+
+type Order {
+  id: str
+  status: str
+  amount: float
+  filled_at: str
+}
+
+task process_order(o: Order) -> Order {
+  return { ...o, status: "filled", filled_at: "2024-01-15T10:30:00Z" }
+}
+
+pending: Order = { status: "pending", amount: 250.0, filled_at: "", id: "ord-42" }
+filled = process_order(pending)
+io.show(filled.id)
+io.show(filled.status)
+io.show(filled.amount)
+io.show(filled.filled_at)
+"#;
+
+#[test]
+fn struct_literal_field_access_and_spread_update_match_the_interpreter() {
+    let compiled = compile_and_run(ORDER_SOURCE);
+    let interpreted = support::run_interpreter(ORDER_SOURCE);
+
+    assert_eq!(
+        String::from_utf8_lossy(&compiled.stdout),
+        String::from_utf8_lossy(&interpreted.stdout),
+        "compiled stdout must match the interpreter's"
+    );
+    assert_eq!(
+        compiled.stdout,
+        b"  ord-42\n  filled\n  250\n  2024-01-15T10:30:00Z\n"
+    );
+}
+
+#[test]
+fn spread_update_over_multiple_generations_preserves_untouched_fields() {
+    let source = r#"
+use std/io
+
+type Config {
+  host: str
+  port: int
+  debug: bool
+}
+
+base: Config = { host: "localhost", port: 8080, debug: false }
+dev = { ...base, debug: true }
+prod = { ...dev, host: "api.example.com", debug: false }
+io.show(prod.host)
+io.show(prod.port)
+io.show(prod.debug)
+"#;
+
+    let compiled = compile_and_run(source);
+    let interpreted = support::run_interpreter(source);
+
+    assert_eq!(
+        String::from_utf8_lossy(&compiled.stdout),
+        String::from_utf8_lossy(&interpreted.stdout),
+        "compiled stdout must match the interpreter's"
+    );
+    assert_eq!(compiled.stdout, b"  api.example.com\n  8080\n  false\n");
+}

--- a/crates/keel-codegen/tests/walking_skeleton.rs
+++ b/crates/keel-codegen/tests/walking_skeleton.rs
@@ -10,7 +10,7 @@
 use std::path::Path;
 use std::process::Command;
 
-use keel_codegen::{BuildOptions, CodegenError};
+use keel_codegen::BuildOptions;
 
 #[path = "support/mod.rs"]
 mod support;
@@ -30,17 +30,6 @@ fn compile_and_run(source: &str) -> (i32, tempfile::TempDir) {
         run.status.code().expect("process exited via a signal"),
         out_dir,
     )
-}
-
-fn compile_err(source: &str) -> CodegenError {
-    let kir = support::parse_check_and_lower(source);
-
-    let out_dir = tempfile::tempdir().expect("create temp out dir");
-    let opts = BuildOptions {
-        out_dir: out_dir.path().to_path_buf(),
-        runtime_link_args: support::runtime_link_args().clone(),
-    };
-    keel_codegen::compile(&kir, &opts).expect_err("compile must be rejected")
 }
 
 #[test]
@@ -99,12 +88,14 @@ fn empty_program_compiles_and_exits_zero() {
 }
 
 #[test]
-fn str_expression_is_rejected_not_silently_dropped() {
-    let err = compile_err("\"hi\"\n");
-    assert!(
-        matches!(err, CodegenError::Unsupported(ref msg) if msg.contains("str")),
-        "unexpected error: {err}"
-    );
+fn bare_str_expression_compiles_and_exits_zero() {
+    // `str` is a full general expression now (M2 needs it for struct
+    // fields — see `layout.rs`'s module doc): a bare top-level string
+    // literal is no longer rejected, it just isn't `int`-typed, so the
+    // exit-code convention falls through to 0, same as the float/bool case
+    // below.
+    let (code, _dir) = compile_and_run("\"hi\"\n");
+    assert_eq!(code, 0);
 }
 
 #[test]

--- a/crates/keel-kir/src/dump.rs
+++ b/crates/keel-kir/src/dump.rs
@@ -8,11 +8,25 @@
 use std::fmt::Write as _;
 
 use crate::ir::{BinOp, Block, CallTarget, Expr, FuncId, KirFunction, KirProgram, Stmt, UnOp};
+use crate::types::KirType;
 
-/// Renders every function in `program`, in declaration order.
+/// Renders every struct declaration, then every function in `program`, in
+/// declaration order.
 #[must_use]
 pub fn dump(program: &KirProgram) -> String {
     let mut out = String::new();
+    for s in &program.structs {
+        let fields = s
+            .fields
+            .iter()
+            .map(|(name, ty)| format!("{name}: {}", fmt_ty(program, *ty)))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let _ = writeln!(out, "struct {} {{ {fields} }}", s.name);
+    }
+    if !program.structs.is_empty() {
+        out.push('\n');
+    }
     for (i, func) in program.functions.iter().enumerate() {
         if i > 0 {
             out.push('\n');
@@ -22,17 +36,32 @@ pub fn dump(program: &KirProgram) -> String {
     out
 }
 
+/// Renders `ty` for the dump — same as `KirType`'s own `Display` for
+/// scalars, but resolves a struct id to its declared name (`KirType` alone
+/// can't, see `types.rs`'s `name()` doc; this function has `program` in hand).
+fn fmt_ty(program: &KirProgram, ty: KirType) -> String {
+    match ty {
+        KirType::Struct(id) => program.structs[id].name.clone(),
+        other => other.to_string(),
+    }
+}
+
 fn dump_function(out: &mut String, program: &KirProgram, func: &KirFunction) {
     let params = func
         .params
         .iter()
         .map(|p| {
             let name = &func.locals[p.local].name;
-            format!("{name}: {}", p.ty)
+            format!("{name}: {}", fmt_ty(program, p.ty))
         })
         .collect::<Vec<_>>()
         .join(", ");
-    let _ = writeln!(out, "fn {}({params}) -> {} {{", func.name, func.ret);
+    let _ = writeln!(
+        out,
+        "fn {}({params}) -> {} {{",
+        func.name,
+        fmt_ty(program, func.ret)
+    );
     dump_block(out, program, func, &func.body, 1);
     out.push_str("}\n");
 }
@@ -70,7 +99,7 @@ fn dump_stmt(
                 out,
                 "let {}: {} = {}",
                 l.name,
-                l.ty,
+                fmt_ty(program, l.ty),
                 fmt_expr(program, func, init)
             );
         }
@@ -163,6 +192,29 @@ fn fmt_expr(program: &KirProgram, func: &KirFunction, expr: &Expr) -> String {
                 .collect::<Vec<_>>()
                 .join(", ");
             format!("{name}({args})")
+        }
+        Expr::MakeStruct { struct_id, fields } => {
+            let layout = &program.structs[*struct_id];
+            let fields = layout
+                .fields
+                .iter()
+                .zip(fields)
+                .map(|((name, _), value)| format!("{name}: {}", fmt_expr(program, func, value)))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("{} {{ {fields} }}", layout.name)
+        }
+        Expr::FieldGet {
+            base, field_index, ..
+        } => {
+            let Expr::Local { ty, .. } = base.as_ref() else {
+                return format!("{}.#{field_index}", fmt_expr(program, func, base));
+            };
+            let KirType::Struct(struct_id) = ty else {
+                return format!("{}.#{field_index}", fmt_expr(program, func, base));
+            };
+            let field_name = &program.structs[*struct_id].fields[*field_index].0;
+            format!("{}.{field_name}", fmt_expr(program, func, base))
         }
     }
 }

--- a/crates/keel-kir/src/ir.rs
+++ b/crates/keel-kir/src/ir.rs
@@ -22,6 +22,9 @@ pub type FuncId = usize;
 /// scoping rule — see `AGENTS.md` / `feedback_keel_assignment_scoping`).
 pub type LocalId = usize;
 
+/// Index into `KirProgram::structs`.
+pub type StructId = usize;
+
 /// A whole lowered program (currently: a single file's tasks + its
 /// top-level statements — multi-module lowering is deferred until the
 /// `keel-compiler` `ModuleGraph`/`CheckArtifacts` seam lands, see `lib.rs`).
@@ -33,7 +36,43 @@ pub struct KirProgram {
     /// The function compiling the file's top-level statements (mirrors
     /// `Interpreter::execute`'s treatment of top-level code).
     pub toplevel: FuncId,
+    /// Every named struct type (`type X { .. }`) declared in the file, in
+    /// declaration order. Anonymous struct shapes (`{x: 1, y: 2}` with no
+    /// resolvable named-type context) aren't interned yet — deferred until
+    /// an M2 fixture actually needs one; see `lower/mod.rs`'s struct-
+    /// resolution doc.
+    pub structs: Vec<StructLayout>,
     pub span_table: SpanTable,
+}
+
+/// A named struct type's compiled layout: field order + `KirType` per
+/// field, fixed at KIR-lowering time (`designs/llvm-compilation.md` §2.3 —
+/// tag/layout values are decided here, not left to codegen).
+#[derive(Debug, Clone)]
+pub struct StructLayout {
+    pub id: StructId,
+    pub name: String,
+    /// Declaration order — struct literals are matched against this by
+    /// field *name* (not literal-source order, matching the checker's
+    /// structural assignability rule) and rebuilt in this order.
+    pub fields: Vec<(String, KirType)>,
+}
+
+impl StructLayout {
+    /// Index of `name` in `fields`, if this struct has such a field.
+    #[must_use]
+    pub fn field_index(&self, name: &str) -> Option<usize> {
+        self.fields.iter().position(|(n, _)| n == name)
+    }
+
+    /// A struct needs heap allocation + RC (a `ptr` in the value ABI) if any
+    /// field is itself heap-typed — recursively, so a struct-of-a-struct-
+    /// with-a-string-field is heap too. Everything else (all-scalar fields)
+    /// is a plain by-value LLVM aggregate, same treatment as tuples (§1.1).
+    #[must_use]
+    pub fn is_heap(&self, program: &KirProgram) -> bool {
+        self.fields.iter().any(|(_, ty)| ty.is_heap(program))
+    }
 }
 
 /// One lowered task (or the synthetic top-level function).
@@ -145,6 +184,23 @@ pub enum Expr {
         ty: KirType,
         span: SpanId,
     },
+    /// Builds a named struct value. `fields` are in the struct's declared
+    /// field order (`StructLayout::fields`), already matched/reordered from
+    /// the literal's (possibly different) source order and, for a spread-
+    /// update, already resolved to each field's final value (overridden or
+    /// copied from the base) — see `lower/expr.rs`'s struct-literal lowering
+    /// doc for why this needs an expected-type context to build at all.
+    MakeStruct {
+        struct_id: StructId,
+        fields: Vec<Expr>,
+    },
+    /// `base.field` on a struct-typed `base` — `field_index` is resolved at
+    /// lowering time via `StructLayout::field_index`.
+    FieldGet {
+        base: Box<Expr>,
+        field_index: usize,
+        ty: KirType,
+    },
 }
 
 /// What an `Expr::Call` invokes.
@@ -172,7 +228,9 @@ impl Expr {
             Expr::Local { ty, .. }
             | Expr::BinOp { ty, .. }
             | Expr::UnOp { ty, .. }
-            | Expr::Call { ty, .. } => *ty,
+            | Expr::Call { ty, .. }
+            | Expr::FieldGet { ty, .. } => *ty,
+            Expr::MakeStruct { struct_id, .. } => KirType::Struct(*struct_id),
         }
     }
 }

--- a/crates/keel-kir/src/lower/decl.rs
+++ b/crates/keel-kir/src/lower/decl.rs
@@ -4,11 +4,10 @@
 
 use std::collections::HashMap;
 
-use keel_compiler::types::artifacts::CheckArtifacts;
 use keel_syntax::ast::TaskDecl;
 
-use super::{FnCtx, FuncSig, LowerError, binding_ident, ty_expr_to_kir};
-use crate::ir::{KirFunction, Param};
+use super::{FnCtx, FuncSig, LowerCtx, LowerError, binding_ident, ty_expr_to_kir};
+use crate::ir::{KirFunction, Param, StructId};
 use crate::span_table::SpanTable;
 use crate::types::KirType;
 
@@ -16,7 +15,10 @@ use crate::types::KirType;
 /// Rejects generics, variadics, and default params — none are in the M0
 /// scalar subset (generics need `mono.rs`; variadics/defaults need the
 /// container ABI and desugaring `sugar.rs` doesn't do yet).
-pub(crate) fn signature_of(task: &TaskDecl) -> Result<(Vec<KirType>, KirType), LowerError> {
+pub(crate) fn signature_of(
+    task: &TaskDecl,
+    structs_by_name: &HashMap<String, StructId>,
+) -> Result<(Vec<KirType>, KirType), LowerError> {
     if !task.type_params.is_empty() {
         return Err(LowerError::unsupported(
             "generic task",
@@ -38,10 +40,10 @@ pub(crate) fn signature_of(task: &TaskDecl) -> Result<(Vec<KirType>, KirType), L
             ));
         }
         binding_ident(&param.name, &param.name_span)?; // rejects destructuring params
-        params.push(ty_expr_to_kir(&param.ty)?);
+        params.push(ty_expr_to_kir(&param.ty, structs_by_name)?);
     }
     let ret = match &task.return_type {
-        Some(ty) => ty_expr_to_kir(ty)?,
+        Some(ty) => ty_expr_to_kir(ty, structs_by_name)?,
         None => KirType::Unit,
     };
     Ok((params, ret))
@@ -51,10 +53,8 @@ pub(crate) fn signature_of(task: &TaskDecl) -> Result<(Vec<KirType>, KirType), L
 pub(crate) fn lower_task_body(
     task: &TaskDecl,
     sig: &FuncSig,
-    funcs: &HashMap<String, FuncSig>,
-    ns_bindings: &HashMap<String, String>,
+    lcx: &LowerCtx<'_>,
     table: &mut SpanTable,
-    artifacts: &CheckArtifacts,
 ) -> Result<KirFunction, LowerError> {
     let mut ctx = FnCtx::new();
     let mut params = Vec::with_capacity(task.params.len());
@@ -64,15 +64,7 @@ pub(crate) fn lower_task_body(
         params.push(Param { local, ty: *ty });
     }
 
-    let body = super::stmt::lower_block(
-        &task.body,
-        &mut ctx,
-        funcs,
-        ns_bindings,
-        table,
-        sig.ret,
-        artifacts,
-    )?;
+    let body = super::stmt::lower_block(&task.body, &mut ctx, lcx, table, sig.ret)?;
 
     Ok(KirFunction {
         id: sig.func_id,

--- a/crates/keel-kir/src/lower/expr.rs
+++ b/crates/keel-kir/src/lower/expr.rs
@@ -1,22 +1,22 @@
 //! Expression lowering — the M0 scalar subset (literals, identifiers,
 //! arithmetic/comparison/logical binary ops, unary `-`/`not`, and direct
 //! calls to other lowered tasks) plus M1's stdlib namespace calls
-//! (`io.show(...)`, `log.info(...)` — see [`lower_call`]). Everything else
-//! (field/index access, value method calls, casts, `if`/`when` as
-//! expressions, lambdas, compound literals, string interpolation, `?.`/`??`,
-//! pipelines, duration literals, enum variants) is rejected; see module docs
-//! on `lower/mod.rs`.
+//! (`io.show(...)`, `log.info(...)` — see [`lower_call`]) and M2's named-
+//! struct literals, spread-update, and field access. Everything else (index
+//! access, value method calls, casts, `if`/`when` as expressions, lambdas,
+//! list/set/tuple literals, string interpolation, `?.`/`??`, pipelines,
+//! duration literals, enum variants) is rejected; see module docs on
+//! `lower/mod.rs`.
 
 use std::collections::HashMap;
 
-use keel_compiler::types::artifacts::CheckArtifacts;
 use keel_syntax::ast::{self, SpannedExpr};
 use keel_syntax::lexer::Span;
 
 use keel_catalog::builtins::BuiltinResult;
 
-use super::{FnCtx, FuncSig, LowerError};
-use crate::ir::{self, CallTarget, Expr};
+use super::{FnCtx, LowerCtx, LowerError, describe_ty};
+use crate::ir::{self, CallTarget, Expr, StructId};
 use crate::span_table::SpanTable;
 use crate::types::KirType;
 
@@ -99,10 +99,8 @@ pub(crate) fn infer_binop_ty(
 pub(crate) fn lower_expr(
     expr: &SpannedExpr,
     ctx: &mut FnCtx,
-    funcs: &HashMap<String, FuncSig>,
-    ns_bindings: &HashMap<String, String>,
+    lcx: &LowerCtx<'_>,
     table: &mut SpanTable,
-    artifacts: &CheckArtifacts,
 ) -> Result<Expr, LowerError> {
     match &expr.kind {
         ast::Expr::Integer(v) => Ok(Expr::ConstInt(*v)),
@@ -117,8 +115,8 @@ pub(crate) fn lower_expr(
             Ok(Expr::Local { id: local, ty })
         }
         ast::Expr::BinaryOp { left, op, right } => {
-            let left_e = lower_expr(left, ctx, funcs, ns_bindings, table, artifacts)?;
-            let right_e = lower_expr(right, ctx, funcs, ns_bindings, table, artifacts)?;
+            let left_e = lower_expr(left, ctx, lcx, table)?;
+            let right_e = lower_expr(right, ctx, lcx, table)?;
             let kir_op = convert_binop(*op);
             let ty = infer_binop_ty(kir_op, left_e.ty(), right_e.ty(), &expr.span)?;
             Ok(Expr::BinOp {
@@ -129,7 +127,7 @@ pub(crate) fn lower_expr(
             })
         }
         ast::Expr::UnaryOp { op, expr: operand } => {
-            let operand_e = lower_expr(operand, ctx, funcs, ns_bindings, table, artifacts)?;
+            let operand_e = lower_expr(operand, ctx, lcx, table)?;
             let ty = match op {
                 ast::UnOp::Neg if operand_e.ty().is_numeric() => operand_e.ty(),
                 ast::UnOp::Not if operand_e.ty() == KirType::Bool => KirType::Bool,
@@ -156,18 +154,29 @@ pub(crate) fn lower_expr(
                 ty,
             })
         }
-        ast::Expr::Call { callee, args } => lower_call(
-            callee,
-            args,
-            ctx,
-            funcs,
-            ns_bindings,
-            table,
-            artifacts,
-            &expr.span,
-        ),
-        ast::Expr::FieldAccess(..) => {
-            Err(LowerError::unsupported("field access", expr.span.clone()))
+        ast::Expr::Call { callee, args } => lower_call(callee, args, ctx, lcx, table, &expr.span),
+        ast::Expr::FieldAccess(base, field) => {
+            let base_e = lower_expr(base, ctx, lcx, table)?;
+            let KirType::Struct(struct_id) = base_e.ty() else {
+                return Err(LowerError::unsupported(
+                    "field access on a non-struct value (containers/dynamic land in a later \
+                     M2 issue)",
+                    expr.span.clone(),
+                ));
+            };
+            let layout = &lcx.struct_layouts[struct_id];
+            let field_index = layout.field_index(field).ok_or_else(|| {
+                LowerError::new(
+                    format!("struct `{}` has no field `{field}`", layout.name),
+                    expr.span.clone(),
+                )
+            })?;
+            let ty = layout.fields[field_index].1;
+            Ok(Expr::FieldGet {
+                base: Box::new(base_e),
+                field_index,
+                ty,
+            })
         }
         ast::Expr::NullFieldAccess(..) => Err(LowerError::unsupported(
             "null-safe field access",
@@ -178,11 +187,18 @@ pub(crate) fn lower_expr(
             Err(LowerError::unsupported("self access", expr.span.clone()))
         }
         ast::Expr::SelfRef => Err(LowerError::unsupported("self reference", expr.span.clone())),
-        ast::Expr::StructLit(_) => {
-            Err(LowerError::unsupported("struct literal", expr.span.clone()))
-        }
+        // No expected-type context here (that's `lower_expr_expecting`'s
+        // job) — an anonymous struct literal with nothing pinning it to a
+        // named struct isn't modeled yet (deferred until an M2 fixture
+        // needs one; see `ir.rs`'s `StructLayout` doc).
+        ast::Expr::StructLit(_) => Err(LowerError::unsupported(
+            "struct literal outside a known-struct-typed position (a `let` annotation, \
+             `return`, or call argument)",
+            expr.span.clone(),
+        )),
         ast::Expr::StructSpreadUpdate { .. } => Err(LowerError::unsupported(
-            "struct spread update",
+            "struct spread-update outside a known-struct-typed position (a `let` annotation, \
+             `return`, or call argument)",
             expr.span.clone(),
         )),
         ast::Expr::ListLit(_) => Err(LowerError::unsupported("list literal", expr.span.clone())),
@@ -205,19 +221,9 @@ pub(crate) fn lower_expr(
             // yet — value methods land alongside the container ABI (M2+).
             if let ast::Expr::Ident(obj_name) = &object.kind
                 && ctx.resolve(obj_name).is_none()
-                && let Some(namespace) = ns_bindings.get(obj_name)
+                && let Some(namespace) = lcx.ns_bindings.get(obj_name)
             {
-                lower_ns_call(
-                    namespace,
-                    method,
-                    args,
-                    ctx,
-                    funcs,
-                    ns_bindings,
-                    table,
-                    artifacts,
-                    &expr.span,
-                )
+                lower_ns_call(namespace, method, args, ctx, lcx, table, &expr.span)
             } else {
                 Err(LowerError::unsupported("method call", expr.span.clone()))
             }
@@ -244,6 +250,189 @@ pub(crate) fn lower_expr(
     }
 }
 
+/// Lowers `expr` against a known expected type — used only where the
+/// surrounding syntax pins a concrete type (a `let` annotation, `return`, a
+/// call argument), so a struct literal or spread-update (which the checker
+/// always types as an unnamed structural shape — see `lower/mod.rs`'s
+/// `CheckArtifacts` doc) can resolve to the *named* struct that context
+/// calls for. Falls through to ordinary bottom-up [`lower_expr`] for every
+/// other expression kind, then checks its type matches.
+pub(crate) fn lower_expr_expecting(
+    expr: &SpannedExpr,
+    expected: KirType,
+    ctx: &mut FnCtx,
+    lcx: &LowerCtx<'_>,
+    table: &mut SpanTable,
+) -> Result<Expr, LowerError> {
+    if let KirType::Struct(struct_id) = expected {
+        match &expr.kind {
+            ast::Expr::StructLit(fields) => {
+                return lower_struct_lit(fields, struct_id, &expr.span, ctx, lcx, table);
+            }
+            ast::Expr::StructSpreadUpdate { base, overrides } => {
+                return lower_struct_spread(base, overrides, struct_id, ctx, lcx, table);
+            }
+            _ => {}
+        }
+    }
+    let lowered = lower_expr(expr, ctx, lcx, table)?;
+    if lowered.ty() != expected {
+        return Err(LowerError::new(
+            format!(
+                "expected `{}`, got `{}`",
+                describe_ty(expected, lcx),
+                describe_ty(lowered.ty(), lcx)
+            ),
+            expr.span.clone(),
+        ));
+    }
+    Ok(lowered)
+}
+
+/// Lowers a struct literal (`{field: value, ...}`) against its expected
+/// struct type — matches fields by *name*, not literal source order
+/// (mirrors the checker's structural assignability rule,
+/// `crates/keel-compiler/src/types/checker.rs`), and rebuilds them in the
+/// struct's declared field order.
+fn lower_struct_lit(
+    lit_fields: &[(ast::MapLitKey, SpannedExpr)],
+    struct_id: StructId,
+    span: &Span,
+    ctx: &mut FnCtx,
+    lcx: &LowerCtx<'_>,
+    table: &mut SpanTable,
+) -> Result<Expr, LowerError> {
+    let layout = &lcx.struct_layouts[struct_id];
+
+    let mut by_name: HashMap<&str, &SpannedExpr> = HashMap::with_capacity(lit_fields.len());
+    for (key, value) in lit_fields {
+        let name = key.as_str().ok_or_else(|| {
+            LowerError::unsupported("non-identifier struct-literal key", value.span.clone())
+        })?;
+        if by_name.insert(name, value).is_some() {
+            return Err(LowerError::new(
+                format!("duplicate field `{name}` in struct literal"),
+                value.span.clone(),
+            ));
+        }
+    }
+
+    let mut fields = Vec::with_capacity(layout.fields.len());
+    for (field_name, field_ty) in &layout.fields {
+        let value = by_name.remove(field_name.as_str()).ok_or_else(|| {
+            LowerError::new(
+                format!("missing field `{field_name}` for struct `{}`", layout.name),
+                span.clone(),
+            )
+        })?;
+        fields.push(lower_expr_expecting(value, *field_ty, ctx, lcx, table)?);
+    }
+    if let Some((extra_name, extra_value)) = by_name.into_iter().next() {
+        return Err(LowerError::new(
+            format!("struct `{}` has no field `{extra_name}`", layout.name),
+            extra_value.span.clone(),
+        ));
+    }
+
+    Ok(Expr::MakeStruct { struct_id, fields })
+}
+
+/// Resolves the `(LocalId, KirType)` a spread-update's `base` already
+/// carries. `base` must be a plain identifier: reading a non-overridden
+/// field means reading `base` again, which is only safe when that's a
+/// side-effect-free variable read, not an arbitrary expression (a call
+/// could have side effects, and KIR's tree-shaped `Expr` has no let-binding
+/// to evaluate an arbitrary `base` once and reuse the result). Every M2
+/// fixture spreads an already-bound struct value, so this covers the exit
+/// criterion; a general expression base is deferred, not silently
+/// mis-evaluated.
+///
+/// Shared by [`lower_struct_spread`] (which also needs the struct id to
+/// build the result) and `lower_stmt`'s `Let` arm (which uses this to infer
+/// the expected type for `x = { ...base, .. }` with no explicit
+/// annotation — the common case, since the type is already pinned by
+/// `base` and an annotation would be redundant).
+pub(crate) fn struct_spread_base(
+    base: &SpannedExpr,
+    ctx: &FnCtx,
+) -> Result<(crate::ir::LocalId, KirType), LowerError> {
+    let ast::Expr::Ident(base_name) = &base.kind else {
+        return Err(LowerError::unsupported(
+            "struct spread-update over a non-identifier base expression",
+            base.span.clone(),
+        ));
+    };
+    let base_local = ctx.resolve(base_name).ok_or_else(|| {
+        LowerError::new(
+            format!("unknown identifier `{base_name}`"),
+            base.span.clone(),
+        )
+    })?;
+    Ok((base_local, ctx.locals[base_local].ty))
+}
+
+/// Lowers `{ ...base, field: value, ... }` against its expected struct
+/// type: copies every non-overridden field from `base`, takes overridden
+/// ones from `overrides`, and rebuilds in declared field order (same as
+/// [`lower_struct_lit`]).
+fn lower_struct_spread(
+    base: &SpannedExpr,
+    overrides: &[(String, SpannedExpr)],
+    struct_id: StructId,
+    ctx: &mut FnCtx,
+    lcx: &LowerCtx<'_>,
+    table: &mut SpanTable,
+) -> Result<Expr, LowerError> {
+    let (base_local, base_ty) = struct_spread_base(base, ctx)?;
+    if base_ty != KirType::Struct(struct_id) {
+        return Err(LowerError::new(
+            format!(
+                "spread-update base is `{}`, expected struct `{}`",
+                describe_ty(base_ty, lcx),
+                lcx.struct_layouts[struct_id].name
+            ),
+            base.span.clone(),
+        ));
+    }
+
+    let mut overrides_by_name: HashMap<&str, &SpannedExpr> =
+        HashMap::with_capacity(overrides.len());
+    for (name, value) in overrides {
+        if overrides_by_name.insert(name.as_str(), value).is_some() {
+            return Err(LowerError::new(
+                format!("duplicate field `{name}` in spread-update"),
+                value.span.clone(),
+            ));
+        }
+    }
+
+    let layout = &lcx.struct_layouts[struct_id];
+    let mut fields = Vec::with_capacity(layout.fields.len());
+    for (index, (field_name, field_ty)) in layout.fields.iter().enumerate() {
+        let field_expr = if let Some(value) = overrides_by_name.remove(field_name.as_str()) {
+            lower_expr_expecting(value, *field_ty, ctx, lcx, table)?
+        } else {
+            Expr::FieldGet {
+                base: Box::new(Expr::Local {
+                    id: base_local,
+                    ty: base_ty,
+                }),
+                field_index: index,
+                ty: *field_ty,
+            }
+        };
+        fields.push(field_expr);
+    }
+    if let Some((extra_name, extra_value)) = overrides_by_name.into_iter().next() {
+        return Err(LowerError::new(
+            format!("struct `{}` has no field `{extra_name}`", layout.name),
+            extra_value.span.clone(),
+        ));
+    }
+
+    Ok(Expr::MakeStruct { struct_id, fields })
+}
+
 /// String interpolation is sugar (desugars to concat calls per §2.3) and is
 /// deferred past M0; only a single non-interpolated literal segment lowers.
 fn lower_string_lit(parts: &[ast::StringPart], span: &Span) -> Result<Expr, LowerError> {
@@ -261,15 +450,12 @@ fn lower_string_lit(parts: &[ast::StringPart], span: &Span) -> Result<Expr, Lowe
 /// calls never reach here — the parser produces `ast::Expr::MethodCall` for
 /// all dot-call syntax, not `Call` with a field-access callee; see the
 /// `ast::Expr::MethodCall` arm in `lower_expr` for namespace-call lowering.
-#[allow(clippy::too_many_arguments)]
 fn lower_call(
     callee: &SpannedExpr,
     args: &[ast::CallArg],
     ctx: &mut FnCtx,
-    funcs: &HashMap<String, FuncSig>,
-    ns_bindings: &HashMap<String, String>,
+    lcx: &LowerCtx<'_>,
     table: &mut SpanTable,
-    artifacts: &CheckArtifacts,
     call_span: &Span,
 ) -> Result<Expr, LowerError> {
     let ast::Expr::Ident(name) = &callee.kind else {
@@ -278,7 +464,7 @@ fn lower_call(
             callee.span.clone(),
         ));
     };
-    let sig = funcs.get(name).ok_or_else(|| {
+    let sig = lcx.funcs.get(name).ok_or_else(|| {
         LowerError::new(format!("unknown function `{name}`"), callee.span.clone())
     })?;
 
@@ -301,17 +487,13 @@ fn lower_call(
                 arg.value.span.clone(),
             ));
         }
-        let lowered = lower_expr(&arg.value, ctx, funcs, ns_bindings, table, artifacts)?;
-        if lowered.ty() != *expected_ty {
-            return Err(LowerError::new(
-                format!(
-                    "argument to `{name}` is `{}`, expected `{expected_ty}`",
-                    lowered.ty()
-                ),
-                arg.value.span.clone(),
-            ));
-        }
-        lowered_args.push(lowered);
+        lowered_args.push(lower_expr_expecting(
+            &arg.value,
+            *expected_ty,
+            ctx,
+            lcx,
+            table,
+        )?);
     }
 
     Ok(Expr::Call {
@@ -330,24 +512,13 @@ fn lower_call(
 /// check` already validated the call before lowering ever sees it). Arity
 /// *is* checked, and named/spread arguments are rejected — no M1 namespace
 /// method in the scalar-subset surface needs them yet.
-///
-/// `namespace`/`method`/`call_span` push this one function over clippy's
-/// default argument-count threshold; the other five are the same lowering
-/// state every function in this module already threads (`ctx`, `funcs`,
-/// `ns_bindings`, `table`) plus the call's own arg list. Bundling all of it
-/// into a shared "lowering context" struct is a reasonable future
-/// refactor, but not one this issue's scope should force — see `lower_call`
-/// just above, at 7 params, one under the limit, using the same pattern.
-#[allow(clippy::too_many_arguments)]
 fn lower_ns_call(
     namespace: &str,
     method: &str,
     args: &[ast::CallArg],
     ctx: &mut FnCtx,
-    funcs: &HashMap<String, FuncSig>,
-    ns_bindings: &HashMap<String, String>,
+    lcx: &LowerCtx<'_>,
     table: &mut SpanTable,
-    artifacts: &CheckArtifacts,
     call_span: &Span,
 ) -> Result<Expr, LowerError> {
     let builtin = keel_catalog::catalog_method(namespace, method).ok_or_else(|| {
@@ -383,14 +554,7 @@ fn lower_ns_call(
                 arg.value.span.clone(),
             ));
         }
-        lowered_args.push(lower_expr(
-            &arg.value,
-            ctx,
-            funcs,
-            ns_bindings,
-            table,
-            artifacts,
-        )?);
+        lowered_args.push(lower_expr(&arg.value, ctx, lcx, table)?);
     }
 
     let ty = result_ty_to_kir(builtin.result, call_span)?;

--- a/crates/keel-kir/src/lower/mod.rs
+++ b/crates/keel-kir/src/lower/mod.rs
@@ -47,10 +47,10 @@ use std::collections::HashMap;
 use std::fmt;
 
 use keel_compiler::types::artifacts::CheckArtifacts;
-use keel_syntax::ast::{Binding, Decl, Program, UseDecl, UseKind, UseSource};
+use keel_syntax::ast::{Binding, Decl, Program, TypeDef, UseDecl, UseKind, UseSource};
 use keel_syntax::lexer::Span;
 
-use crate::ir::{FuncId, KirFunction, KirProgram, LocalId};
+use crate::ir::{FuncId, KirFunction, KirProgram, LocalId, StructId, StructLayout};
 use crate::span_table::SpanTable;
 use crate::types::KirType;
 
@@ -96,6 +96,37 @@ pub(crate) struct FuncSig {
     pub(crate) func_id: FuncId,
     pub(crate) params: Vec<KirType>,
     pub(crate) ret: KirType,
+}
+
+/// Shared, read-only lowering state threaded through every lowering
+/// function (bundled into one struct rather than growing the parameter
+/// list further — M2's per-feature issues each add another whole-program
+/// lookup table; structs here, more to come). `table: &mut SpanTable`
+/// (mutable) and `ctx: &mut FnCtx` (per-function, mutable) stay separate
+/// parameters — only immutable, whole-program state lives here.
+pub(crate) struct LowerCtx<'a> {
+    pub(crate) funcs: &'a HashMap<String, FuncSig>,
+    pub(crate) ns_bindings: &'a HashMap<String, String>,
+    pub(crate) structs_by_name: &'a HashMap<String, StructId>,
+    pub(crate) struct_layouts: &'a [StructLayout],
+    /// Not consumed yet — #145 (named structs) resolves everything through
+    /// context-threaded expected types instead (see `expr::lower_expr_expecting`).
+    /// Becomes load-bearing for a construct the checker must resolve and
+    /// lowering can't (an anonymous struct literal, a nullable's inner type,
+    /// …) — see the module doc's `CheckArtifacts` section.
+    #[allow(dead_code)]
+    pub(crate) artifacts: &'a CheckArtifacts,
+}
+
+/// Describes `ty` for a diagnostic message. Same as `KirType`'s own
+/// `Display` for scalars, but resolves a struct id to its declared name —
+/// `KirType` alone can't do this (no `KirProgram` access, see `types.rs`'s
+/// `name()` doc), but lowering always has `lcx.struct_layouts` in hand.
+pub(crate) fn describe_ty(ty: KirType, lcx: &LowerCtx<'_>) -> String {
+    match ty {
+        KirType::Struct(id) => format!("struct {}", lcx.struct_layouts[id].name),
+        other => other.to_string(),
+    }
 }
 
 /// Per-function lowering state: the locals table under construction and a
@@ -167,15 +198,64 @@ pub fn lower_program(
     let mut funcs: HashMap<String, FuncSig> = HashMap::new();
     let mut ns_bindings: HashMap<String, String> = HashMap::new();
     let mut task_order: Vec<&keel_syntax::ast::TaskDecl> = Vec::new();
+    let mut structs_by_name: HashMap<String, StructId> = HashMap::new();
+    let mut struct_decls: Vec<&keel_syntax::ast::TypeDecl> = Vec::new();
 
-    // Pass 1: collect every task signature (so calls resolve regardless of
+    // Pass 1a: reserve a `StructId` for every named struct declaration
+    // before resolving any field types, so a field can reference another
+    // struct regardless of declaration order (forward references) — same
+    // rationale as task signatures resolving before bodies. Only
+    // `TypeDef::Struct` is in scope here; `SimpleEnum`/`RichEnum` land in a
+    // later M2 issue, `Alias` isn't scoped yet either.
+    for decl in &program.declarations {
+        if let Decl::Type(type_decl) = &decl.kind {
+            let TypeDef::Struct(_) = &type_decl.def else {
+                return Err(LowerError::unsupported(
+                    "non-struct type declaration (enums/aliases land in a later M2 issue)",
+                    decl.span.clone(),
+                ));
+            };
+            if !type_decl.type_params.is_empty() {
+                return Err(LowerError::unsupported(
+                    "generic struct type",
+                    type_decl.name_span.clone(),
+                ));
+            }
+            let id = struct_decls.len();
+            structs_by_name.insert(type_decl.name.clone(), id);
+            struct_decls.push(type_decl);
+        }
+    }
+
+    // Pass 1b: resolve each struct's field types now that every struct name
+    // in the file is known.
+    let mut struct_layouts: Vec<StructLayout> = Vec::with_capacity(struct_decls.len());
+    for (id, type_decl) in struct_decls.iter().enumerate() {
+        let TypeDef::Struct(ast_fields) = &type_decl.def else {
+            unreachable!("struct_decls only ever holds TypeDef::Struct entries, filtered above")
+        };
+        let mut fields = Vec::with_capacity(ast_fields.len());
+        for field in ast_fields {
+            fields.push((
+                field.name.clone(),
+                ty_expr_to_kir(&field.ty, &structs_by_name)?,
+            ));
+        }
+        struct_layouts.push(StructLayout {
+            id,
+            name: type_decl.name.clone(),
+            fields,
+        });
+    }
+
+    // Pass 2: collect every task signature (so calls resolve regardless of
     // declaration order — forward references, mutual/self recursion) and
     // every `use std/<name>` namespace binding (so namespace calls resolve
     // regardless of whether the `use` appears before or after they're used).
     for decl in &program.declarations {
         match &decl.kind {
             Decl::Task(task) => {
-                let (params, ret) = decl::signature_of(task)?;
+                let (params, ret) = decl::signature_of(task, &structs_by_name)?;
                 let func_id = task_order.len();
                 task_order.push(task);
                 funcs.insert(
@@ -190,7 +270,8 @@ pub fn lower_program(
             Decl::Use(use_decl) => {
                 lower_use(use_decl, &decl.span, &mut ns_bindings)?;
             }
-            Decl::Stmt(_) => {} // handled in pass 2 (toplevel)
+            Decl::Type(_) => {} // already handled in pass 1a/1b
+            Decl::Stmt(_) => {} // handled in pass 3 (toplevel)
             other => {
                 return Err(LowerError::unsupported(
                     decl_kind_name(other),
@@ -200,18 +281,19 @@ pub fn lower_program(
         }
     }
 
-    // Pass 2: lower each task body now that `funcs`/`ns_bindings` are complete.
+    let lcx = LowerCtx {
+        funcs: &funcs,
+        ns_bindings: &ns_bindings,
+        structs_by_name: &structs_by_name,
+        struct_layouts: &struct_layouts,
+        artifacts,
+    };
+
+    // Pass 3: lower each task body now that `lcx` is complete.
     let mut functions: Vec<KirFunction> = Vec::with_capacity(task_order.len() + 1);
     for task in &task_order {
         let sig = &funcs[&task.name];
-        functions.push(decl::lower_task_body(
-            task,
-            sig,
-            &funcs,
-            &ns_bindings,
-            &mut span_table,
-            artifacts,
-        )?);
+        functions.push(decl::lower_task_body(task, sig, &lcx, &mut span_table)?);
     }
 
     // Toplevel: every `Decl::Stmt` compiles into one synthetic function,
@@ -224,11 +306,9 @@ pub fn lower_program(
             body.push(stmt::lower_stmt(
                 stmt,
                 &mut ctx,
-                &funcs,
-                &ns_bindings,
+                &lcx,
                 &mut span_table,
                 KirType::Unit,
-                artifacts,
             )?);
         }
     }
@@ -244,6 +324,7 @@ pub fn lower_program(
     Ok(KirProgram {
         functions,
         toplevel: toplevel_id,
+        structs: struct_layouts,
         span_table,
     })
 }
@@ -304,9 +385,12 @@ fn decl_kind_name(decl: &Decl) -> &'static str {
 }
 
 /// Converts a parsed type annotation to a `KirType`, rejecting every
-/// variant outside the M0 scalar subset.
+/// variant outside the M0/M1/M2-so-far subset. `structs_by_name` resolves a
+/// bare `Named` type to a declared struct — checked after the built-in
+/// scalar names, so a struct can't shadow a reserved type name.
 pub(crate) fn ty_expr_to_kir(
     ty: &keel_syntax::ast::Node<keel_syntax::ast::TypeExpr>,
+    structs_by_name: &HashMap<String, StructId>,
 ) -> Result<KirType, LowerError> {
     use keel_syntax::ast::TypeExpr;
     match &ty.kind {
@@ -316,10 +400,15 @@ pub(crate) fn ty_expr_to_kir(
             "bool" => Ok(KirType::Bool),
             "str" => Ok(KirType::Str),
             "none" => Ok(KirType::Unit),
-            other => Err(LowerError::unsupported(
-                &format!("named type `{other}`"),
-                ty.span.clone(),
-            )),
+            other => structs_by_name.get(other).map_or_else(
+                || {
+                    Err(LowerError::unsupported(
+                        &format!("named type `{other}`"),
+                        ty.span.clone(),
+                    ))
+                },
+                |id| Ok(KirType::Struct(*id)),
+            ),
         },
         TypeExpr::Nullable(_) => Err(LowerError::unsupported("nullable type", ty.span.clone())),
         TypeExpr::List(_) => Err(LowerError::unsupported("list type", ty.span.clone())),

--- a/crates/keel-kir/src/lower/stmt.rs
+++ b/crates/keel-kir/src/lower/stmt.rs
@@ -1,45 +1,31 @@
-//! Statement lowering — the M0 scalar subset plus M1's `for`-over-ranges:
-//! `let`/assign, `if`/`else`, `while`, `for x in a..b`, `return`, and bare
-//! expression statements. Everything else (`when`, `try`/`catch`, `raise`,
-//! `assert`, `break`/`continue`, `self.field = ...`, `for` with a `where`
-//! filter or a non-range iterable) is rejected; see module docs on
-//! `lower/mod.rs`.
+//! Statement lowering — the M0 scalar subset plus M1's `for`-over-ranges
+//! and M2's named-struct literals in `let`/`return` position: `let`/assign,
+//! `if`/`else`, `while`, `for x in a..b`, `return`, and bare expression
+//! statements. Everything else (`when`, `try`/`catch`, `raise`, `assert`,
+//! `break`/`continue`, `self.field = ...`, `for` with a `where` filter or a
+//! non-range iterable) is rejected; see module docs on `lower/mod.rs`.
 
-use std::collections::HashMap;
-
-use keel_compiler::types::artifacts::CheckArtifacts;
 use keel_syntax::ast::{self, Node};
 
-use super::{FnCtx, FuncSig, LowerError, binding_ident, ty_expr_to_kir};
+use super::{FnCtx, LowerCtx, LowerError, binding_ident, ty_expr_to_kir};
 use crate::ir::{self, Block};
 use crate::span_table::SpanTable;
 use crate::types::KirType;
 
-use super::expr::lower_expr;
+use super::expr::{lower_expr, lower_expr_expecting, struct_spread_base};
 
 /// Lowers a `{ ... }` block in its own child scope.
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn lower_block(
     block: &ast::Block,
     ctx: &mut FnCtx,
-    funcs: &HashMap<String, FuncSig>,
-    ns_bindings: &HashMap<String, String>,
+    lcx: &LowerCtx<'_>,
     table: &mut SpanTable,
     ret_ty: KirType,
-    artifacts: &CheckArtifacts,
 ) -> Result<Block, LowerError> {
     ctx.push_scope();
     let mut out = Vec::with_capacity(block.len());
     for stmt in block {
-        out.push(lower_stmt(
-            stmt,
-            ctx,
-            funcs,
-            ns_bindings,
-            table,
-            ret_ty,
-            artifacts,
-        )?);
+        out.push(lower_stmt(stmt, ctx, lcx, table, ret_ty)?);
     }
     ctx.pop_scope();
     Ok(out)
@@ -49,32 +35,34 @@ pub(crate) fn lower_block(
 /// need block scoping (`if`/`while` bodies) go through [`lower_block`]; the
 /// synthetic top-level function lowers its statements directly into the
 /// function's single root scope.
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn lower_stmt(
     stmt: &Node<ast::Stmt>,
     ctx: &mut FnCtx,
-    funcs: &HashMap<String, FuncSig>,
-    ns_bindings: &HashMap<String, String>,
+    lcx: &LowerCtx<'_>,
     table: &mut SpanTable,
     ret_ty: KirType,
-    artifacts: &CheckArtifacts,
 ) -> Result<ir::Stmt, LowerError> {
     match &stmt.kind {
         ast::Stmt::Let { binding, ty, value } => {
             let name = binding_ident(binding, &stmt.span)?;
-            let init = lower_expr(value, ctx, funcs, ns_bindings, table, artifacts)?;
+            // An explicit annotation pins the expected type up front — this
+            // is what lets a struct literal (which the checker always types
+            // as an unnamed structural shape, see `lower/mod.rs`'s
+            // `CheckArtifacts` doc) resolve to the *named* struct the
+            // annotation calls for.
+            let init = if let Some(annotation) = ty {
+                let expected = ty_expr_to_kir(annotation, lcx.structs_by_name)?;
+                lower_expr_expecting(value, expected, ctx, lcx, table)?
+            } else if let ast::Expr::StructSpreadUpdate { base, .. } = &value.kind {
+                // No annotation, but the spread's own base already carries a
+                // known struct type (`dev = { ...base, debug: true }`) — use
+                // that instead of requiring a redundant annotation.
+                let (_, expected) = struct_spread_base(base, ctx)?;
+                lower_expr_expecting(value, expected, ctx, lcx, table)?
+            } else {
+                lower_expr(value, ctx, lcx, table)?
+            };
             let declared_ty = init.ty();
-            if let Some(annotation) = ty {
-                let annotated = ty_expr_to_kir(annotation)?;
-                if annotated != declared_ty {
-                    return Err(LowerError::new(
-                        format!(
-                            "`{name}` is annotated `{annotated}` but the initializer is `{declared_ty}`"
-                        ),
-                        annotation.span.clone(),
-                    ));
-                }
-            }
             let local = ctx.declare(name, declared_ty);
             Ok(ir::Stmt::Let { local, init })
         }
@@ -88,7 +76,7 @@ pub(crate) fn lower_stmt(
                 LowerError::new(format!("unknown identifier `{name}`"), name_span.clone())
             })?;
             let local_ty = ctx.locals[local].ty;
-            let rhs_expr = lower_expr(rhs, ctx, funcs, ns_bindings, table, artifacts)?;
+            let rhs_expr = lower_expr(rhs, ctx, lcx, table)?;
             let op = super::expr::convert_binop(*op);
             let result_ty = super::expr::infer_binop_ty(op, local_ty, rhs_expr.ty(), &stmt.span)?;
             if result_ty != local_ty {
@@ -120,16 +108,7 @@ pub(crate) fn lower_stmt(
             Ok(ir::Stmt::Return(None))
         }
         ast::Stmt::Return(Some(value)) => {
-            let expr = lower_expr(value, ctx, funcs, ns_bindings, table, artifacts)?;
-            if expr.ty() != ret_ty {
-                return Err(LowerError::new(
-                    format!(
-                        "`return` value is `{}` but the function returns `{ret_ty}`",
-                        expr.ty()
-                    ),
-                    value.span.clone(),
-                ));
-            }
+            let expr = lower_expr_expecting(value, ret_ty, ctx, lcx, table)?;
             Ok(ir::Stmt::Return(Some(expr)))
         }
         ast::Stmt::If {
@@ -137,17 +116,16 @@ pub(crate) fn lower_stmt(
             then_body,
             else_body,
         } => {
-            let cond_expr = lower_expr(cond, ctx, funcs, ns_bindings, table, artifacts)?;
+            let cond_expr = lower_expr(cond, ctx, lcx, table)?;
             if cond_expr.ty() != KirType::Bool {
                 return Err(LowerError::new(
                     format!("`if` condition is `{}`, expected `bool`", cond_expr.ty()),
                     cond.span.clone(),
                 ));
             }
-            let then_branch =
-                lower_block(then_body, ctx, funcs, ns_bindings, table, ret_ty, artifacts)?;
+            let then_branch = lower_block(then_body, ctx, lcx, table, ret_ty)?;
             let else_branch = match else_body {
-                Some(body) => lower_block(body, ctx, funcs, ns_bindings, table, ret_ty, artifacts)?,
+                Some(body) => lower_block(body, ctx, lcx, table, ret_ty)?,
                 None => Vec::new(),
             };
             Ok(ir::Stmt::If {
@@ -157,27 +135,20 @@ pub(crate) fn lower_stmt(
             })
         }
         ast::Stmt::While { cond, body } => {
-            let cond_expr = lower_expr(cond, ctx, funcs, ns_bindings, table, artifacts)?;
+            let cond_expr = lower_expr(cond, ctx, lcx, table)?;
             if cond_expr.ty() != KirType::Bool {
                 return Err(LowerError::new(
                     format!("`while` condition is `{}`, expected `bool`", cond_expr.ty()),
                     cond.span.clone(),
                 ));
             }
-            let body = lower_block(body, ctx, funcs, ns_bindings, table, ret_ty, artifacts)?;
+            let body = lower_block(body, ctx, lcx, table, ret_ty)?;
             Ok(ir::Stmt::While {
                 cond: cond_expr,
                 body,
             })
         }
-        ast::Stmt::Expr(expr) => Ok(ir::Stmt::Expr(lower_expr(
-            expr,
-            ctx,
-            funcs,
-            ns_bindings,
-            table,
-            artifacts,
-        )?)),
+        ast::Stmt::Expr(expr) => Ok(ir::Stmt::Expr(lower_expr(expr, ctx, lcx, table)?)),
         ast::Stmt::SelfAssign { .. } => Err(LowerError::unsupported(
             "self.field assignment",
             stmt.span.clone(),
@@ -203,14 +174,14 @@ pub(crate) fn lower_stmt(
             };
             // Bounds are evaluated once, before `var` exists, so they lower
             // in the enclosing scope and cannot reference the loop variable.
-            let low = lower_expr(start, ctx, funcs, ns_bindings, table, artifacts)?;
+            let low = lower_expr(start, ctx, lcx, table)?;
             if low.ty() != KirType::I64 {
                 return Err(LowerError::new(
                     format!("`for` range start is `{}`, expected `int`", low.ty()),
                     start.span.clone(),
                 ));
             }
-            let high = lower_expr(end, ctx, funcs, ns_bindings, table, artifacts)?;
+            let high = lower_expr(end, ctx, lcx, table)?;
             if high.ty() != KirType::I64 {
                 return Err(LowerError::new(
                     format!("`for` range end is `{}`, expected `int`", high.ty()),
@@ -219,7 +190,7 @@ pub(crate) fn lower_stmt(
             }
             ctx.push_scope();
             let var = ctx.declare(name, KirType::I64);
-            let body = lower_block(body, ctx, funcs, ns_bindings, table, ret_ty, artifacts)?;
+            let body = lower_block(body, ctx, lcx, table, ret_ty)?;
             ctx.pop_scope();
             Ok(ir::Stmt::ForIndex {
                 var,

--- a/crates/keel-kir/src/passes/verify.rs
+++ b/crates/keel-kir/src/passes/verify.rs
@@ -12,7 +12,9 @@
 
 use std::fmt;
 
-use crate::ir::{Block, CallTarget, Expr, FuncId, KirFunction, KirProgram, LocalId, Stmt};
+use crate::ir::{
+    Block, CallTarget, Expr, FuncId, KirFunction, KirProgram, LocalId, Stmt, StructId,
+};
 use crate::types::KirType;
 
 #[derive(Debug, Clone)]
@@ -97,6 +99,16 @@ fn check_func(program: &KirProgram, id: FuncId) -> Result<(), String> {
         return Err(format!(
             "FuncId {id} out of range ({} functions)",
             program.functions.len()
+        ));
+    }
+    Ok(())
+}
+
+fn check_struct(program: &KirProgram, id: StructId) -> Result<(), String> {
+    if id >= program.structs.len() {
+        return Err(format!(
+            "StructId {id} out of range ({} structs)",
+            program.structs.len()
         ));
     }
     Ok(())
@@ -232,6 +244,59 @@ fn verify_expr(program: &KirProgram, func: &KirFunction, expr: &Expr) -> Result<
                     verify_ns_call(*ns_id, *method_id, args, *ty)
                 }
             }
+        }
+        Expr::MakeStruct { struct_id, fields } => {
+            check_struct(program, *struct_id)?;
+            let layout = &program.structs[*struct_id];
+            if layout.fields.len() != fields.len() {
+                return Err(format!(
+                    "`{}` literal has {} field(s), struct declares {}",
+                    layout.name,
+                    fields.len(),
+                    layout.fields.len()
+                ));
+            }
+            for (field, (name, declared_ty)) in fields.iter().zip(&layout.fields) {
+                verify_expr(program, func, field)?;
+                if field.ty() != *declared_ty {
+                    return Err(format!(
+                        "`{}.{name}` is declared {declared_ty} but the literal supplies {}",
+                        layout.name,
+                        field.ty()
+                    ));
+                }
+            }
+            Ok(())
+        }
+        Expr::FieldGet {
+            base,
+            field_index,
+            ty,
+        } => {
+            verify_expr(program, func, base)?;
+            let KirType::Struct(struct_id) = base.ty() else {
+                return Err(format!(
+                    "field-get base is {}, expected a struct",
+                    base.ty()
+                ));
+            };
+            check_struct(program, struct_id)?;
+            let layout = &program.structs[struct_id];
+            if *field_index >= layout.fields.len() {
+                return Err(format!(
+                    "field-get index {field_index} out of range for `{}` ({} fields)",
+                    layout.name,
+                    layout.fields.len()
+                ));
+            }
+            let declared_ty = layout.fields[*field_index].1;
+            if declared_ty != *ty {
+                return Err(format!(
+                    "field-get on `{}.{}` claims type {ty} but the field is {declared_ty}",
+                    layout.name, layout.fields[*field_index].0
+                ));
+            }
+            Ok(())
         }
     }
 }

--- a/crates/keel-kir/src/types.rs
+++ b/crates/keel-kir/src/types.rs
@@ -1,11 +1,13 @@
 //! `KirType` — the lowered type vocabulary KIR expressions carry.
 //!
 //! M0/M1 lower the scalar subset only (see `designs/llvm-compilation.md`
-//! §4), so only the unboxed-scalar variants are reachable from `lower/`
-//! today. The remaining variants sketched in the design doc's `KirType`
-//! (§2.3) — containers, structs, enums, nullable, func, boxed `dynamic`,
-//! opaque handles — are deliberately not modeled yet; adding them is M2+
-//! work, done alongside the lowering support that produces them.
+//! §4); M2 adds named structs. The remaining variants sketched in the
+//! design doc's `KirType` (§2.3) — containers, anonymous struct shapes,
+//! enums, nullable, func, boxed `dynamic`, opaque handles — are
+//! deliberately not modeled yet; adding them is later-M2+ work, done
+//! alongside the lowering support that produces them.
+
+use crate::ir::{KirProgram, StructId};
 
 /// A KIR-level type. Every KIR expression carries one.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -23,10 +25,18 @@ pub enum KirType {
     /// literals and `+` concatenation are simple enough to lower now without
     /// the container ABI landing first.
     Str,
+    /// A named struct type (`type X { .. }`) — see `KirProgram::structs` for
+    /// the field layout this id indexes. Anonymous shapes have no `KirType`
+    /// yet (deferred, see `ir.rs`'s `StructLayout` doc).
+    Struct(StructId),
 }
 
 impl KirType {
-    /// Pretty name used by `dump.rs` and diagnostics.
+    /// Pretty name used by `dump.rs` and diagnostics. Doesn't have access to
+    /// `KirProgram::structs`, so a struct type prints as the generic
+    /// `"struct"` here — call sites that can name the actual struct (lowering
+    /// error messages, which already have the name in hand; `dump.rs`, which
+    /// carries the whole program) do so directly instead of through this.
     #[must_use]
     pub const fn name(self) -> &'static str {
         match self {
@@ -35,6 +45,7 @@ impl KirType {
             KirType::Bool => "bool",
             KirType::Unit => "none",
             KirType::Str => "str",
+            KirType::Struct(_) => "struct",
         }
     }
 
@@ -42,6 +53,19 @@ impl KirType {
     #[must_use]
     pub const fn is_numeric(self) -> bool {
         matches!(self, KirType::I64 | KirType::F64)
+    }
+
+    /// `true` for types the value ABI represents as a `ptr` to RC'd heap
+    /// data — `str` today, plus a struct whose layout contains a heap field
+    /// anywhere (recursively, via `StructLayout::is_heap`). Everything else
+    /// is a plain by-value scalar/aggregate.
+    #[must_use]
+    pub fn is_heap(self, program: &KirProgram) -> bool {
+        match self {
+            KirType::Str => true,
+            KirType::Struct(id) => program.structs[id].is_heap(program),
+            KirType::I64 | KirType::F64 | KirType::Bool | KirType::Unit => false,
+        }
     }
 
     /// Maps a catalog [`keel_catalog::builtins::TySpec`] to the equivalent

--- a/crates/keel-kir/tests/fixtures/structs.keel
+++ b/crates/keel-kir/tests/fixtures/structs.keel
@@ -1,0 +1,13 @@
+type Order {
+  id: str
+  status: str
+  amount: float
+}
+
+task process_order(o: Order) -> Order {
+  return { ...o, status: "filled" }
+}
+
+pending: Order = { id: "ord-42", status: "pending", amount: 250.0 }
+filled = process_order(pending)
+result = filled.status

--- a/crates/keel-kir/tests/fixtures/structs.kir
+++ b/crates/keel-kir/tests/fixtures/structs.kir
@@ -1,0 +1,11 @@
+struct Order { id: str, status: str, amount: float }
+
+fn process_order(o: Order) -> Order {
+  return Order { id: o.id, status: "filled", amount: o.amount }
+}
+
+fn <toplevel>() -> none {
+  let pending: Order = Order { id: "ord-42", status: "pending", amount: 250.0 }
+  let filled: Order = process_order(pending)
+  let result: str = filled.status
+}

--- a/crates/keel-kir/tests/lower_errors.rs
+++ b/crates/keel-kir/tests/lower_errors.rs
@@ -148,7 +148,7 @@ task f() -> int {
 }
 "#,
     );
-    assert!(msg.contains("annotated"), "unexpected message: {msg}");
+    assert!(msg.contains("expected"), "unexpected message: {msg}");
 }
 
 #[test]
@@ -250,4 +250,116 @@ io.show("hi")
 "#,
     );
     assert!(msg.contains("method call"), "unexpected message: {msg}");
+}
+
+#[test]
+fn struct_literal_missing_a_field_is_rejected() {
+    let msg = lower_err(
+        r#"
+type Point { x: int, y: int }
+
+p: Point = { x: 1 }
+"#,
+    );
+    assert!(
+        msg.contains("missing field `y`"),
+        "unexpected message: {msg}"
+    );
+}
+
+#[test]
+fn struct_literal_with_an_unknown_field_is_rejected() {
+    let msg = lower_err(
+        r#"
+type Point { x: int, y: int }
+
+p: Point = { x: 1, y: 2, z: 3 }
+"#,
+    );
+    assert!(
+        msg.contains("has no field `z`"),
+        "unexpected message: {msg}"
+    );
+}
+
+#[test]
+fn struct_literal_field_type_mismatch_is_rejected() {
+    let msg = lower_err(
+        r#"
+type Point { x: int, y: int }
+
+p: Point = { x: 1, y: "two" }
+"#,
+    );
+    assert!(msg.contains("expected"), "unexpected message: {msg}");
+}
+
+#[test]
+fn field_access_on_a_non_struct_value_is_rejected() {
+    let msg = lower_err(
+        r#"
+task f() -> int {
+  x = 1
+  return x.y
+}
+"#,
+    );
+    assert!(
+        msg.contains("field access on a non-struct value"),
+        "unexpected message: {msg}"
+    );
+}
+
+#[test]
+fn field_access_on_an_unknown_field_is_rejected() {
+    let msg = lower_err(
+        r#"
+type Point { x: int, y: int }
+
+task f(p: Point) -> int {
+  return p.z
+}
+"#,
+    );
+    assert!(
+        msg.contains("has no field `z`"),
+        "unexpected message: {msg}"
+    );
+}
+
+#[test]
+fn struct_spread_update_over_a_non_identifier_base_is_rejected() {
+    let msg = lower_err(
+        r#"
+type Point { x: int, y: int }
+
+task make() -> Point {
+  return { x: 1, y: 2 }
+}
+
+p: Point = { ...make(), x: 3 }
+"#,
+    );
+    assert!(
+        msg.contains("non-identifier base"),
+        "unexpected message: {msg}"
+    );
+}
+
+#[test]
+fn non_struct_type_declaration_is_rejected() {
+    let msg = lower_err("type Color = red | green | blue\n");
+    assert!(
+        msg.contains("non-struct type declaration"),
+        "unexpected message: {msg}"
+    );
+}
+
+#[test]
+fn generic_struct_type_is_rejected() {
+    let msg = lower_err("type Box[T] { value: int }\n");
+    assert!(
+        msg.contains("generic struct type"),
+        "unexpected message: {msg}"
+    );
 }


### PR DESCRIPTION
## Summary

Part of M2 (#113). Implements `type Order { ... }`-style named structs across `keel-kir` and `keel-codegen`: declaration, literal construction, field access, and spread-update (`{ ...o, status: "filled" }`), compiled to native code and verified byte-for-byte against the interpreter.

- `KirType::Struct(StructId)` + `StructLayout` (field order + types) on `KirProgram`.
- `Expr::MakeStruct` / `Expr::FieldGet` KIR nodes.
- `lower_expr_expecting`: threads an expected type through `let` annotations, `return`, and call arguments so a struct literal (which the checker always types as an unnamed structural shape) resolves to the concrete named struct the position calls for. Struct literals match fields by name, not source order, and rebuild in declared field order.
- Spread-update resolves its `base` (must be a plain identifier — a general expression base would need a let-binding KIR doesn't have yet) and rebuilds every field, taking overrides where given and reading `base` otherwise.
- Codegen: a struct containing any heap-typed field (string, container, boxed `dynamic`, or another heap struct), recursively, is malloc'd and GEP-addressed; an all-scalar struct is explicitly rejected for now (`layout::llvm_type`) since no M2 fixture needs by-value aggregates yet.
- As a side effect, `str` is now a fully supported codegen value type (a boxed pointer) rather than being rejected — a bare string literal compiles and exits 0.
- Extended `--emit=kir` dump, golden-dump test, and `passes/verify.rs` for the new node/type shapes.

## Deferred (called out, not silently dropped)

- **Tuples** — split to #157. While implementing this, found that positional tuple access (`pair.0`) doesn't parse at all today: `field_name()` in `keel-syntax` only accepts identifiers, not `Token::Integer`. That's a pre-existing gap spanning the parser, the checker's `resolve_struct_field` (no `Ty::Tuple` arm), and possibly the interpreter — well outside a `keel-kir`/`keel-codegen` issue. Tuple construction and destructuring already work; only `.N` read access is missing. #157 covers the whole feature in one pass so the by-value-aggregate codegen path gets written once, not twice.
- **Anonymous struct shapes** (`{ x: 1, y: 2 }` with no named-type context) — not interned. Every struct literal in this PR resolves against a named type via the expected-type-threading mechanism above; no M2 fixture needs a truly anonymous shape yet.
- **All-scalar by-value structs** — rejected in codegen (`CodegenError::Unsupported`) rather than silently miscompiled, since nothing exercises the by-value path yet.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo clippy --workspace --all-targets --features build-backend -- -D warnings`
- [x] `cargo test --workspace` (all green)
- [x] `cargo test --workspace --features build-backend` (all green, including the two new `keel-codegen/tests/structs.rs` integration tests comparing compiled vs. interpreted output for struct literals, field access, spread-update, and multi-generation spread chains)
- [x] 8 new rejection tests in `keel-kir/tests/lower_errors.rs` covering malformed struct literals/field access/spread bases and invalid type declarations

Close #145