### PR TITLE
keel-kir + keel-codegen: simple enums and when (statement form) end to end

### DIFF
--- a/crates/keel-codegen/src/expr.rs
+++ b/crates/keel-codegen/src/expr.rs
@@ -62,6 +62,11 @@ pub(crate) fn emit_expr<'ctx>(
             field_index,
             ty,
         } => emit_field_get(fcx, base, *field_index, *ty),
+        Expr::MakeEnum { variant_index, .. } => Ok(fcx
+            .context
+            .i32_type()
+            .const_int(*variant_index as u64, false)
+            .into()),
     }
 }
 
@@ -289,10 +294,55 @@ fn emit_binop<'ctx>(
             };
             Ok(result)
         }
-        KirType::Str => Err(CodegenError::Unsupported(
-            "str concatenation/comparison (string interpolation lands in a later M2 issue)"
-                .to_string(),
-        )),
+        KirType::Str => match op {
+            BinOp::Eq | BinOp::Neq => {
+                let l = lv.into_pointer_value();
+                let r = rv.into_pointer_value();
+                let ptr_type = fcx.context.ptr_type(AddressSpace::default());
+                let i8_type = fcx.context.i8_type();
+                let f = crate::ns_call::declare_or_get(fcx.module, "keel_str_eq", || {
+                    i8_type.fn_type(&[ptr_type.into(), ptr_type.into()], false)
+                });
+                let call = b
+                    .build_call(f, &[l.into(), r.into()], "str_eq")
+                    .map_err(llvm_err)?;
+                let eq = match call.try_as_basic_value() {
+                    ValueKind::Basic(v) => v.into_int_value(),
+                    ValueKind::Instruction(_) => {
+                        unreachable!("keel_str_eq returns a u8, never void")
+                    }
+                };
+                let eq_bool = b
+                    .build_int_truncate(eq, fcx.context.bool_type(), "str_eq_bool")
+                    .map_err(llvm_err)?;
+                Ok(if op == BinOp::Eq {
+                    eq_bool.into()
+                } else {
+                    b.build_not(eq_bool, "str_ne_bool")
+                        .map_err(llvm_err)?
+                        .into()
+                })
+            }
+            _ => Err(CodegenError::Unsupported(
+                "str concatenation (string interpolation lands in a later M2 issue)".to_string(),
+            )),
+        },
+        KirType::Enum(_) => {
+            let l = lv.into_int_value();
+            let r = rv.into_int_value();
+            let result: BasicValueEnum = match op {
+                BinOp::Eq => b
+                    .build_int_compare(IntPredicate::EQ, l, r, "eeq")
+                    .map_err(llvm_err)?
+                    .into(),
+                BinOp::Neq => b
+                    .build_int_compare(IntPredicate::NE, l, r, "ene")
+                    .map_err(llvm_err)?
+                    .into(),
+                _ => return Err(unreachable_combo(op, operand_ty)),
+            };
+            Ok(result)
+        }
         KirType::Unit | KirType::Struct(_) => Err(unreachable_combo(op, operand_ty)),
     }
 }

--- a/crates/keel-codegen/src/layout.rs
+++ b/crates/keel-codegen/src/layout.rs
@@ -8,7 +8,8 @@
 //! struct (`KirType::Struct`) is `ptr` too, when it has a heap field
 //! (`StructLayout::is_heap`) — an all-scalar struct would be a by-value
 //! LLVM aggregate, but that path isn't wired up yet (every M2 fixture uses
-//! a struct with at least one `str` field).
+//! a struct with at least one `str` field). A simple enum (`KirType::Enum`)
+//! is a plain by-value `i32` tag — no heap allocation or RC, unlike `Struct`.
 
 use inkwell::AddressSpace;
 use inkwell::context::Context;
@@ -43,6 +44,7 @@ pub(crate) fn llvm_type<'ctx>(
                 )))
             }
         }
+        KirType::Enum(_) => Ok(context.i32_type().into()),
     }
 }
 

--- a/crates/keel-codegen/src/ns_call.rs
+++ b/crates/keel-codegen/src/ns_call.rs
@@ -105,6 +105,11 @@ fn emit_box_arg<'ctx>(
              Value::Struct is a later-M2/M3 concern — see designs/llvm-compilation.md §2.4)"
                 .to_string(),
         )),
+        KirType::Enum(_) => Err(CodegenError::Unsupported(
+            "enum-typed argument to a namespace call (marshaling an enum tag into a boxed \
+             Value is a later-M2/M3 concern)"
+                .to_string(),
+        )),
     }
 }
 

--- a/crates/keel-codegen/tests/enums_when.rs
+++ b/crates/keel-codegen/tests/enums_when.rs
@@ -1,0 +1,138 @@
+//! Exit criterion for issue #146: a program declaring a simple enum and
+//! matching it exhaustively via `when` (each arm returning directly, side-
+//! effect style — `when` as an *expression*, e.g. `x = when ... {...}`,
+//! isn't lowered yet), plus a `when` over a `str` scrutinee with a wildcard
+//! arm, compiles, links, and matches the interpreter byte-for-byte
+//! (`examples/when_expression.keel`'s shape, minus its implicit-tail-return
+//! style — see #159).
+
+use std::process::Command;
+
+use keel_codegen::BuildOptions;
+
+#[path = "support/mod.rs"]
+mod support;
+
+fn compile_and_run(source: &str) -> std::process::Output {
+    let kir = support::parse_check_and_lower(source);
+
+    let out_dir = tempfile::tempdir().expect("create temp out dir");
+    let opts = BuildOptions {
+        out_dir: out_dir.path().to_path_buf(),
+        runtime_link_args: support::runtime_link_args().clone(),
+    };
+    let bin = keel_codegen::compile(&kir, &opts).expect("compile must succeed");
+    Command::new(&bin).output().expect("run compiled binary")
+}
+
+const SOURCE: &str = r#"
+use std/io
+
+type Priority = low | medium | high
+
+task label(p: Priority) -> str {
+  when p {
+    low => { return "low priority" }
+    medium => { return "medium priority" }
+    high => { return "high priority" }
+  }
+}
+
+task grade(score: str) -> str {
+  when score {
+    "A" => { return "excellent" }
+    "B" => { return "good" }
+    _ => { return "needs work" }
+  }
+}
+
+io.show(label(Priority.low))
+io.show(label(Priority.high))
+io.show(grade("A"))
+io.show(grade("D"))
+"#;
+
+#[test]
+fn enum_when_and_str_when_with_wildcard_match_the_interpreter() {
+    let compiled = compile_and_run(SOURCE);
+    let interpreted = support::run_interpreter(SOURCE);
+
+    assert_eq!(
+        String::from_utf8_lossy(&compiled.stdout),
+        String::from_utf8_lossy(&interpreted.stdout),
+        "compiled stdout must match the interpreter's"
+    );
+    assert_eq!(
+        compiled.stdout,
+        b"  low priority\n  high priority\n  excellent\n  needs work\n"
+    );
+}
+
+#[test]
+fn non_returning_when_statement_falls_through_to_a_later_statement() {
+    // Every arm above terminates via `return` (each branch's LLVM block
+    // already has a terminator, so nothing merges). This exercises the
+    // other shape: an arm that falls off the end of its block (`io.show`,
+    // no `return`) merges back into the enclosing function and execution
+    // continues past the `when` — a different codegen path (`emit_if`'s
+    // per-branch unconditional-branch-to-merge case) than every other test
+    // in this file exhausts.
+    let source = r#"
+use std/io
+
+type Priority = low | medium | high
+
+task announce(p: Priority) {
+  when p {
+    low => { io.show("low seen") }
+    medium => { io.show("medium seen") }
+    high => { io.show("high seen") }
+  }
+  io.show("done")
+}
+
+announce(Priority.low)
+announce(Priority.high)
+"#;
+
+    let compiled = compile_and_run(source);
+    let interpreted = support::run_interpreter(source);
+
+    assert_eq!(
+        String::from_utf8_lossy(&compiled.stdout),
+        String::from_utf8_lossy(&interpreted.stdout),
+        "compiled stdout must match the interpreter's"
+    );
+    assert_eq!(
+        compiled.stdout,
+        b"  low seen\n  done\n  high seen\n  done\n"
+    );
+}
+
+#[test]
+fn when_arm_with_multiple_comma_separated_patterns_matches_the_interpreter() {
+    let source = r#"
+use std/io
+
+task grade(score: str) -> str {
+  when score {
+    "A", "B" => { return "good" }
+    _ => { return "needs work" }
+  }
+}
+
+io.show(grade("A"))
+io.show(grade("B"))
+io.show(grade("C"))
+"#;
+
+    let compiled = compile_and_run(source);
+    let interpreted = support::run_interpreter(source);
+
+    assert_eq!(
+        String::from_utf8_lossy(&compiled.stdout),
+        String::from_utf8_lossy(&interpreted.stdout),
+        "compiled stdout must match the interpreter's"
+    );
+    assert_eq!(compiled.stdout, b"  good\n  good\n  needs work\n");
+}

--- a/crates/keel-kir/src/dump.rs
+++ b/crates/keel-kir/src/dump.rs
@@ -24,7 +24,10 @@ pub fn dump(program: &KirProgram) -> String {
             .join(", ");
         let _ = writeln!(out, "struct {} {{ {fields} }}", s.name);
     }
-    if !program.structs.is_empty() {
+    for e in &program.enums {
+        let _ = writeln!(out, "enum {} {{ {} }}", e.name, e.variants.join(", "));
+    }
+    if !program.structs.is_empty() || !program.enums.is_empty() {
         out.push('\n');
     }
     for (i, func) in program.functions.iter().enumerate() {
@@ -42,6 +45,7 @@ pub fn dump(program: &KirProgram) -> String {
 fn fmt_ty(program: &KirProgram, ty: KirType) -> String {
     match ty {
         KirType::Struct(id) => program.structs[id].name.clone(),
+        KirType::Enum(id) => program.enums[id].name.clone(),
         other => other.to_string(),
     }
 }
@@ -215,6 +219,13 @@ fn fmt_expr(program: &KirProgram, func: &KirFunction, expr: &Expr) -> String {
             };
             let field_name = &program.structs[*struct_id].fields[*field_index].0;
             format!("{}.{field_name}", fmt_expr(program, func, base))
+        }
+        Expr::MakeEnum {
+            enum_id,
+            variant_index,
+        } => {
+            let layout = &program.enums[*enum_id];
+            format!("{}.{}", layout.name, layout.variants[*variant_index])
         }
     }
 }

--- a/crates/keel-kir/src/ir.rs
+++ b/crates/keel-kir/src/ir.rs
@@ -25,6 +25,9 @@ pub type LocalId = usize;
 /// Index into `KirProgram::structs`.
 pub type StructId = usize;
 
+/// Index into `KirProgram::enums`.
+pub type EnumId = usize;
+
 /// A whole lowered program (currently: a single file's tasks + its
 /// top-level statements — multi-module lowering is deferred until the
 /// `keel-compiler` `ModuleGraph`/`CheckArtifacts` seam lands, see `lib.rs`).
@@ -42,6 +45,11 @@ pub struct KirProgram {
     /// an M2 fixture actually needs one; see `lower/mod.rs`'s struct-
     /// resolution doc.
     pub structs: Vec<StructLayout>,
+    /// Every simple (unit-variant) enum type (`type Priority = low | medium |
+    /// high`) declared in the file, in declaration order. Rich (payload-
+    /// carrying) variants aren't modeled yet — deferred to a follow-up
+    /// issue; see `lower/mod.rs`'s enum-resolution doc.
+    pub enums: Vec<EnumLayout>,
     pub span_table: SpanTable,
 }
 
@@ -72,6 +80,26 @@ impl StructLayout {
     #[must_use]
     pub fn is_heap(&self, program: &KirProgram) -> bool {
         self.fields.iter().any(|(_, ty)| ty.is_heap(program))
+    }
+}
+
+/// A simple enum type's compiled layout: variant names in declaration order,
+/// where a variant's position *is* its runtime tag (fixed at KIR-lowering
+/// time, same rationale as `StructLayout`). Values are a plain by-value
+/// `i32` — no payload, no heap allocation, no RC.
+#[derive(Debug, Clone)]
+pub struct EnumLayout {
+    pub id: EnumId,
+    pub name: String,
+    pub variants: Vec<String>,
+}
+
+impl EnumLayout {
+    /// Index of `name` in `variants` (its runtime tag), if this enum has
+    /// such a variant.
+    #[must_use]
+    pub fn variant_index(&self, name: &str) -> Option<usize> {
+        self.variants.iter().position(|v| v == name)
     }
 }
 
@@ -201,6 +229,13 @@ pub enum Expr {
         field_index: usize,
         ty: KirType,
     },
+    /// Builds a simple-enum value (`Priority.low`) — just its runtime tag,
+    /// resolved at lowering time via `EnumLayout::variant_index`. No payload
+    /// (rich variants aren't modeled yet).
+    MakeEnum {
+        enum_id: EnumId,
+        variant_index: usize,
+    },
 }
 
 /// What an `Expr::Call` invokes.
@@ -231,6 +266,7 @@ impl Expr {
             | Expr::Call { ty, .. }
             | Expr::FieldGet { ty, .. } => *ty,
             Expr::MakeStruct { struct_id, .. } => KirType::Struct(*struct_id),
+            Expr::MakeEnum { enum_id, .. } => KirType::Enum(*enum_id),
         }
     }
 }

--- a/crates/keel-kir/src/lower/decl.rs
+++ b/crates/keel-kir/src/lower/decl.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use keel_syntax::ast::TaskDecl;
 
 use super::{FnCtx, FuncSig, LowerCtx, LowerError, binding_ident, ty_expr_to_kir};
-use crate::ir::{KirFunction, Param, StructId};
+use crate::ir::{EnumId, KirFunction, Param, StructId};
 use crate::span_table::SpanTable;
 use crate::types::KirType;
 
@@ -18,6 +18,7 @@ use crate::types::KirType;
 pub(crate) fn signature_of(
     task: &TaskDecl,
     structs_by_name: &HashMap<String, StructId>,
+    enums_by_name: &HashMap<String, EnumId>,
 ) -> Result<(Vec<KirType>, KirType), LowerError> {
     if !task.type_params.is_empty() {
         return Err(LowerError::unsupported(
@@ -40,10 +41,10 @@ pub(crate) fn signature_of(
             ));
         }
         binding_ident(&param.name, &param.name_span)?; // rejects destructuring params
-        params.push(ty_expr_to_kir(&param.ty, structs_by_name)?);
+        params.push(ty_expr_to_kir(&param.ty, structs_by_name, enums_by_name)?);
     }
     let ret = match &task.return_type {
-        Some(ty) => ty_expr_to_kir(ty, structs_by_name)?,
+        Some(ty) => ty_expr_to_kir(ty, structs_by_name, enums_by_name)?,
         None => KirType::Unit,
     };
     Ok((params, ret))

--- a/crates/keel-kir/src/lower/expr.rs
+++ b/crates/keel-kir/src/lower/expr.rs
@@ -2,10 +2,11 @@
 //! arithmetic/comparison/logical binary ops, unary `-`/`not`, and direct
 //! calls to other lowered tasks) plus M1's stdlib namespace calls
 //! (`io.show(...)`, `log.info(...)` — see [`lower_call`]) and M2's named-
-//! struct literals, spread-update, and field access. Everything else (index
-//! access, value method calls, casts, `if`/`when` as expressions, lambdas,
-//! list/set/tuple literals, string interpolation, `?.`/`??`, pipelines,
-//! duration literals, enum variants) is rejected; see module docs on
+//! struct literals, spread-update, field access, and simple-enum variant
+//! construction (`Priority.low`). Everything else (index access, value
+//! method calls, casts, `if`/`when` as expressions, lambdas, list/set/tuple
+//! literals, string interpolation, `?.`/`??`, pipelines, duration literals,
+//! rich (payload-carrying) enum variants) is rejected; see module docs on
 //! `lower/mod.rs`.
 
 use std::collections::HashMap;
@@ -156,6 +157,29 @@ pub(crate) fn lower_expr(
         }
         ast::Expr::Call { callee, args } => lower_call(callee, args, ctx, lcx, table, &expr.span),
         ast::Expr::FieldAccess(base, field) => {
+            // Enum-variant construction (`Priority.low`): unlike struct field
+            // access, `base` here is a *type name*, not a value — mirrors
+            // the checker's "lexical locals shadow globals" precedence
+            // (`NameKind::Enum` short-circuit in `checker/expr.rs`) so a
+            // local that happens to shadow an enum's name still resolves as
+            // a value, not a variant.
+            if let ast::Expr::Ident(name) = &base.kind
+                && ctx.resolve(name).is_none()
+                && let Some(enum_id) = lcx.enums_by_name.get(name).copied()
+            {
+                let layout = &lcx.enum_layouts[enum_id];
+                let variant_index = layout.variant_index(field).ok_or_else(|| {
+                    LowerError::new(
+                        format!("enum `{}` has no variant `{field}`", layout.name),
+                        expr.span.clone(),
+                    )
+                })?;
+                return Ok(Expr::MakeEnum {
+                    enum_id,
+                    variant_index,
+                });
+            }
+
             let base_e = lower_expr(base, ctx, lcx, table)?;
             let KirType::Struct(struct_id) = base_e.ty() else {
                 return Err(LowerError::unsupported(

--- a/crates/keel-kir/src/lower/mod.rs
+++ b/crates/keel-kir/src/lower/mod.rs
@@ -50,7 +50,9 @@ use keel_compiler::types::artifacts::CheckArtifacts;
 use keel_syntax::ast::{Binding, Decl, Program, TypeDef, UseDecl, UseKind, UseSource};
 use keel_syntax::lexer::Span;
 
-use crate::ir::{FuncId, KirFunction, KirProgram, LocalId, StructId, StructLayout};
+use crate::ir::{
+    EnumId, EnumLayout, FuncId, KirFunction, KirProgram, LocalId, StructId, StructLayout,
+};
 use crate::span_table::SpanTable;
 use crate::types::KirType;
 
@@ -109,6 +111,8 @@ pub(crate) struct LowerCtx<'a> {
     pub(crate) ns_bindings: &'a HashMap<String, String>,
     pub(crate) structs_by_name: &'a HashMap<String, StructId>,
     pub(crate) struct_layouts: &'a [StructLayout],
+    pub(crate) enums_by_name: &'a HashMap<String, EnumId>,
+    pub(crate) enum_layouts: &'a [EnumLayout],
     /// Not consumed yet — #145 (named structs) resolves everything through
     /// context-threaded expected types instead (see `expr::lower_expr_expecting`).
     /// Becomes load-bearing for a construct the checker must resolve and
@@ -125,6 +129,7 @@ pub(crate) struct LowerCtx<'a> {
 pub(crate) fn describe_ty(ty: KirType, lcx: &LowerCtx<'_>) -> String {
     match ty {
         KirType::Struct(id) => format!("struct {}", lcx.struct_layouts[id].name),
+        KirType::Enum(id) => format!("enum {}", lcx.enum_layouts[id].name),
         other => other.to_string(),
     }
 }
@@ -200,35 +205,60 @@ pub fn lower_program(
     let mut task_order: Vec<&keel_syntax::ast::TaskDecl> = Vec::new();
     let mut structs_by_name: HashMap<String, StructId> = HashMap::new();
     let mut struct_decls: Vec<&keel_syntax::ast::TypeDecl> = Vec::new();
+    let mut enums_by_name: HashMap<String, EnumId> = HashMap::new();
+    let mut enum_layouts: Vec<EnumLayout> = Vec::new();
 
     // Pass 1a: reserve a `StructId` for every named struct declaration
     // before resolving any field types, so a field can reference another
     // struct regardless of declaration order (forward references) — same
-    // rationale as task signatures resolving before bodies. Only
-    // `TypeDef::Struct` is in scope here; `SimpleEnum`/`RichEnum` land in a
-    // later M2 issue, `Alias` isn't scoped yet either.
+    // rationale as task signatures resolving before bodies. A simple enum
+    // has no forward-reference problem (variants are bare names, not
+    // types), so it's fully built here in one step rather than needing a
+    // reserve-then-resolve split like structs. `RichEnum`/`Alias` aren't
+    // scoped yet — rich (payload-carrying) variants are a follow-up issue
+    // (see `ir.rs`'s `KirProgram::enums` doc).
     for decl in &program.declarations {
         if let Decl::Type(type_decl) = &decl.kind {
-            let TypeDef::Struct(_) = &type_decl.def else {
-                return Err(LowerError::unsupported(
-                    "non-struct type declaration (enums/aliases land in a later M2 issue)",
-                    decl.span.clone(),
-                ));
-            };
-            if !type_decl.type_params.is_empty() {
-                return Err(LowerError::unsupported(
-                    "generic struct type",
-                    type_decl.name_span.clone(),
-                ));
+            match &type_decl.def {
+                TypeDef::Struct(_) => {
+                    if !type_decl.type_params.is_empty() {
+                        return Err(LowerError::unsupported(
+                            "generic struct type",
+                            type_decl.name_span.clone(),
+                        ));
+                    }
+                    let id = struct_decls.len();
+                    structs_by_name.insert(type_decl.name.clone(), id);
+                    struct_decls.push(type_decl);
+                }
+                TypeDef::SimpleEnum(variants) => {
+                    if !type_decl.type_params.is_empty() {
+                        return Err(LowerError::unsupported(
+                            "generic enum type",
+                            type_decl.name_span.clone(),
+                        ));
+                    }
+                    let id = enum_layouts.len();
+                    enums_by_name.insert(type_decl.name.clone(), id);
+                    enum_layouts.push(EnumLayout {
+                        id,
+                        name: type_decl.name.clone(),
+                        variants: variants.clone(),
+                    });
+                }
+                TypeDef::RichEnum(_) | TypeDef::Alias(_) => {
+                    return Err(LowerError::unsupported(
+                        "rich enum or type-alias declaration (rich/payload-carrying variants \
+                         land in a later M2/M3 issue; aliases aren't scoped yet)",
+                        decl.span.clone(),
+                    ));
+                }
             }
-            let id = struct_decls.len();
-            structs_by_name.insert(type_decl.name.clone(), id);
-            struct_decls.push(type_decl);
         }
     }
 
-    // Pass 1b: resolve each struct's field types now that every struct name
-    // in the file is known.
+    // Pass 1b: resolve each struct's field types now that every struct and
+    // enum name in the file is known.
     let mut struct_layouts: Vec<StructLayout> = Vec::with_capacity(struct_decls.len());
     for (id, type_decl) in struct_decls.iter().enumerate() {
         let TypeDef::Struct(ast_fields) = &type_decl.def else {
@@ -238,7 +268,7 @@ pub fn lower_program(
         for field in ast_fields {
             fields.push((
                 field.name.clone(),
-                ty_expr_to_kir(&field.ty, &structs_by_name)?,
+                ty_expr_to_kir(&field.ty, &structs_by_name, &enums_by_name)?,
             ));
         }
         struct_layouts.push(StructLayout {
@@ -255,7 +285,7 @@ pub fn lower_program(
     for decl in &program.declarations {
         match &decl.kind {
             Decl::Task(task) => {
-                let (params, ret) = decl::signature_of(task, &structs_by_name)?;
+                let (params, ret) = decl::signature_of(task, &structs_by_name, &enums_by_name)?;
                 let func_id = task_order.len();
                 task_order.push(task);
                 funcs.insert(
@@ -286,6 +316,8 @@ pub fn lower_program(
         ns_bindings: &ns_bindings,
         structs_by_name: &structs_by_name,
         struct_layouts: &struct_layouts,
+        enums_by_name: &enums_by_name,
+        enum_layouts: &enum_layouts,
         artifacts,
     };
 
@@ -325,6 +357,7 @@ pub fn lower_program(
         functions,
         toplevel: toplevel_id,
         structs: struct_layouts,
+        enums: enum_layouts,
         span_table,
     })
 }
@@ -385,12 +418,14 @@ fn decl_kind_name(decl: &Decl) -> &'static str {
 }
 
 /// Converts a parsed type annotation to a `KirType`, rejecting every
-/// variant outside the M0/M1/M2-so-far subset. `structs_by_name` resolves a
-/// bare `Named` type to a declared struct — checked after the built-in
-/// scalar names, so a struct can't shadow a reserved type name.
+/// variant outside the M0/M1/M2-so-far subset. `structs_by_name`/
+/// `enums_by_name` resolve a bare `Named` type to a declared struct or enum
+/// — checked after the built-in scalar names, so neither can shadow a
+/// reserved type name.
 pub(crate) fn ty_expr_to_kir(
     ty: &keel_syntax::ast::Node<keel_syntax::ast::TypeExpr>,
     structs_by_name: &HashMap<String, StructId>,
+    enums_by_name: &HashMap<String, EnumId>,
 ) -> Result<KirType, LowerError> {
     use keel_syntax::ast::TypeExpr;
     match &ty.kind {
@@ -400,15 +435,18 @@ pub(crate) fn ty_expr_to_kir(
             "bool" => Ok(KirType::Bool),
             "str" => Ok(KirType::Str),
             "none" => Ok(KirType::Unit),
-            other => structs_by_name.get(other).map_or_else(
-                || {
+            other => {
+                if let Some(id) = structs_by_name.get(other) {
+                    Ok(KirType::Struct(*id))
+                } else if let Some(id) = enums_by_name.get(other) {
+                    Ok(KirType::Enum(*id))
+                } else {
                     Err(LowerError::unsupported(
                         &format!("named type `{other}`"),
                         ty.span.clone(),
                     ))
-                },
-                |id| Ok(KirType::Struct(*id)),
-            ),
+                }
+            }
         },
         TypeExpr::Nullable(_) => Err(LowerError::unsupported("nullable type", ty.span.clone())),
         TypeExpr::List(_) => Err(LowerError::unsupported("list type", ty.span.clone())),

--- a/crates/keel-kir/src/lower/stmt.rs
+++ b/crates/keel-kir/src/lower/stmt.rs
@@ -1,14 +1,17 @@
 //! Statement lowering — the M0 scalar subset plus M1's `for`-over-ranges
-//! and M2's named-struct literals in `let`/`return` position: `let`/assign,
-//! `if`/`else`, `while`, `for x in a..b`, `return`, and bare expression
-//! statements. Everything else (`when`, `try`/`catch`, `raise`, `assert`,
-//! `break`/`continue`, `self.field = ...`, `for` with a `where` filter or a
-//! non-range iterable) is rejected; see module docs on `lower/mod.rs`.
+//! and M2's named-struct literals in `let`/`return` position, plus `when` as
+//! a statement (over a simple-enum or a str/int scrutinee with a wildcard
+//! arm — see [`lower_when_stmt`]): `let`/assign, `if`/`else`, `while`,
+//! `for x in a..b`, `return`, `when`, and bare expression statements.
+//! Everything else (`try`/`catch`, `raise`, `assert`, `break`/`continue`,
+//! `self.field = ...`, `for` with a `where` filter or a non-range iterable)
+//! is rejected; see module docs on `lower/mod.rs`.
 
 use keel_syntax::ast::{self, Node};
+use keel_syntax::lexer::Span;
 
 use super::{FnCtx, LowerCtx, LowerError, binding_ident, ty_expr_to_kir};
-use crate::ir::{self, Block};
+use crate::ir::{self, Block, LocalId};
 use crate::span_table::SpanTable;
 use crate::types::KirType;
 
@@ -51,7 +54,7 @@ pub(crate) fn lower_stmt(
             // `CheckArtifacts` doc) resolve to the *named* struct the
             // annotation calls for.
             let init = if let Some(annotation) = ty {
-                let expected = ty_expr_to_kir(annotation, lcx.structs_by_name)?;
+                let expected = ty_expr_to_kir(annotation, lcx.structs_by_name, lcx.enums_by_name)?;
                 lower_expr_expecting(value, expected, ctx, lcx, table)?
             } else if let ast::Expr::StructSpreadUpdate { base, .. } = &value.kind {
                 // No annotation, but the spread's own base already carries a
@@ -199,11 +202,232 @@ pub(crate) fn lower_stmt(
                 body,
             })
         }
-        ast::Stmt::When { .. } => Err(LowerError::unsupported("when statement", stmt.span.clone())),
+        ast::Stmt::When { subject, arms } => {
+            lower_when_stmt(subject, arms, ctx, lcx, table, ret_ty, &stmt.span)
+        }
         ast::Stmt::TryCatch { .. } => Err(LowerError::unsupported("try/catch", stmt.span.clone())),
         ast::Stmt::Raise(_) => Err(LowerError::unsupported("raise", stmt.span.clone())),
         ast::Stmt::Assert { .. } => Err(LowerError::unsupported("assert", stmt.span.clone())),
         ast::Stmt::Break => Err(LowerError::unsupported("break", stmt.span.clone())),
         ast::Stmt::Continue => Err(LowerError::unsupported("continue", stmt.span.clone())),
+    }
+}
+
+/// Lowers `when subject { arms }` used as a statement (each arm runs for its
+/// side effect — `return`, a namespace call, etc. — not for a produced
+/// value; `when` *as an expression*, e.g. `x = when ... { ... }`, isn't
+/// lowered yet, see `lower/expr.rs`'s `WhenExpr` rejection).
+///
+/// `subject` must be a plain identifier (a local/param already in scope),
+/// not an arbitrary expression: KIR's `Expr` is a tree with no let-binding
+/// of its own, so a non-trivial subject would otherwise get re-evaluated
+/// once per arm comparison — same restriction, and same rationale, as
+/// `expr::struct_spread_base`'s spread-update base.
+fn lower_when_stmt(
+    subject: &ast::SpannedExpr,
+    arms: &[ast::WhenArm],
+    ctx: &mut FnCtx,
+    lcx: &LowerCtx<'_>,
+    table: &mut SpanTable,
+    ret_ty: KirType,
+    stmt_span: &Span,
+) -> Result<ir::Stmt, LowerError> {
+    let ast::Expr::Ident(name) = &subject.kind else {
+        return Err(LowerError::unsupported(
+            "`when` over a non-identifier subject (only a bare local/param scrutinee is \
+             lowered today)",
+            subject.span.clone(),
+        ));
+    };
+    let local = ctx.resolve(name).ok_or_else(|| {
+        LowerError::new(format!("unknown identifier `{name}`"), subject.span.clone())
+    })?;
+    let scrutinee_ty = ctx.locals[local].ty;
+
+    if arms.is_empty() {
+        return Err(LowerError::new(
+            "`when` has no arms".to_string(),
+            subject.span.clone(),
+        ));
+    }
+    build_when_chain(
+        arms,
+        0,
+        local,
+        scrutinee_ty,
+        ctx,
+        lcx,
+        table,
+        ret_ty,
+        stmt_span,
+    )
+}
+
+/// Builds the nested `if`/`else` chain for `arms[idx..]`. Exhaustiveness is
+/// already proven by the checker (`keel-compiler`'s `when` exhaustiveness
+/// check) — this does not re-derive that proof, so the *last* arm is always
+/// lowered unconditionally: if every earlier arm's condition was false,
+/// exhaustiveness guarantees the last arm is the only remaining possibility,
+/// whether or not it's spelled as a wildcard `_`.
+#[allow(clippy::too_many_arguments)]
+fn build_when_chain(
+    arms: &[ast::WhenArm],
+    idx: usize,
+    local: LocalId,
+    scrutinee_ty: KirType,
+    ctx: &mut FnCtx,
+    lcx: &LowerCtx<'_>,
+    table: &mut SpanTable,
+    ret_ty: KirType,
+    stmt_span: &Span,
+) -> Result<ir::Stmt, LowerError> {
+    let arm = &arms[idx];
+    if let Some(guard) = &arm.guard {
+        return Err(LowerError::unsupported(
+            "`when` arm guard (`where`)",
+            guard.span.clone(),
+        ));
+    }
+    let then_branch = lower_block(&arm.body, ctx, lcx, table, ret_ty)?;
+    let is_last = idx + 1 == arms.len();
+    let cond = if is_last {
+        ir::Expr::ConstBool(true)
+    } else {
+        lower_arm_condition(
+            &arm.patterns,
+            local,
+            scrutinee_ty,
+            ctx,
+            lcx,
+            table,
+            stmt_span,
+        )?
+    };
+    let else_branch = if is_last {
+        Vec::new()
+    } else {
+        vec![build_when_chain(
+            arms,
+            idx + 1,
+            local,
+            scrutinee_ty,
+            ctx,
+            lcx,
+            table,
+            ret_ty,
+            stmt_span,
+        )?]
+    };
+    Ok(ir::Stmt::If {
+        cond,
+        then_branch,
+        else_branch,
+    })
+}
+
+/// ORs together the per-pattern equality tests for one `when` arm (an arm
+/// can list multiple comma-separated patterns, matching if any one does —
+/// the parser guarantees at least one).
+fn lower_arm_condition(
+    patterns: &[ast::Pattern],
+    local: LocalId,
+    scrutinee_ty: KirType,
+    ctx: &mut FnCtx,
+    lcx: &LowerCtx<'_>,
+    table: &mut SpanTable,
+    stmt_span: &Span,
+) -> Result<ir::Expr, LowerError> {
+    let mut cond: Option<ir::Expr> = None;
+    for pattern in patterns {
+        let test = lower_pattern_test(pattern, local, scrutinee_ty, ctx, lcx, table, stmt_span)?;
+        cond = Some(match cond {
+            None => test,
+            Some(prev) => ir::Expr::BinOp {
+                op: ir::BinOp::Or,
+                left: Box::new(prev),
+                right: Box::new(test),
+                ty: KirType::Bool,
+            },
+        });
+    }
+    Ok(cond.expect("the parser requires at least one pattern per `when` arm"))
+}
+
+/// Lowers one `when`-arm pattern to a `bool` equality test against the
+/// scrutinee local. `Pattern::Ident`/`Wildcard`/`Variant`/`Struct` carry no
+/// span of their own (see `keel-syntax`'s `ast::stmt::Pattern`) — diagnostics
+/// for them fall back to `stmt_span` (the whole `when` statement's span).
+/// Rich enum-variant/struct destructuring patterns aren't lowered yet
+/// (payload extraction is a follow-up issue, same deferral as rich enum
+/// construction — see `lower/mod.rs`'s enum-resolution doc).
+fn lower_pattern_test(
+    pattern: &ast::Pattern,
+    local: LocalId,
+    scrutinee_ty: KirType,
+    ctx: &mut FnCtx,
+    lcx: &LowerCtx<'_>,
+    table: &mut SpanTable,
+    stmt_span: &Span,
+) -> Result<ir::Expr, LowerError> {
+    match pattern {
+        ast::Pattern::Wildcard => Ok(ir::Expr::ConstBool(true)),
+        ast::Pattern::Ident(name) => {
+            let KirType::Enum(enum_id) = scrutinee_ty else {
+                return Err(LowerError::unsupported(
+                    "identifier pattern on a non-enum scrutinee (variable-binding patterns \
+                     aren't lowered yet)",
+                    stmt_span.clone(),
+                ));
+            };
+            let layout = &lcx.enum_layouts[enum_id];
+            let variant_index = layout.variant_index(name).ok_or_else(|| {
+                LowerError::new(
+                    format!("enum `{}` has no variant `{name}`", layout.name),
+                    stmt_span.clone(),
+                )
+            })?;
+            Ok(ir::Expr::BinOp {
+                op: ir::BinOp::Eq,
+                left: Box::new(ir::Expr::Local {
+                    id: local,
+                    ty: scrutinee_ty,
+                }),
+                right: Box::new(ir::Expr::MakeEnum {
+                    enum_id,
+                    variant_index,
+                }),
+                ty: KirType::Bool,
+            })
+        }
+        ast::Pattern::Literal(lit_expr) => {
+            let lit = lower_expr(lit_expr, ctx, lcx, table)?;
+            if lit.ty() != scrutinee_ty {
+                return Err(LowerError::new(
+                    format!(
+                        "`when` pattern is `{}`, scrutinee is `{}`",
+                        super::describe_ty(lit.ty(), lcx),
+                        super::describe_ty(scrutinee_ty, lcx)
+                    ),
+                    lit_expr.span.clone(),
+                ));
+            }
+            Ok(ir::Expr::BinOp {
+                op: ir::BinOp::Eq,
+                left: Box::new(ir::Expr::Local {
+                    id: local,
+                    ty: scrutinee_ty,
+                }),
+                right: Box::new(lit),
+                ty: KirType::Bool,
+            })
+        }
+        ast::Pattern::Variant { .. } => Err(LowerError::unsupported(
+            "rich enum-variant pattern (payload destructuring lands in a later M2/M3 issue)",
+            stmt_span.clone(),
+        )),
+        ast::Pattern::Struct { .. } => Err(LowerError::unsupported(
+            "struct pattern in `when`",
+            stmt_span.clone(),
+        )),
     }
 }

--- a/crates/keel-kir/src/passes/verify.rs
+++ b/crates/keel-kir/src/passes/verify.rs
@@ -13,7 +13,7 @@
 use std::fmt;
 
 use crate::ir::{
-    Block, CallTarget, Expr, FuncId, KirFunction, KirProgram, LocalId, Stmt, StructId,
+    Block, CallTarget, EnumId, Expr, FuncId, KirFunction, KirProgram, LocalId, Stmt, StructId,
 };
 use crate::types::KirType;
 
@@ -109,6 +109,16 @@ fn check_struct(program: &KirProgram, id: StructId) -> Result<(), String> {
         return Err(format!(
             "StructId {id} out of range ({} structs)",
             program.structs.len()
+        ));
+    }
+    Ok(())
+}
+
+fn check_enum(program: &KirProgram, id: EnumId) -> Result<(), String> {
+    if id >= program.enums.len() {
+        return Err(format!(
+            "EnumId {id} out of range ({} enums)",
+            program.enums.len()
         ));
     }
     Ok(())
@@ -294,6 +304,21 @@ fn verify_expr(program: &KirProgram, func: &KirFunction, expr: &Expr) -> Result<
                 return Err(format!(
                     "field-get on `{}.{}` claims type {ty} but the field is {declared_ty}",
                     layout.name, layout.fields[*field_index].0
+                ));
+            }
+            Ok(())
+        }
+        Expr::MakeEnum {
+            enum_id,
+            variant_index,
+        } => {
+            check_enum(program, *enum_id)?;
+            let layout = &program.enums[*enum_id];
+            if *variant_index >= layout.variants.len() {
+                return Err(format!(
+                    "MakeEnum variant index {variant_index} out of range for `{}` ({} variants)",
+                    layout.name,
+                    layout.variants.len()
                 ));
             }
             Ok(())

--- a/crates/keel-kir/src/types.rs
+++ b/crates/keel-kir/src/types.rs
@@ -7,7 +7,7 @@
 //! deliberately not modeled yet; adding them is later-M2+ work, done
 //! alongside the lowering support that produces them.
 
-use crate::ir::{KirProgram, StructId};
+use crate::ir::{EnumId, KirProgram, StructId};
 
 /// A KIR-level type. Every KIR expression carries one.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -29,6 +29,12 @@ pub enum KirType {
     /// the field layout this id indexes. Anonymous shapes have no `KirType`
     /// yet (deferred, see `ir.rs`'s `StructLayout` doc).
     Struct(StructId),
+    /// A simple (unit-variant) enum type (`type Priority = low | medium |
+    /// high`) — see `KirProgram::enums` for the variant list this id
+    /// indexes. Rich (payload-carrying) variants have no `KirType` yet
+    /// (deferred, see `ir.rs`'s `EnumLayout` doc). By-value `i32` tag — no
+    /// heap allocation or RC, unlike `Struct`.
+    Enum(EnumId),
 }
 
 impl KirType {
@@ -46,6 +52,7 @@ impl KirType {
             KirType::Unit => "none",
             KirType::Str => "str",
             KirType::Struct(_) => "struct",
+            KirType::Enum(_) => "enum",
         }
     }
 
@@ -64,7 +71,7 @@ impl KirType {
         match self {
             KirType::Str => true,
             KirType::Struct(id) => program.structs[id].is_heap(program),
-            KirType::I64 | KirType::F64 | KirType::Bool | KirType::Unit => false,
+            KirType::I64 | KirType::F64 | KirType::Bool | KirType::Unit | KirType::Enum(_) => false,
         }
     }
 

--- a/crates/keel-kir/tests/fixtures/enums_when.keel
+++ b/crates/keel-kir/tests/fixtures/enums_when.keel
@@ -1,0 +1,17 @@
+type Priority = low | medium | high
+
+task label(p: Priority) -> str {
+  when p {
+    low => { return "low priority" }
+    medium => { return "medium priority" }
+    high => { return "high priority" }
+  }
+}
+
+task grade(score: str) -> str {
+  when score {
+    "A" => { return "excellent" }
+    "B" => { return "good" }
+    _ => { return "needs work" }
+  }
+}

--- a/crates/keel-kir/tests/fixtures/enums_when.kir
+++ b/crates/keel-kir/tests/fixtures/enums_when.kir
@@ -1,0 +1,32 @@
+enum Priority { low, medium, high }
+
+fn label(p: Priority) -> str {
+  if (p == Priority.low) {
+    return "low priority"
+  } else {
+    if (p == Priority.medium) {
+      return "medium priority"
+    } else {
+      if true {
+        return "high priority"
+      }
+    }
+  }
+}
+
+fn grade(score: str) -> str {
+  if (score == "A") {
+    return "excellent"
+  } else {
+    if (score == "B") {
+      return "good"
+    } else {
+      if true {
+        return "needs work"
+      }
+    }
+  }
+}
+
+fn <toplevel>() -> none {
+}

--- a/crates/keel-kir/tests/lower_errors.rs
+++ b/crates/keel-kir/tests/lower_errors.rs
@@ -347,10 +347,13 @@ p: Point = { ...make(), x: 3 }
 }
 
 #[test]
-fn non_struct_type_declaration_is_rejected() {
-    let msg = lower_err("type Color = red | green | blue\n");
+fn type_alias_declaration_is_rejected() {
+    // `type Color = red | green | blue` is a simple enum, not an alias — and
+    // is no longer rejected as of #146 (see `enum_when` fixtures). Aliases
+    // (`type Timestamp = datetime`) remain unsupported.
+    let msg = lower_err("type Timestamp = datetime\n");
     assert!(
-        msg.contains("non-struct type declaration"),
+        msg.contains("rich enum or type-alias declaration"),
         "unexpected message: {msg}"
     );
 }
@@ -360,6 +363,127 @@ fn generic_struct_type_is_rejected() {
     let msg = lower_err("type Box[T] { value: int }\n");
     assert!(
         msg.contains("generic struct type"),
+        "unexpected message: {msg}"
+    );
+}
+
+#[test]
+fn rich_enum_type_declaration_is_rejected() {
+    let msg = lower_err(
+        r#"
+type Action =
+  | reply { to: str }
+  | archive
+"#,
+    );
+    assert!(
+        msg.contains("rich enum or type-alias declaration"),
+        "unexpected message: {msg}"
+    );
+}
+
+#[test]
+fn generic_enum_type_is_rejected() {
+    let msg = lower_err("type Pair[T] = a | b\n");
+    assert!(
+        msg.contains("generic enum type"),
+        "unexpected message: {msg}"
+    );
+}
+
+#[test]
+fn unknown_enum_variant_in_construction_is_rejected() {
+    let msg = lower_err(
+        r#"
+type Priority = low | medium | high
+
+task f() -> Priority {
+  return Priority.urgent
+}
+"#,
+    );
+    assert!(
+        msg.contains("has no variant `urgent`"),
+        "unexpected message: {msg}"
+    );
+}
+
+#[test]
+fn when_over_a_non_identifier_subject_is_rejected() {
+    let msg = lower_err(
+        r#"
+type Priority = low | medium | high
+
+task make() -> Priority {
+  return Priority.low
+}
+
+task f() -> str {
+  when make() {
+    low => { return "low" }
+    medium => { return "medium" }
+    high => { return "high" }
+  }
+}
+"#,
+    );
+    assert!(
+        msg.contains("non-identifier subject"),
+        "unexpected message: {msg}"
+    );
+}
+
+#[test]
+fn when_arm_guard_is_rejected() {
+    let msg = lower_err(
+        r#"
+task f(n: int) -> str {
+  when n {
+    x where x > 0 => { return "positive" }
+    _ => { return "other" }
+  }
+}
+"#,
+    );
+    assert!(msg.contains("arm guard"), "unexpected message: {msg}");
+}
+
+#[test]
+fn identifier_pattern_on_a_non_enum_scrutinee_is_rejected() {
+    let msg = lower_err(
+        r#"
+task f(n: int) -> str {
+  when n {
+    x => { return "bound" }
+    _ => { return "other" }
+  }
+}
+"#,
+    );
+    assert!(
+        msg.contains("identifier pattern on a non-enum scrutinee"),
+        "unexpected message: {msg}"
+    );
+}
+
+#[test]
+fn when_expression_position_is_still_rejected() {
+    // `when` as a value-producing expression (`x = when ... {...}`) isn't
+    // lowered yet — only the statement form (each arm terminating via
+    // `return`) is, see `lower/stmt.rs`'s `lower_when_stmt` doc.
+    let msg = lower_err(
+        r#"
+task grade(score: str) -> str {
+  result = when score {
+    "A" => "excellent"
+    _ => "needs work"
+  }
+  return result
+}
+"#,
+    );
+    assert!(
+        msg.contains("when` expression"),
         "unexpected message: {msg}"
     );
 }

--- a/crates/keel-rt-ffi/src/abi/mod.rs
+++ b/crates/keel-rt-ffi/src/abi/mod.rs
@@ -61,6 +61,24 @@ pub unsafe extern "C" fn keel_box_str(ptr: *const u8, len: usize) -> *const Valu
     Arc::into_raw(Arc::new(Value::String(s)))
 }
 
+/// Compares two boxed strings for equality without consuming either
+/// caller's reference — backs `keel-codegen`'s `str == str` / `str != str`
+/// (`when` over a `str` scrutinee, or any other string comparison).
+/// Returns `1` for equal, `0` otherwise.
+///
+/// # Safety
+///
+/// `a` and `b` must each be a live `KeelBox` (see [`borrow`]) whose
+/// underlying `Value` is `Value::String` — always true for a `str`-typed
+/// KIR expression, which is the only thing `keel-codegen` ever passes here.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn keel_str_eq(a: *const Value, b: *const Value) -> u8 {
+    let (Value::String(a), Value::String(b)) = (unsafe { &*a }, unsafe { &*b }) else {
+        unreachable!("keel-codegen only calls keel_str_eq on str-typed (Value::String) operands");
+    };
+    u8::from(a == b)
+}
+
 /// Reads a `KeelBox`'s value without consuming the caller's reference —
 /// used to marshal namespace-call arguments (`const KeelBox**`, i.e.
 /// borrowed) into owned `Value`s.


### PR DESCRIPTION
## Summary

Part of M2 (#113). Implements `type Priority = low | medium | high`-style simple enums plus `when` (as a statement) across `keel-kir` and `keel-codegen`: variant construction, exhaustive matching over an enum scrutinee, and matching over a `str` scrutinee with a wildcard arm — compiled to native code and verified byte-for-byte against the interpreter.

- `KirType::Enum(EnumId)` + `EnumLayout` (variant names, in declaration order — a variant's position is its runtime tag) on `KirProgram`.
- `Expr::MakeEnum` KIR node. `Priority.low` resolves through the same "is this identifier a known type name, not a shadowed local" precedence namespace-call lowering already uses (mirrors the checker's `NameKind::Enum` short-circuit).
- `when` lowers to a nested `if`/`else` chain: each arm's condition ORs its (possibly multiple, comma-separated) patterns; the *last* arm is always unconditional — exhaustiveness is already proven by the checker, so lowering doesn't re-derive it, it just trusts that if every earlier condition was false, the last arm is the only possibility left (whether or not it's spelled `_`).
- `when` over a `str` scrutinee needed string equality, which didn't exist in codegen at all (`BinOp::Eq`/`Neq` on `KirType::Str` was a blanket `Unsupported`). Added `keel_str_eq` to `keel-rt-ffi` (compares the underlying `Value::String` without consuming either reference) and wired it into `keel-codegen`'s `emit_binop`.
- Codegen: enum values are a plain by-value `i32` tag — no heap allocation or RC, unlike a heap struct.
- Extended `--emit=kir` dump, golden-dump test, and `passes/verify.rs` for the new node/type shapes.

## Deferred (called out, not silently dropped)

- **`when` as an expression** (`result = when score {...}`) — split to #160. This issue's own exit criterion is satisfied with hand-written fixtures where every arm terminates via `return` or falls through for a side effect (both shapes are tested); the real `examples/when_expression.keel`'s `grade` task uses the expression form, which needs a declare-without-init local KIR doesn't have yet.
- **Rich (payload-carrying) enum variants** — the target conformance corpus doesn't exercise them (checked before implementing); `type Action = | reply { to: str } | archive`-style declarations are rejected outright at the type-declaration level, not silently mishandled. `when`-pattern support for `Pattern::Variant`/`Pattern::Struct` (rich-variant destructuring) is unreachable code until rich variants land — kept as explicit match arms (project convention: enumerate all variants) but untestable via the public API today, so no test for that specific rejection message.
- **Implicit tail-expression-as-return** (`label`'s style in `examples/when_expression.keel`, no explicit `return`) — a pre-existing gap unrelated to enums/`when`, tracked separately as #159.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo clippy --workspace --all-targets --features build-backend -- -D warnings`
- [x] `cargo test --workspace` (all green)
- [x] `cargo test --workspace --features build-backend` (all green, including three new `keel-codegen/tests/enums_when.rs` integration tests: enum + str-with-wildcard matching, a non-returning `when` that falls through to a later statement — a different codegen path than every returning-arm test — and a multi-pattern arm)
- [x] M1 conformance test run 3x for stability (all green)
- [x] New rejection tests in `keel-kir/tests/lower_errors.rs`: rich enum declaration, generic enum, unknown variant, non-identifier `when` subject, arm guards, identifier pattern on a non-enum scrutinee, `when`-as-expression still rejected; updated one pre-existing test whose premise (`type Color = red | green | blue` is rejected) is no longer true now that simple enums are supported

Close #146