### PR TITLE
keel-kir + keel-codegen: list[T] containers end to end

### DIFF
--- a/crates/keel-codegen/src/expr.rs
+++ b/crates/keel-codegen/src/expr.rs
@@ -67,6 +67,7 @@ pub(crate) fn emit_expr<'ctx>(
             .i32_type()
             .const_int(*variant_index as u64, false)
             .into()),
+        Expr::Index { list, index, ty } => crate::rt_call::emit_index(fcx, list, index, *ty),
     }
 }
 
@@ -151,6 +152,7 @@ fn emit_call<'ctx>(
         CallTarget::Ns { ns_id, method_id } => {
             return crate::ns_call::emit_ns_call(fcx, ns_id, method_id, args, span);
         }
+        CallTarget::Rt(rt_fn) => return crate::rt_call::emit_rt_call(fcx, rt_fn, args),
     };
     let callee = fcx.functions[func_id]
         .expect("declare_functions declares every non-toplevel FuncId before any body is emitted");
@@ -343,7 +345,9 @@ fn emit_binop<'ctx>(
             };
             Ok(result)
         }
-        KirType::Unit | KirType::Struct(_) => Err(unreachable_combo(op, operand_ty)),
+        KirType::Unit | KirType::Struct(_) | KirType::List(_) => {
+            Err(unreachable_combo(op, operand_ty))
+        }
     }
 }
 

--- a/crates/keel-codegen/src/layout.rs
+++ b/crates/keel-codegen/src/layout.rs
@@ -45,6 +45,7 @@ pub(crate) fn llvm_type<'ctx>(
             }
         }
         KirType::Enum(_) => Ok(context.i32_type().into()),
+        KirType::List(_) => Ok(context.ptr_type(AddressSpace::default()).into()),
     }
 }
 

--- a/crates/keel-codegen/src/lib.rs
+++ b/crates/keel-codegen/src/lib.rs
@@ -21,6 +21,7 @@ mod func;
 mod layout;
 mod link;
 mod ns_call;
+mod rt_call;
 mod stmt;
 
 use std::path::PathBuf;

--- a/crates/keel-codegen/src/ns_call.rs
+++ b/crates/keel-codegen/src/ns_call.rs
@@ -58,7 +58,7 @@ fn call_box_fn<'ctx>(
     }
 }
 
-fn emit_box_arg<'ctx>(
+pub(crate) fn emit_box_arg<'ctx>(
     fcx: &FuncCtx<'ctx, '_>,
     arg: &Expr,
 ) -> Result<PointerValue<'ctx>, CodegenError> {
@@ -110,6 +110,10 @@ fn emit_box_arg<'ctx>(
              Value is a later-M2/M3 concern)"
                 .to_string(),
         )),
+        // A `list[T]` value is already a boxed `*const Value` (`Value::List`,
+        // same representation `keel_rt_call_ns`/every `keel_list_*` expects)
+        // — no extra boxing needed, same as `Str`.
+        KirType::List(_) => Ok(emit_expr(fcx, arg)?.into_pointer_value()),
     }
 }
 

--- a/crates/keel-codegen/src/rt_call.rs
+++ b/crates/keel-codegen/src/rt_call.rs
@@ -1,0 +1,185 @@
+//! `CallTarget::Rt` codegen — the container-ABI runtime calls
+//! (`designs/llvm-compilation.md` §2.7: "container primitives... are
+//! synchronous `CallTarget::Rt` calls into the container ABI from day
+//! one"). Every container value is a boxed `*const Value` (`KeelBox`, same
+//! representation `CallTarget::Ns` already uses for `str` — there is no
+//! separate `#[repr(C)] KeelList`, see `keel-rt-ffi`'s `keel_list_*` docs),
+//! so element marshaling reuses `ns_call::emit_box_arg`'s exact per-type
+//! dispatch.
+
+use inkwell::AddressSpace;
+use inkwell::values::{BasicValueEnum, ValueKind};
+
+use keel_kir::ir::{Expr, RtFn};
+use keel_kir::types::KirType;
+
+use crate::CodegenError;
+use crate::func::FuncCtx;
+use crate::ns_call::{declare_or_get, emit_box_arg};
+
+fn llvm_err(e: impl std::fmt::Display) -> CodegenError {
+    CodegenError::Llvm(e.to_string())
+}
+
+pub(crate) fn emit_rt_call<'ctx>(
+    fcx: &FuncCtx<'ctx, '_>,
+    rt_fn: RtFn,
+    args: &[Expr],
+) -> Result<BasicValueEnum<'ctx>, CodegenError> {
+    let ptr_type = fcx.context.ptr_type(AddressSpace::default());
+
+    match rt_fn {
+        RtFn::ListNew => {
+            let f = declare_or_get(fcx.module, "keel_list_new", || ptr_type.fn_type(&[], false));
+            call_ptr_fn(fcx, f, &[])
+        }
+        RtFn::ListPush => {
+            let [list, elem] = args else {
+                unreachable!("verified KIR: RtFn::ListPush always takes exactly 2 args");
+            };
+            let list_ptr = crate::expr::emit_expr(fcx, list)?.into_pointer_value();
+            let elem_ptr = emit_box_arg(fcx, elem)?;
+            let f = declare_or_get(fcx.module, "keel_list_push", || {
+                ptr_type.fn_type(&[ptr_type.into(), ptr_type.into()], false)
+            });
+            call_ptr_fn(fcx, f, &[list_ptr.into(), elem_ptr.into()])
+        }
+        RtFn::ListLen => {
+            let [list] = args else {
+                unreachable!("verified KIR: RtFn::ListLen always takes exactly 1 arg");
+            };
+            let list_ptr = crate::expr::emit_expr(fcx, list)?.into_pointer_value();
+            let f = declare_or_get(fcx.module, "keel_list_len", || {
+                fcx.context.i64_type().fn_type(&[ptr_type.into()], false)
+            });
+            let call = fcx
+                .builder
+                .build_call(f, &[list_ptr.into()], "list_len")
+                .map_err(llvm_err)?;
+            match call.try_as_basic_value() {
+                ValueKind::Basic(v) => Ok(v),
+                ValueKind::Instruction(_) => unreachable!("keel_list_len returns i64, never void"),
+            }
+        }
+    }
+}
+
+/// Calls `keel_list_len` directly (not through an `Expr::Call` — used by
+/// `stmt::emit_for_each`'s internal loop counter, which isn't itself a KIR
+/// node).
+pub(crate) fn emit_list_len<'ctx>(
+    fcx: &FuncCtx<'ctx, '_>,
+    list_ptr: inkwell::values::PointerValue<'ctx>,
+) -> Result<inkwell::values::IntValue<'ctx>, CodegenError> {
+    let ptr_type = fcx.context.ptr_type(AddressSpace::default());
+    let f = declare_or_get(fcx.module, "keel_list_len", || {
+        fcx.context.i64_type().fn_type(&[ptr_type.into()], false)
+    });
+    Ok(call_ptr_fn(fcx, f, &[list_ptr.into()])?.into_int_value())
+}
+
+/// Calls `keel_list_get` directly, returning the still-boxed element (the
+/// caller unboxes via [`unbox_value`]) — same rationale as
+/// [`emit_list_len`].
+pub(crate) fn emit_list_get<'ctx>(
+    fcx: &FuncCtx<'ctx, '_>,
+    list_ptr: inkwell::values::PointerValue<'ctx>,
+    index: inkwell::values::IntValue<'ctx>,
+) -> Result<inkwell::values::PointerValue<'ctx>, CodegenError> {
+    let ptr_type = fcx.context.ptr_type(AddressSpace::default());
+    let f = declare_or_get(fcx.module, "keel_list_get", || {
+        ptr_type.fn_type(&[ptr_type.into(), fcx.context.i64_type().into()], false)
+    });
+    Ok(call_ptr_fn(fcx, f, &[list_ptr.into(), index.into()])?.into_pointer_value())
+}
+
+/// Emits `xs[i]` — bounds-checked in `keel_list_get` itself (see its doc),
+/// then unboxes the result to `ty` (the reverse of `emit_box_arg`: a
+/// scalar comes back as a raw LLVM primitive, a `str` element is already a
+/// `ptr` and needs no unboxing).
+pub(crate) fn emit_index<'ctx>(
+    fcx: &FuncCtx<'ctx, '_>,
+    list: &Expr,
+    index: &Expr,
+    ty: KirType,
+) -> Result<BasicValueEnum<'ctx>, CodegenError> {
+    let list_ptr = crate::expr::emit_expr(fcx, list)?.into_pointer_value();
+    let index_v = crate::expr::emit_expr(fcx, index)?.into_int_value();
+    let elem_ptr = emit_list_get(fcx, list_ptr, index_v)?;
+    unbox_value(fcx, elem_ptr, ty)
+}
+
+/// Unboxes a `*const Value` (`KeelBox`) to its raw LLVM representation:
+/// scalars come back as `i64`/`f64`/`i1` via a `keel_unbox_*` call; a `str`
+/// (or another `list[T]`) is already the right representation (a `ptr`) and
+/// passes through untouched.
+pub(crate) fn unbox_value<'ctx>(
+    fcx: &FuncCtx<'ctx, '_>,
+    boxed: inkwell::values::PointerValue<'ctx>,
+    ty: KirType,
+) -> Result<BasicValueEnum<'ctx>, CodegenError> {
+    let ptr_type = fcx.context.ptr_type(AddressSpace::default());
+    match ty {
+        KirType::I64 => {
+            let f = declare_or_get(fcx.module, "keel_unbox_int", || {
+                fcx.context.i64_type().fn_type(&[ptr_type.into()], false)
+            });
+            call_scalar_fn(fcx, f, &[boxed.into()], "unbox_int")
+        }
+        KirType::F64 => {
+            let f = declare_or_get(fcx.module, "keel_unbox_float", || {
+                fcx.context.f64_type().fn_type(&[ptr_type.into()], false)
+            });
+            call_scalar_fn(fcx, f, &[boxed.into()], "unbox_float")
+        }
+        KirType::Bool => {
+            let f = declare_or_get(fcx.module, "keel_unbox_bool", || {
+                fcx.context.i8_type().fn_type(&[ptr_type.into()], false)
+            });
+            let raw = call_scalar_fn(fcx, f, &[boxed.into()], "unbox_bool_u8")?.into_int_value();
+            let b = fcx
+                .builder
+                .build_int_truncate(raw, fcx.context.bool_type(), "unbox_bool")
+                .map_err(llvm_err)?;
+            Ok(b.into())
+        }
+        KirType::Str | KirType::List(_) => Ok(boxed.into()),
+        KirType::Unit | KirType::Struct(_) | KirType::Enum(_) => Err(CodegenError::Unsupported(
+            "a list element type other than int/float/bool/str (struct/enum elements need \
+             Value marshaling, a later M2/M3 concern)"
+                .to_string(),
+        )),
+    }
+}
+
+fn call_ptr_fn<'ctx>(
+    fcx: &FuncCtx<'ctx, '_>,
+    f: inkwell::values::FunctionValue<'ctx>,
+    args: &[inkwell::values::BasicMetadataValueEnum<'ctx>],
+) -> Result<BasicValueEnum<'ctx>, CodegenError> {
+    let call = fcx
+        .builder
+        .build_call(f, args, "rt_call")
+        .map_err(llvm_err)?;
+    match call.try_as_basic_value() {
+        ValueKind::Basic(v) => Ok(v),
+        ValueKind::Instruction(_) => {
+            unreachable!("every keel_list_* fn returns a value, never void")
+        }
+    }
+}
+
+fn call_scalar_fn<'ctx>(
+    fcx: &FuncCtx<'ctx, '_>,
+    f: inkwell::values::FunctionValue<'ctx>,
+    args: &[inkwell::values::BasicMetadataValueEnum<'ctx>],
+    name: &str,
+) -> Result<BasicValueEnum<'ctx>, CodegenError> {
+    let call = fcx.builder.build_call(f, args, name).map_err(llvm_err)?;
+    match call.try_as_basic_value() {
+        ValueKind::Basic(v) => Ok(v),
+        ValueKind::Instruction(_) => {
+            unreachable!("every keel_unbox_* fn returns a value, never void")
+        }
+    }
+}

--- a/crates/keel-codegen/src/stmt.rs
+++ b/crates/keel-codegen/src/stmt.rs
@@ -82,6 +82,15 @@ fn emit_stmt<'ctx>(
             emit_for_index(fcx, *var, low, high, body)?;
             Ok(None)
         }
+        Stmt::ForEach {
+            var,
+            elem_ty,
+            list,
+            body,
+        } => {
+            emit_for_each(fcx, *var, *elem_ty, list, body)?;
+            Ok(None)
+        }
         Stmt::Return(value) => {
             emit_return(fcx, value.as_ref())?;
             Ok(None)
@@ -217,6 +226,90 @@ fn emit_for_index<'ctx>(
             .build_int_add(cur, i64_type.const_int(1, false), "for.next")
             .map_err(llvm_err)?;
         fcx.builder.build_store(var_ptr, next).map_err(llvm_err)?;
+        fcx.builder
+            .build_unconditional_branch(cond_bb)
+            .map_err(llvm_err)?;
+    }
+
+    fcx.builder.position_at_end(end_bb);
+    Ok(())
+}
+
+/// `for var in xs { body }` over a `list[T]` — an internal `i64` index
+/// counter (never itself a KIR local, so it can't collide with a user
+/// binding) drives `keel_list_len`/`keel_list_get` each iteration; `var`'s
+/// `alloca` is re-stored with the unboxed element every pass, same
+/// re-initialize-on-reach rationale as [`emit_for_index`].
+fn emit_for_each<'ctx>(
+    fcx: &mut FuncCtx<'ctx, '_>,
+    var: keel_kir::ir::LocalId,
+    elem_ty: KirType,
+    list: &keel_kir::ir::Expr,
+    body: &Block,
+) -> Result<(), CodegenError> {
+    let list_ptr = expr::emit_expr(fcx, list)?.into_pointer_value();
+    let len = crate::rt_call::emit_list_len(fcx, list_ptr)?;
+
+    let i64_type = fcx.context.i64_type();
+    let idx_ptr = fcx
+        .builder
+        .build_alloca(i64_type, "foreach.idx")
+        .map_err(llvm_err)?;
+    fcx.builder
+        .build_store(idx_ptr, i64_type.const_zero())
+        .map_err(llvm_err)?;
+
+    let elem_ty_llvm = layout::llvm_type(fcx.context, fcx.program, elem_ty)?;
+    let var_ptr = fcx
+        .builder
+        .build_alloca(elem_ty_llvm, &format!("local.{var}"))
+        .map_err(llvm_err)?;
+    fcx.locals.insert(var, var_ptr);
+
+    let cond_bb = fcx.context.append_basic_block(fcx.function, "foreach.cond");
+    let body_bb = fcx.context.append_basic_block(fcx.function, "foreach.body");
+    let end_bb = fcx.context.append_basic_block(fcx.function, "foreach.end");
+
+    fcx.builder
+        .build_unconditional_branch(cond_bb)
+        .map_err(llvm_err)?;
+
+    fcx.builder.position_at_end(cond_bb);
+    let idx = fcx
+        .builder
+        .build_load(i64_type, idx_ptr, "foreach.idx.cur")
+        .map_err(llvm_err)?
+        .into_int_value();
+    let cond_v = fcx
+        .builder
+        .build_int_compare(IntPredicate::SLT, idx, len, "foreach.test")
+        .map_err(llvm_err)?;
+    fcx.builder
+        .build_conditional_branch(cond_v, body_bb, end_bb)
+        .map_err(llvm_err)?;
+
+    fcx.builder.position_at_end(body_bb);
+    let idx = fcx
+        .builder
+        .build_load(i64_type, idx_ptr, "foreach.idx.cur")
+        .map_err(llvm_err)?
+        .into_int_value();
+    let elem_boxed = crate::rt_call::emit_list_get(fcx, list_ptr, idx)?;
+    let elem_v = crate::rt_call::unbox_value(fcx, elem_boxed, elem_ty)?;
+    fcx.builder.build_store(var_ptr, elem_v).map_err(llvm_err)?;
+
+    emit_block(fcx, body)?;
+    if !block_is_terminated(fcx.builder) {
+        let idx = fcx
+            .builder
+            .build_load(i64_type, idx_ptr, "foreach.idx.cur")
+            .map_err(llvm_err)?
+            .into_int_value();
+        let next = fcx
+            .builder
+            .build_int_add(idx, i64_type.const_int(1, false), "foreach.idx.next")
+            .map_err(llvm_err)?;
+        fcx.builder.build_store(idx_ptr, next).map_err(llvm_err)?;
         fcx.builder
             .build_unconditional_branch(cond_bb)
             .map_err(llvm_err)?;

--- a/crates/keel-codegen/tests/lists.rs
+++ b/crates/keel-codegen/tests/lists.rs
@@ -1,0 +1,104 @@
+//! Exit criterion for issue #147 (list slice): a program building a
+//! `list[int]`, pushing/indexing/iterating it, and observing correct
+//! copy-on-write *behavior* — two bindings that alias the same list before
+//! one is reassigned via `.push(...)` must not see each other's change —
+//! compiles, links, and matches the interpreter byte-for-byte.
+//!
+//! `push`/every list mutation is a pure value method (confirmed against the
+//! interpreter: a bare `a.push(4)` statement is a no-op on `a`'s binding —
+//! the result must be reassigned, `a = a.push(4)`, matching Keel's
+//! always-declares assignment scoping). Codegen implements this as
+//! always-clone-on-push (see `keel-rt-ffi`'s `keel_list_push` doc) rather
+//! than real reference-counted copy-on-write — the RC-insertion pass
+//! (retain-on-alias, release-on-scope-exit) that real CoW would need
+//! doesn't exist in this codebase yet, so always-clone is what makes the
+//! aliasing scenario below correct *by construction*, not just by testing.
+
+use std::process::Command;
+
+use keel_codegen::BuildOptions;
+
+#[path = "support/mod.rs"]
+mod support;
+
+fn compile_and_run(source: &str) -> std::process::Output {
+    let kir = support::parse_check_and_lower(source);
+
+    let out_dir = tempfile::tempdir().expect("create temp out dir");
+    let opts = BuildOptions {
+        out_dir: out_dir.path().to_path_buf(),
+        runtime_link_args: support::runtime_link_args().clone(),
+    };
+    let bin = keel_codegen::compile(&kir, &opts).expect("compile must succeed");
+    Command::new(&bin).output().expect("run compiled binary")
+}
+
+fn assert_matches_interpreter(source: &str, expected_stdout: &[u8]) {
+    let compiled = compile_and_run(source);
+    let interpreted = support::run_interpreter(source);
+
+    assert_eq!(
+        String::from_utf8_lossy(&compiled.stdout),
+        String::from_utf8_lossy(&interpreted.stdout),
+        "compiled stdout must match the interpreter's"
+    );
+    assert_eq!(compiled.stdout, expected_stdout);
+}
+
+#[test]
+fn aliased_bindings_do_not_observe_each_others_push() {
+    // The differential aliasing test: `b` is bound to `a` *before* `a` is
+    // reassigned via push, and both are printed *after* — the only shape
+    // that actually exercises whether the two engines agree on the
+    // mutation model (see this file's module doc). A bare `a.push(4)`
+    // (discarding the result) would make this pass vacuously.
+    let source = r#"
+use std/io
+
+a = [1, 2, 3]
+b = a
+a = a.push(4)
+io.show(a)
+io.show(b)
+"#;
+    assert_matches_interpreter(
+        source,
+        b"  1. 1\n  2. 2\n  3. 3\n  4. 4\n  1. 1\n  2. 2\n  3. 3\n",
+    );
+}
+
+#[test]
+fn push_len_index_and_for_each_match_the_interpreter() {
+    let source = r#"
+use std/io
+
+task sum(xs: list[int]) -> int {
+  total = 0
+  for x in xs {
+    total += x
+  }
+  return total
+}
+
+a = [1, 2, 3]
+a = a.push(4)
+io.show(a.len())
+io.show(a[0])
+io.show(a[3])
+io.show(sum(a))
+"#;
+    assert_matches_interpreter(source, b"  4\n  1\n  4\n  10\n");
+}
+
+#[test]
+fn list_of_str_elements_matches_the_interpreter() {
+    let source = r#"
+use std/io
+
+names = ["alice", "bob"]
+names = names.push("carol")
+io.show(names.len())
+io.show(names[2])
+"#;
+    assert_matches_interpreter(source, b"  3\n  carol\n");
+}

--- a/crates/keel-kir/src/dump.rs
+++ b/crates/keel-kir/src/dump.rs
@@ -46,6 +46,7 @@ fn fmt_ty(program: &KirProgram, ty: KirType) -> String {
     match ty {
         KirType::Struct(id) => program.structs[id].name.clone(),
         KirType::Enum(id) => program.enums[id].name.clone(),
+        KirType::List(id) => format!("list[{}]", fmt_ty(program, program.lists[id])),
         other => other.to_string(),
     }
 }
@@ -152,6 +153,20 @@ fn dump_stmt(
             indent(out, depth);
             out.push_str("}\n");
         }
+        Stmt::ForEach {
+            var, list, body, ..
+        } => {
+            let v = &func.locals[*var];
+            let _ = writeln!(
+                out,
+                "for {} in {} {{",
+                v.name,
+                fmt_expr(program, func, list)
+            );
+            dump_block(out, program, func, body, depth + 1);
+            indent(out, depth);
+            out.push_str("}\n");
+        }
         Stmt::Return(None) => {
             out.push_str("return\n");
         }
@@ -227,6 +242,13 @@ fn fmt_expr(program: &KirProgram, func: &KirFunction, expr: &Expr) -> String {
             let layout = &program.enums[*enum_id];
             format!("{}.{}", layout.name, layout.variants[*variant_index])
         }
+        Expr::Index { list, index, .. } => {
+            format!(
+                "{}[{}]",
+                fmt_expr(program, func, list),
+                fmt_expr(program, func, index)
+            )
+        }
     }
 }
 
@@ -246,6 +268,15 @@ fn call_target_name(program: &KirProgram, target: CallTarget) -> String {
             })
             .map(|m| format!("{}.{}", m.namespace, m.name))
             .unwrap_or_else(|| format!("ns#{ns_id}.method#{method_id}")),
+        CallTarget::Rt(rt_fn) => format!("rt.{}", rt_fn_name(rt_fn)),
+    }
+}
+
+fn rt_fn_name(rt_fn: crate::ir::RtFn) -> &'static str {
+    match rt_fn {
+        crate::ir::RtFn::ListNew => "list_new",
+        crate::ir::RtFn::ListPush => "list_push",
+        crate::ir::RtFn::ListLen => "list_len",
     }
 }
 

--- a/crates/keel-kir/src/ir.rs
+++ b/crates/keel-kir/src/ir.rs
@@ -28,6 +28,12 @@ pub type StructId = usize;
 /// Index into `KirProgram::enums`.
 pub type EnumId = usize;
 
+/// Index into `KirProgram::lists` — a *structural* intern id (unlike
+/// `StructId`/`EnumId`, which are nominal: two declarations with identical
+/// shape are still distinct types). `list[int]` written anywhere in the
+/// program is the same `ListId` — see `lower/mod.rs`'s list-interning doc.
+pub type ListId = usize;
+
 /// A whole lowered program (currently: a single file's tasks + its
 /// top-level statements — multi-module lowering is deferred until the
 /// `keel-compiler` `ModuleGraph`/`CheckArtifacts` seam lands, see `lib.rs`).
@@ -50,6 +56,12 @@ pub struct KirProgram {
     /// carrying) variants aren't modeled yet — deferred to a follow-up
     /// issue; see `lower/mod.rs`'s enum-resolution doc.
     pub enums: Vec<EnumLayout>,
+    /// Every distinct list element type interned so far (structural, not
+    /// declaration order — see `ListId`'s doc). Only int/float/bool/str
+    /// elements are modeled; a struct/enum element needs `Value`
+    /// marshaling that doesn't exist yet (deferred, see `lower/expr.rs`'s
+    /// list-literal lowering doc).
+    pub lists: Vec<KirType>,
     pub span_table: SpanTable,
 }
 
@@ -176,6 +188,17 @@ pub enum Stmt {
         high: Expr,
         body: Block,
     },
+    /// `for x in xs { ... }` over a `list[T]` — indexed internally
+    /// (`keel_list_len`/`keel_list_get`, see `keel-codegen`'s `emit_for_each`)
+    /// rather than a real iterator, so this is a distinct shape from
+    /// `ForIndex` (whose `var` is always `I64`, a range bound). `var` is
+    /// rebound each iteration to the *unboxed* element value (`elem_ty`).
+    ForEach {
+        var: LocalId,
+        elem_ty: KirType,
+        list: Expr,
+        body: Block,
+    },
     /// `return expr` / bare `return`.
     Return(Option<Expr>),
     /// Expression evaluated for its side effect (e.g. a bare call).
@@ -236,6 +259,15 @@ pub enum Expr {
         enum_id: EnumId,
         variant_index: usize,
     },
+    /// `xs[i]` on a `list[T]`-typed `xs` — bounds-checked at runtime
+    /// (`keel_list_get`); `ty` is the already-unboxed element type. See
+    /// `keel-rt-ffi`'s `keel_list_get` doc for the current (pre-#150)
+    /// out-of-bounds behavior.
+    Index {
+        list: Box<Expr>,
+        index: Box<Expr>,
+        ty: KirType,
+    },
 }
 
 /// What an `Expr::Call` invokes.
@@ -249,6 +281,24 @@ pub enum CallTarget {
     /// resolved at lowering time — `keel-codegen` (M1+) compiles this to a
     /// call into `keel_rt_call_ns(ns_id, method_id, ...)` (§2.7).
     Ns { ns_id: u16, method_id: u16 },
+    /// A typed runtime-ABI call — container primitives today (§2.7: "opaque
+    /// to codegen... synchronous `CallTarget::Rt` calls into the container
+    /// ABI from day one"), never inline LLVM logic.
+    Rt(RtFn),
+}
+
+/// One `keel-rt-ffi` container-ABI entry point. Each maps to exactly one
+/// `#[no_mangle]` symbol in `keel-rt-ffi`'s `abi/mod.rs` — see
+/// `keel-codegen`'s `rt_call.rs` for the symbol/signature each one declares.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RtFn {
+    /// `keel_list_new() -> list` — builds an empty list.
+    ListNew,
+    /// `keel_list_push(list, elem) -> list'` — always clones (see
+    /// `keel-rt-ffi`'s doc on why this isn't real copy-on-write yet).
+    ListPush,
+    /// `keel_list_len(list) -> int`.
+    ListLen,
 }
 
 impl Expr {
@@ -267,6 +317,7 @@ impl Expr {
             | Expr::FieldGet { ty, .. } => *ty,
             Expr::MakeStruct { struct_id, .. } => KirType::Struct(*struct_id),
             Expr::MakeEnum { enum_id, .. } => KirType::Enum(*enum_id),
+            Expr::Index { ty, .. } => *ty,
         }
     }
 }

--- a/crates/keel-kir/src/lower/decl.rs
+++ b/crates/keel-kir/src/lower/decl.rs
@@ -19,6 +19,7 @@ pub(crate) fn signature_of(
     task: &TaskDecl,
     structs_by_name: &HashMap<String, StructId>,
     enums_by_name: &HashMap<String, EnumId>,
+    lists: &std::cell::RefCell<Vec<KirType>>,
 ) -> Result<(Vec<KirType>, KirType), LowerError> {
     if !task.type_params.is_empty() {
         return Err(LowerError::unsupported(
@@ -41,10 +42,15 @@ pub(crate) fn signature_of(
             ));
         }
         binding_ident(&param.name, &param.name_span)?; // rejects destructuring params
-        params.push(ty_expr_to_kir(&param.ty, structs_by_name, enums_by_name)?);
+        params.push(ty_expr_to_kir(
+            &param.ty,
+            structs_by_name,
+            enums_by_name,
+            lists,
+        )?);
     }
     let ret = match &task.return_type {
-        Some(ty) => ty_expr_to_kir(ty, structs_by_name, enums_by_name)?,
+        Some(ty) => ty_expr_to_kir(ty, structs_by_name, enums_by_name, lists)?,
         None => KirType::Unit,
     };
     Ok((params, ret))

--- a/crates/keel-kir/src/lower/expr.rs
+++ b/crates/keel-kir/src/lower/expr.rs
@@ -1,13 +1,14 @@
 //! Expression lowering — the M0 scalar subset (literals, identifiers,
 //! arithmetic/comparison/logical binary ops, unary `-`/`not`, and direct
 //! calls to other lowered tasks) plus M1's stdlib namespace calls
-//! (`io.show(...)`, `log.info(...)` — see [`lower_call`]) and M2's named-
-//! struct literals, spread-update, field access, and simple-enum variant
-//! construction (`Priority.low`). Everything else (index access, value
-//! method calls, casts, `if`/`when` as expressions, lambdas, list/set/tuple
+//! (`io.show(...)`, `log.info(...)` — see [`lower_call`]), M2's named-
+//! struct literals, spread-update, field access, simple-enum variant
+//! construction (`Priority.low`), and `list[T]` literals/`push`/`len`/
+//! indexing (`T` restricted to int/float/bool/str — see [`lower_list_lit`]).
+//! Everything else (casts, `if`/`when` as expressions, lambdas, set/tuple
 //! literals, string interpolation, `?.`/`??`, pipelines, duration literals,
-//! rich (payload-carrying) enum variants) is rejected; see module docs on
-//! `lower/mod.rs`.
+//! rich (payload-carrying) enum variants, non-list method calls/indexing)
+//! is rejected; see module docs on `lower/mod.rs`.
 
 use std::collections::HashMap;
 
@@ -225,7 +226,7 @@ pub(crate) fn lower_expr(
              `return`, or call argument)",
             expr.span.clone(),
         )),
-        ast::Expr::ListLit(_) => Err(LowerError::unsupported("list literal", expr.span.clone())),
+        ast::Expr::ListLit(items) => lower_list_lit(items, &expr.span, ctx, lcx, table),
         ast::Expr::SetLit(_) => Err(LowerError::unsupported("set literal", expr.span.clone())),
         ast::Expr::TupleLit(_) => Err(LowerError::unsupported("tuple literal", expr.span.clone())),
         ast::Expr::NullCoalesce(..) => Err(LowerError::unsupported("`??`", expr.span.clone())),
@@ -247,9 +248,14 @@ pub(crate) fn lower_expr(
                 && ctx.resolve(obj_name).is_none()
                 && let Some(namespace) = lcx.ns_bindings.get(obj_name)
             {
-                lower_ns_call(namespace, method, args, ctx, lcx, table, &expr.span)
-            } else {
-                Err(LowerError::unsupported("method call", expr.span.clone()))
+                return lower_ns_call(namespace, method, args, ctx, lcx, table, &expr.span);
+            }
+            let object_e = lower_expr(object, ctx, lcx, table)?;
+            match object_e.ty() {
+                KirType::List(_) => {
+                    lower_list_method_call(object_e, method, args, ctx, lcx, table, &expr.span)
+                }
+                _ => Err(LowerError::unsupported("method call", expr.span.clone())),
             }
         }
         ast::Expr::Cast { .. } => Err(LowerError::unsupported("`as` cast", expr.span.clone())),
@@ -262,7 +268,31 @@ pub(crate) fn lower_expr(
             expr.span.clone(),
         )),
         ast::Expr::Lambda { .. } => Err(LowerError::unsupported("lambda", expr.span.clone())),
-        ast::Expr::Index { .. } => Err(LowerError::unsupported("index access", expr.span.clone())),
+        ast::Expr::Index { object, index } => {
+            let object_e = lower_expr(object, ctx, lcx, table)?;
+            let KirType::List(list_id) = object_e.ty() else {
+                return Err(LowerError::unsupported(
+                    "index access on a non-list value (strings/maps land in a later M2 issue)",
+                    expr.span.clone(),
+                ));
+            };
+            let index_e = lower_expr(index, ctx, lcx, table)?;
+            if index_e.ty() != KirType::I64 {
+                return Err(LowerError::new(
+                    format!(
+                        "list index is `{}`, expected `int`",
+                        describe_ty(index_e.ty(), lcx)
+                    ),
+                    index.span.clone(),
+                ));
+            }
+            let elem_ty = lcx.lists.borrow()[list_id];
+            Ok(Expr::Index {
+                list: Box::new(object_e),
+                index: Box::new(index_e),
+                ty: elem_ty,
+            })
+        }
         ast::Expr::Duration { .. } => Err(LowerError::unsupported(
             "duration literal",
             expr.span.clone(),
@@ -610,4 +640,138 @@ fn result_ty_to_kir(result: BuiltinResult, span: &Span) -> Result<KirType, Lower
             span.clone(),
         )
     })
+}
+
+/// Lowers `[e0, e1, ...]` to a chain of `CallTarget::Rt` calls — `keel_list_
+/// new()` then a `keel_list_push` per element, folded left-to-right (no
+/// dedicated `MakeStruct`-style construction node needed: the container ABI
+/// is "opaque to codegen, every operation a runtime call" by design,
+/// `designs/llvm-compilation.md` §2.7, and push already is one).
+///
+/// Every element must share one `KirType`, restricted to int/float/bool/str
+/// (`is_list_element_ty`) — a struct/enum element needs `Value` marshaling
+/// that doesn't exist yet. An empty literal is rejected too: with no
+/// elements there's nothing to infer the element type from, and this crate
+/// doesn't consult the checker's own inference for it (see `lower/mod.rs`'s
+/// `CheckArtifacts` doc).
+fn lower_list_lit(
+    items: &[SpannedExpr],
+    span: &Span,
+    ctx: &mut FnCtx,
+    lcx: &LowerCtx<'_>,
+    table: &mut SpanTable,
+) -> Result<Expr, LowerError> {
+    let [first, rest @ ..] = items else {
+        return Err(LowerError::unsupported(
+            "empty list literal (element type can't be inferred without an annotation)",
+            span.clone(),
+        ));
+    };
+    let first_e = lower_expr(first, ctx, lcx, table)?;
+    let elem_ty = first_e.ty();
+    if !super::is_list_element_ty(elem_ty) {
+        return Err(LowerError::unsupported(
+            "list element type other than int/float/bool/str (struct/enum elements need \
+             Value marshaling, a later M2/M3 concern)",
+            first.span.clone(),
+        ));
+    }
+
+    let mut elements = Vec::with_capacity(items.len());
+    elements.push(first_e);
+    for item in rest {
+        let item_e = lower_expr(item, ctx, lcx, table)?;
+        if item_e.ty() != elem_ty {
+            return Err(LowerError::new(
+                format!(
+                    "list literal has mixed element types: `{}` and `{}`",
+                    describe_ty(elem_ty, lcx),
+                    describe_ty(item_e.ty(), lcx)
+                ),
+                item.span.clone(),
+            ));
+        }
+        elements.push(item_e);
+    }
+
+    let list_id = super::intern_list(lcx.lists, elem_ty);
+    let list_ty = KirType::List(list_id);
+    let span_id = table.intern(span.clone());
+    let mut acc = Expr::Call {
+        target: CallTarget::Rt(ir::RtFn::ListNew),
+        args: Vec::new(),
+        ty: list_ty,
+        span: span_id,
+    };
+    for element in elements {
+        acc = Expr::Call {
+            target: CallTarget::Rt(ir::RtFn::ListPush),
+            args: vec![acc, element],
+            ty: list_ty,
+            span: span_id,
+        };
+    }
+    Ok(acc)
+}
+
+/// Lowers a value method call on a `list[T]`-typed receiver (`xs.push(v)`,
+/// `xs.len()`) — the only container value methods lowered so far.
+fn lower_list_method_call(
+    object_e: Expr,
+    method: &str,
+    args: &[ast::CallArg],
+    ctx: &mut FnCtx,
+    lcx: &LowerCtx<'_>,
+    table: &mut SpanTable,
+    call_span: &Span,
+) -> Result<Expr, LowerError> {
+    let KirType::List(list_id) = object_e.ty() else {
+        unreachable!("caller only invokes lower_list_method_call on a KirType::List receiver");
+    };
+    for arg in args {
+        if arg.name.is_some() || arg.spread {
+            return Err(LowerError::unsupported(
+                "named or spread arguments to a list method call",
+                arg.value.span.clone(),
+            ));
+        }
+    }
+
+    let elem_ty = lcx.lists.borrow()[list_id];
+    let span_id = table.intern(call_span.clone());
+    match method {
+        "push" => {
+            let [arg] = args else {
+                return Err(LowerError::new(
+                    format!("`push` takes 1 argument, got {}", args.len()),
+                    call_span.clone(),
+                ));
+            };
+            let elem_e = lower_expr_expecting(&arg.value, elem_ty, ctx, lcx, table)?;
+            Ok(Expr::Call {
+                target: CallTarget::Rt(ir::RtFn::ListPush),
+                args: vec![object_e, elem_e],
+                ty: KirType::List(list_id),
+                span: span_id,
+            })
+        }
+        "len" | "count" => {
+            if !args.is_empty() {
+                return Err(LowerError::new(
+                    format!("`{method}` takes 0 arguments, got {}", args.len()),
+                    call_span.clone(),
+                ));
+            }
+            Ok(Expr::Call {
+                target: CallTarget::Rt(ir::RtFn::ListLen),
+                args: vec![object_e],
+                ty: KirType::I64,
+                span: span_id,
+            })
+        }
+        other => Err(LowerError::unsupported(
+            &format!("list method `{other}` (only `push`/`len`/`count` are lowered so far)"),
+            call_span.clone(),
+        )),
+    }
 }

--- a/crates/keel-kir/src/lower/mod.rs
+++ b/crates/keel-kir/src/lower/mod.rs
@@ -51,7 +51,7 @@ use keel_syntax::ast::{Binding, Decl, Program, TypeDef, UseDecl, UseKind, UseSou
 use keel_syntax::lexer::Span;
 
 use crate::ir::{
-    EnumId, EnumLayout, FuncId, KirFunction, KirProgram, LocalId, StructId, StructLayout,
+    EnumId, EnumLayout, FuncId, KirFunction, KirProgram, ListId, LocalId, StructId, StructLayout,
 };
 use crate::span_table::SpanTable;
 use crate::types::KirType;
@@ -113,6 +113,9 @@ pub(crate) struct LowerCtx<'a> {
     pub(crate) struct_layouts: &'a [StructLayout],
     pub(crate) enums_by_name: &'a HashMap<String, EnumId>,
     pub(crate) enum_layouts: &'a [EnumLayout],
+    /// See `lower_program`'s `lists` local for why this needs interior
+    /// mutability (structurally discovered, not pre-declared).
+    pub(crate) lists: &'a std::cell::RefCell<Vec<KirType>>,
     /// Not consumed yet — #145 (named structs) resolves everything through
     /// context-threaded expected types instead (see `expr::lower_expr_expecting`).
     /// Becomes load-bearing for a construct the checker must resolve and
@@ -207,6 +210,14 @@ pub fn lower_program(
     let mut struct_decls: Vec<&keel_syntax::ast::TypeDecl> = Vec::new();
     let mut enums_by_name: HashMap<String, EnumId> = HashMap::new();
     let mut enum_layouts: Vec<EnumLayout> = Vec::new();
+    // `list[T]` shapes are structurally interned (see `ir.rs`'s `ListId`
+    // doc) as they're *discovered* while lowering type annotations and list
+    // literals throughout the whole program — unlike `structs_by_name`/
+    // `enums_by_name` (built once, up front, from declarations), there's no
+    // separate "declaration" pass to collect these from. `RefCell` keeps
+    // `LowerCtx` otherwise fully immutable/shared (see its doc) while still
+    // letting every lowering function grow this table via `intern_list`.
+    let lists: std::cell::RefCell<Vec<KirType>> = std::cell::RefCell::new(Vec::new());
 
     // Pass 1a: reserve a `StructId` for every named struct declaration
     // before resolving any field types, so a field can reference another
@@ -268,7 +279,7 @@ pub fn lower_program(
         for field in ast_fields {
             fields.push((
                 field.name.clone(),
-                ty_expr_to_kir(&field.ty, &structs_by_name, &enums_by_name)?,
+                ty_expr_to_kir(&field.ty, &structs_by_name, &enums_by_name, &lists)?,
             ));
         }
         struct_layouts.push(StructLayout {
@@ -285,7 +296,8 @@ pub fn lower_program(
     for decl in &program.declarations {
         match &decl.kind {
             Decl::Task(task) => {
-                let (params, ret) = decl::signature_of(task, &structs_by_name, &enums_by_name)?;
+                let (params, ret) =
+                    decl::signature_of(task, &structs_by_name, &enums_by_name, &lists)?;
                 let func_id = task_order.len();
                 task_order.push(task);
                 funcs.insert(
@@ -318,6 +330,7 @@ pub fn lower_program(
         struct_layouts: &struct_layouts,
         enums_by_name: &enums_by_name,
         enum_layouts: &enum_layouts,
+        lists: &lists,
         artifacts,
     };
 
@@ -358,6 +371,7 @@ pub fn lower_program(
         toplevel: toplevel_id,
         structs: struct_layouts,
         enums: enum_layouts,
+        lists: lists.into_inner(),
         span_table,
     })
 }
@@ -426,6 +440,7 @@ pub(crate) fn ty_expr_to_kir(
     ty: &keel_syntax::ast::Node<keel_syntax::ast::TypeExpr>,
     structs_by_name: &HashMap<String, StructId>,
     enums_by_name: &HashMap<String, EnumId>,
+    lists: &std::cell::RefCell<Vec<KirType>>,
 ) -> Result<KirType, LowerError> {
     use keel_syntax::ast::TypeExpr;
     match &ty.kind {
@@ -449,7 +464,22 @@ pub(crate) fn ty_expr_to_kir(
             }
         },
         TypeExpr::Nullable(_) => Err(LowerError::unsupported("nullable type", ty.span.clone())),
-        TypeExpr::List(_) => Err(LowerError::unsupported("list type", ty.span.clone())),
+        TypeExpr::List(inner) => {
+            // `TypeExpr::List` boxes a bare `TypeExpr`, not a `Node<TypeExpr>`
+            // (no span of its own — see `keel-syntax`'s `ast::ty::TypeExpr`),
+            // so diagnostics about the element type fall back to the whole
+            // `list[...]` annotation's span.
+            let inner_node = keel_syntax::ast::Node::new((**inner).clone(), ty.span.clone());
+            let elem_ty = ty_expr_to_kir(&inner_node, structs_by_name, enums_by_name, lists)?;
+            if !is_list_element_ty(elem_ty) {
+                return Err(LowerError::unsupported(
+                    "list element type other than int/float/bool/str (struct/enum elements \
+                     need Value marshaling, a later M2/M3 concern)",
+                    ty.span.clone(),
+                ));
+            }
+            Ok(KirType::List(intern_list(lists, elem_ty)))
+        }
         TypeExpr::Map(_, _) => Err(LowerError::unsupported("map type", ty.span.clone())),
         TypeExpr::Set(_) => Err(LowerError::unsupported("set type", ty.span.clone())),
         TypeExpr::Struct(_) => Err(LowerError::unsupported(
@@ -462,6 +492,31 @@ pub(crate) fn ty_expr_to_kir(
         TypeExpr::Dynamic => Err(LowerError::unsupported("dynamic type", ty.span.clone())),
         TypeExpr::SelfType => Err(LowerError::unsupported("`self` type", ty.span.clone())),
     }
+}
+
+/// `true` for the element types a `list[T]` can hold today — int/float/
+/// bool/str, the same set `emit_box_arg`/`rt_call::unbox_value` in
+/// `keel-codegen` can marshal to/from a boxed `Value` without needing
+/// struct/enum `Value` conversion (a later M2/M3 concern).
+pub(crate) fn is_list_element_ty(ty: KirType) -> bool {
+    matches!(
+        ty,
+        KirType::I64 | KirType::F64 | KirType::Bool | KirType::Str
+    )
+}
+
+/// Interns `elem` into `lists`, returning its `ListId` — reuses an existing
+/// entry for a structurally-identical element type rather than minting a
+/// fresh one (`list[int]` written twice in a program is one `ListId`, not
+/// two; see `ir.rs`'s `ListId` doc on why this differs from `StructId`/
+/// `EnumId`'s nominal, declaration-order interning).
+pub(crate) fn intern_list(lists: &std::cell::RefCell<Vec<KirType>>, elem: KirType) -> ListId {
+    let mut lists = lists.borrow_mut();
+    if let Some(id) = lists.iter().position(|t| *t == elem) {
+        return id;
+    }
+    lists.push(elem);
+    lists.len() - 1
 }
 
 /// Extracts the plain identifier a `Binding` names, rejecting destructuring

--- a/crates/keel-kir/src/lower/stmt.rs
+++ b/crates/keel-kir/src/lower/stmt.rs
@@ -1,11 +1,13 @@
 //! Statement lowering — the M0 scalar subset plus M1's `for`-over-ranges
-//! and M2's named-struct literals in `let`/`return` position, plus `when` as
+//! and M2's named-struct literals in `let`/`return` position, `when` as
 //! a statement (over a simple-enum or a str/int scrutinee with a wildcard
-//! arm — see [`lower_when_stmt`]): `let`/assign, `if`/`else`, `while`,
-//! `for x in a..b`, `return`, `when`, and bare expression statements.
-//! Everything else (`try`/`catch`, `raise`, `assert`, `break`/`continue`,
-//! `self.field = ...`, `for` with a `where` filter or a non-range iterable)
-//! is rejected; see module docs on `lower/mod.rs`.
+//! arm — see [`lower_when_stmt`]), and `for x in xs` over a `list[T]`
+//! (lowered to [`keel_kir::ir::Stmt::ForEach`]): `let`/assign, `if`/`else`,
+//! `while`, `for x in a..b`, `for x in xs`, `return`, `when`, and bare
+//! expression statements. Everything else (`try`/`catch`, `raise`, `assert`,
+//! `break`/`continue`, `self.field = ...`, `for` with a `where` filter or a
+//! non-range, non-list iterable) is rejected; see module docs on
+//! `lower/mod.rs`.
 
 use keel_syntax::ast::{self, Node};
 use keel_syntax::lexer::Span;
@@ -54,7 +56,12 @@ pub(crate) fn lower_stmt(
             // `CheckArtifacts` doc) resolve to the *named* struct the
             // annotation calls for.
             let init = if let Some(annotation) = ty {
-                let expected = ty_expr_to_kir(annotation, lcx.structs_by_name, lcx.enums_by_name)?;
+                let expected = ty_expr_to_kir(
+                    annotation,
+                    lcx.structs_by_name,
+                    lcx.enums_by_name,
+                    lcx.lists,
+                )?;
                 lower_expr_expecting(value, expected, ctx, lcx, table)?
             } else if let ast::Expr::StructSpreadUpdate { base, .. } = &value.kind {
                 // No annotation, but the spread's own base already carries a
@@ -170,10 +177,27 @@ pub(crate) fn lower_stmt(
             }
             let name = binding_ident(binding, &stmt.span)?;
             let ast::Expr::Range(start, end) = &iter.kind else {
-                return Err(LowerError::unsupported(
-                    "`for` over a non-range iterable (container ABI lands in M2)",
-                    iter.span.clone(),
-                ));
+                // Not a range literal — try a `list[T]` iterable instead of
+                // rejecting outright.
+                let iter_e = lower_expr(iter, ctx, lcx, table)?;
+                let KirType::List(list_id) = iter_e.ty() else {
+                    return Err(LowerError::unsupported(
+                        "`for` over a non-range, non-list iterable (maps/sets land in a later \
+                         M2 issue)",
+                        iter.span.clone(),
+                    ));
+                };
+                let elem_ty = lcx.lists.borrow()[list_id];
+                ctx.push_scope();
+                let var = ctx.declare(name, elem_ty);
+                let body = lower_block(body, ctx, lcx, table, ret_ty)?;
+                ctx.pop_scope();
+                return Ok(ir::Stmt::ForEach {
+                    var,
+                    elem_ty,
+                    list: iter_e,
+                    body,
+                });
             };
             // Bounds are evaluated once, before `var` exists, so they lower
             // in the enclosing scope and cannot reference the loop variable.

--- a/crates/keel-kir/src/passes/verify.rs
+++ b/crates/keel-kir/src/passes/verify.rs
@@ -124,6 +124,16 @@ fn check_enum(program: &KirProgram, id: EnumId) -> Result<(), String> {
     Ok(())
 }
 
+fn check_list(program: &KirProgram, id: crate::ir::ListId) -> Result<(), String> {
+    if id >= program.lists.len() {
+        return Err(format!(
+            "ListId {id} out of range ({} lists)",
+            program.lists.len()
+        ));
+    }
+    Ok(())
+}
+
 fn verify_block(program: &KirProgram, func: &KirFunction, block: &Block) -> Result<(), String> {
     for stmt in block {
         verify_stmt(program, func, stmt)?;
@@ -200,6 +210,32 @@ fn verify_stmt(program: &KirProgram, func: &KirFunction, stmt: &Stmt) -> Result<
             }
             verify_block(program, func, body)
         }
+        Stmt::ForEach {
+            var,
+            elem_ty,
+            list,
+            body,
+        } => {
+            check_local(func, *var)?;
+            verify_expr(program, func, list)?;
+            let KirType::List(list_id) = list.ty() else {
+                return Err(format!("for-each list is {}, expected a list", list.ty()));
+            };
+            check_list(program, list_id)?;
+            let declared_elem = program.lists[list_id];
+            if declared_elem != *elem_ty {
+                return Err(format!(
+                    "for-each elem_ty claims {elem_ty} but the list holds {declared_elem}"
+                ));
+            }
+            let var_ty = func.locals[*var].ty;
+            if var_ty != *elem_ty {
+                return Err(format!(
+                    "for-each loop variable {var} is {var_ty}, expected {elem_ty}"
+                ));
+            }
+            verify_block(program, func, body)
+        }
         Stmt::Return(None) => {
             if func.ret != KirType::Unit {
                 return Err(format!(
@@ -253,6 +289,7 @@ fn verify_expr(program: &KirProgram, func: &KirFunction, expr: &Expr) -> Result<
                 CallTarget::Ns { ns_id, method_id } => {
                     verify_ns_call(*ns_id, *method_id, args, *ty)
                 }
+                CallTarget::Rt(rt_fn) => verify_rt_call(program, *rt_fn, args, *ty),
             }
         }
         Expr::MakeStruct { struct_id, fields } => {
@@ -319,6 +356,24 @@ fn verify_expr(program: &KirProgram, func: &KirFunction, expr: &Expr) -> Result<
                     "MakeEnum variant index {variant_index} out of range for `{}` ({} variants)",
                     layout.name,
                     layout.variants.len()
+                ));
+            }
+            Ok(())
+        }
+        Expr::Index { list, index, ty } => {
+            verify_expr(program, func, list)?;
+            verify_expr(program, func, index)?;
+            if index.ty() != KirType::I64 {
+                return Err(format!("index is {}, expected int", index.ty()));
+            }
+            let KirType::List(list_id) = list.ty() else {
+                return Err(format!("index base is {}, expected a list", list.ty()));
+            };
+            check_list(program, list_id)?;
+            let declared_elem = program.lists[list_id];
+            if declared_elem != *ty {
+                return Err(format!(
+                    "index claims type {ty} but the list holds {declared_elem}"
                 ));
             }
             Ok(())
@@ -402,4 +457,69 @@ fn verify_ns_call(ns_id: u16, method_id: u16, args: &[Expr], ty: KirType) -> Res
         ));
     }
     Ok(())
+}
+
+/// Verifies a `CallTarget::Rt` call shape against the arity/type each
+/// `RtFn` variant declares (`keel-codegen`'s `rt_call.rs` implements the
+/// matching codegen side).
+fn verify_rt_call(
+    program: &KirProgram,
+    rt_fn: crate::ir::RtFn,
+    args: &[Expr],
+    ty: KirType,
+) -> Result<(), String> {
+    use crate::ir::RtFn;
+    match rt_fn {
+        RtFn::ListNew => {
+            if !args.is_empty() {
+                return Err(format!("rt.list_new takes 0 args, got {}", args.len()));
+            }
+            let KirType::List(list_id) = ty else {
+                return Err(format!("rt.list_new result is {ty}, expected a list"));
+            };
+            check_list(program, list_id)
+        }
+        RtFn::ListPush => {
+            let [list, elem] = args else {
+                return Err(format!("rt.list_push takes 2 args, got {}", args.len()));
+            };
+            let KirType::List(list_id) = list.ty() else {
+                return Err(format!(
+                    "rt.list_push base is {}, expected a list",
+                    list.ty()
+                ));
+            };
+            check_list(program, list_id)?;
+            let elem_ty = program.lists[list_id];
+            if elem.ty() != elem_ty {
+                return Err(format!(
+                    "rt.list_push element is {} but the list holds {elem_ty}",
+                    elem.ty()
+                ));
+            }
+            if ty != list.ty() {
+                return Err(format!(
+                    "rt.list_push result is {ty} but the base list is {}",
+                    list.ty()
+                ));
+            }
+            Ok(())
+        }
+        RtFn::ListLen => {
+            let [list] = args else {
+                return Err(format!("rt.list_len takes 1 arg, got {}", args.len()));
+            };
+            let KirType::List(list_id) = list.ty() else {
+                return Err(format!(
+                    "rt.list_len base is {}, expected a list",
+                    list.ty()
+                ));
+            };
+            check_list(program, list_id)?;
+            if ty != KirType::I64 {
+                return Err(format!("rt.list_len result is {ty}, expected int"));
+            }
+            Ok(())
+        }
+    }
 }

--- a/crates/keel-kir/src/types.rs
+++ b/crates/keel-kir/src/types.rs
@@ -1,13 +1,14 @@
 //! `KirType` — the lowered type vocabulary KIR expressions carry.
 //!
 //! M0/M1 lower the scalar subset only (see `designs/llvm-compilation.md`
-//! §4); M2 adds named structs. The remaining variants sketched in the
-//! design doc's `KirType` (§2.3) — containers, anonymous struct shapes,
-//! enums, nullable, func, boxed `dynamic`, opaque handles — are
-//! deliberately not modeled yet; adding them is later-M2+ work, done
-//! alongside the lowering support that produces them.
+//! §4); M2 adds named structs, simple enums, and `list[T]` (int/float/bool/
+//! str elements only). The remaining variants sketched in the design doc's
+//! `KirType` (§2.3) — map/set, anonymous struct shapes, rich enum variants,
+//! nullable, func, boxed `dynamic`, opaque handles — are deliberately not
+//! modeled yet; adding them is later-M2+ work, done alongside the lowering
+//! support that produces them.
 
-use crate::ir::{EnumId, KirProgram, StructId};
+use crate::ir::{EnumId, KirProgram, ListId, StructId};
 
 /// A KIR-level type. Every KIR expression carries one.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -35,6 +36,11 @@ pub enum KirType {
     /// (deferred, see `ir.rs`'s `EnumLayout` doc). By-value `i32` tag — no
     /// heap allocation or RC, unlike `Struct`.
     Enum(EnumId),
+    /// `list[T]` (`T` restricted to int/float/bool/str — see
+    /// `KirProgram::lists`'s doc) — a `ptr` to an RC'd, always-clone-on-
+    /// mutation `Value::List` (opaque to codegen; every operation is a
+    /// `CallTarget::Rt` runtime call, `designs/llvm-compilation.md` §2.7).
+    List(ListId),
 }
 
 impl KirType {
@@ -53,6 +59,7 @@ impl KirType {
             KirType::Str => "str",
             KirType::Struct(_) => "struct",
             KirType::Enum(_) => "enum",
+            KirType::List(_) => "list",
         }
     }
 
@@ -71,6 +78,7 @@ impl KirType {
         match self {
             KirType::Str => true,
             KirType::Struct(id) => program.structs[id].is_heap(program),
+            KirType::List(_) => true,
             KirType::I64 | KirType::F64 | KirType::Bool | KirType::Unit | KirType::Enum(_) => false,
         }
     }

--- a/crates/keel-kir/tests/fixtures/lists.keel
+++ b/crates/keel-kir/tests/fixtures/lists.keel
@@ -1,0 +1,14 @@
+task sum(xs: list[int]) -> int {
+  total = 0
+  for x in xs {
+    total += x
+  }
+  return total
+}
+
+a = [1, 2, 3]
+b = a
+a = a.push(4)
+count = a.len()
+first = a[0]
+result = sum(a)

--- a/crates/keel-kir/tests/fixtures/lists.kir
+++ b/crates/keel-kir/tests/fixtures/lists.kir
@@ -1,0 +1,16 @@
+fn sum(xs: list[int]) -> int {
+  let total: int = 0
+  for x in xs {
+    total = (total + x)
+  }
+  return total
+}
+
+fn <toplevel>() -> none {
+  let a: list[int] = rt.list_push(rt.list_push(rt.list_push(rt.list_new(), 1), 2), 3)
+  let b: list[int] = a
+  let a: list[int] = rt.list_push(a, 4)
+  let count: int = rt.list_len(a)
+  let first: int = a[0]
+  let result: int = sum(a)
+}

--- a/crates/keel-kir/tests/lower_errors.rs
+++ b/crates/keel-kir/tests/lower_errors.rs
@@ -20,26 +20,28 @@ fn lower_err(source: &str) -> String {
 }
 
 #[test]
-fn for_over_list_param_is_rejected_at_signature() {
-    // `for` over a range lowers now (see golden fixture `for_range.kir`);
-    // this pins that a `list[int]` param is still rejected — at the
-    // signature, before the for-loop body is ever reached.
+fn list_of_struct_element_type_is_rejected() {
+    // `list[int]` lowers now (see golden fixture `lists.kir`, #147) — this
+    // pins that a struct-element list is still rejected at the type
+    // annotation (struct/enum elements need `Value` marshaling that
+    // doesn't exist yet).
     let msg = lower_err(
         r#"
-task sum(xs: list[int]) -> int {
-  total = 0
-  for x in xs {
-    total += x
-  }
-  return total
+type Point { x: int, y: int }
+
+task f(xs: list[Point]) -> int {
+  return 0
 }
 "#,
     );
-    assert!(msg.contains("list type"), "unexpected message: {msg}");
+    assert!(
+        msg.contains("list element type other than int/float/bool/str"),
+        "unexpected message: {msg}"
+    );
 }
 
 #[test]
-fn for_over_non_range_iterable_is_rejected() {
+fn for_over_non_range_non_list_iterable_is_rejected() {
     let msg = lower_err(
         r#"
 task f(n: int) -> int {
@@ -50,7 +52,7 @@ task f(n: int) -> int {
 "#,
     );
     assert!(
-        msg.contains("non-range iterable"),
+        msg.contains("non-range, non-list iterable"),
         "unexpected message: {msg}"
     );
 }
@@ -484,6 +486,109 @@ task grade(score: str) -> str {
     );
     assert!(
         msg.contains("when` expression"),
+        "unexpected message: {msg}"
+    );
+}
+
+#[test]
+fn empty_list_literal_is_rejected() {
+    let msg = lower_err(
+        r#"
+task f() -> int {
+  xs = []
+  return 0
+}
+"#,
+    );
+    assert!(
+        msg.contains("empty list literal"),
+        "unexpected message: {msg}"
+    );
+}
+
+#[test]
+fn list_literal_with_mixed_element_types_is_rejected() {
+    let msg = lower_err(
+        r#"
+task f() -> int {
+  xs = [1, "two"]
+  return 0
+}
+"#,
+    );
+    assert!(
+        msg.contains("mixed element types"),
+        "unexpected message: {msg}"
+    );
+}
+
+#[test]
+fn unknown_list_method_is_rejected() {
+    let msg = lower_err(
+        r#"
+task f() -> int {
+  xs = [1, 2, 3]
+  ys = xs.reverse()
+  return 0
+}
+"#,
+    );
+    assert!(msg.contains("list method"), "unexpected message: {msg}");
+}
+
+#[test]
+fn list_push_wrong_arg_count_is_rejected() {
+    let msg = lower_err(
+        r#"
+task f() -> int {
+  xs = [1, 2, 3]
+  ys = xs.push(1, 2)
+  return 0
+}
+"#,
+    );
+    assert!(msg.contains("`push`"), "unexpected message: {msg}");
+}
+
+#[test]
+fn list_push_wrong_element_type_is_rejected() {
+    let msg = lower_err(
+        r#"
+task f() -> int {
+  xs = [1, 2, 3]
+  ys = xs.push("four")
+  return 0
+}
+"#,
+    );
+    assert!(msg.contains("expected"), "unexpected message: {msg}");
+}
+
+#[test]
+fn non_int_list_index_is_rejected() {
+    let msg = lower_err(
+        r#"
+task f() -> int {
+  xs = [1, 2, 3]
+  return xs["0"]
+}
+"#,
+    );
+    assert!(msg.contains("list index"), "unexpected message: {msg}");
+}
+
+#[test]
+fn index_access_on_a_non_list_value_is_rejected() {
+    let msg = lower_err(
+        r#"
+task f() -> int {
+  x = 1
+  return x[0]
+}
+"#,
+    );
+    assert!(
+        msg.contains("index access on a non-list value"),
         "unexpected message: {msg}"
     );
 }

--- a/crates/keel-rt-ffi/src/abi/mod.rs
+++ b/crates/keel-rt-ffi/src/abi/mod.rs
@@ -79,6 +79,124 @@ pub unsafe extern "C" fn keel_str_eq(a: *const Value, b: *const Value) -> u8 {
     u8::from(a == b)
 }
 
+/// Unboxes an `int` — `keel-codegen` only ever calls this (and its
+/// `keel_unbox_float`/`keel_unbox_bool` siblings) on a box it knows (from
+/// the expression's `KirType`) holds that scalar kind.
+///
+/// # Safety
+///
+/// `ptr` must be a live `KeelBox` (see [`borrow`]) whose `Value` is
+/// `Value::Integer`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn keel_unbox_int(ptr: *const Value) -> i64 {
+    let Value::Integer(v) = (unsafe { &*ptr }) else {
+        unreachable!("keel-codegen only calls keel_unbox_int on int-typed (Value::Integer) boxes");
+    };
+    *v
+}
+
+/// Unboxes a `float`. See [`keel_unbox_int`].
+///
+/// # Safety
+///
+/// `ptr` must be a live `KeelBox` whose `Value` is `Value::Float`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn keel_unbox_float(ptr: *const Value) -> f64 {
+    let Value::Float(v) = (unsafe { &*ptr }) else {
+        unreachable!(
+            "keel-codegen only calls keel_unbox_float on float-typed (Value::Float) boxes"
+        );
+    };
+    *v
+}
+
+/// Unboxes a `bool` (`0`/`1`, matching [`keel_box_bool`]'s convention). See
+/// [`keel_unbox_int`].
+///
+/// # Safety
+///
+/// `ptr` must be a live `KeelBox` whose `Value` is `Value::Bool`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn keel_unbox_bool(ptr: *const Value) -> u8 {
+    let Value::Bool(v) = (unsafe { &*ptr }) else {
+        unreachable!("keel-codegen only calls keel_unbox_bool on bool-typed (Value::Bool) boxes");
+    };
+    u8::from(*v)
+}
+
+/// Builds an empty list. See [`keel_box_int`] for ownership.
+#[unsafe(no_mangle)]
+pub extern "C" fn keel_list_new() -> *const Value {
+    Arc::into_raw(Arc::new(Value::List(Vec::new())))
+}
+
+/// Returns a **fresh** list with `elem` appended, leaving `list` and `elem`
+/// untouched (a deliberate always-clone, not a real copy-on-write: `Arc::
+/// make_mut`-style in-place mutation would only be sound with accurate
+/// strong counts, which needs the retain-on-alias/release-on-scope-exit RC
+/// pass `designs/llvm-compilation.md` §2.3 describes and this codebase does
+/// not implement yet — see `keel-codegen`'s module docs. Always-cloning
+/// matches the interpreter's own `Value::List` "push" method exactly
+/// (`interpreter/methods.rs`: `let mut result = items.clone(); result.push(..)`),
+/// so this is semantically identical, just not the eventual perf
+/// optimization). See [`keel_box_int`] for the returned reference's
+/// ownership; `list`/`elem` are borrowed, not consumed.
+///
+/// # Safety
+///
+/// `list` must be a live `KeelBox` whose `Value` is `Value::List`; `elem`
+/// must be a live `KeelBox` (any variant — it becomes one of the list's
+/// elements as-is).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn keel_list_push(list: *const Value, elem: *const Value) -> *const Value {
+    let Value::List(items) = (unsafe { &*list }) else {
+        unreachable!("keel-codegen only calls keel_list_push on a KirType::List value");
+    };
+    let mut items = items.clone();
+    items.push(unsafe { borrow(elem) });
+    boxed(Value::List(items))
+}
+
+/// Returns a list's element count.
+///
+/// # Safety
+///
+/// `list` must be a live `KeelBox` whose `Value` is `Value::List`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn keel_list_len(list: *const Value) -> i64 {
+    let Value::List(items) = (unsafe { &*list }) else {
+        unreachable!("keel-codegen only calls keel_list_len on a KirType::List value");
+    };
+    items.len() as i64
+}
+
+/// Returns the element at `index` as a **borrowed-then-retained** `KeelBox`
+/// (the caller owns the returned reference, same convention as every other
+/// `keel_box_*`/`keel_list_*` return). Exits the process with a clear
+/// message on out-of-bounds — the interpreter *raises* (`NullError`-style,
+/// catchable), but the compiled result/raise calling convention (§2.5)
+/// isn't wired up yet (#150); this is an explicit placeholder, not a
+/// silent divergence into undefined behavior.
+///
+/// # Safety
+///
+/// `list` must be a live `KeelBox` whose `Value` is `Value::List`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn keel_list_get(list: *const Value, index: i64) -> *const Value {
+    let Value::List(items) = (unsafe { &*list }) else {
+        unreachable!("keel-codegen only calls keel_list_get on a KirType::List value");
+    };
+    let Ok(idx) = usize::try_from(index) else {
+        eprintln!("index {index} out of bounds (length {})", items.len());
+        std::process::exit(1);
+    };
+    let Some(item) = items.get(idx) else {
+        eprintln!("index {index} out of bounds (length {})", items.len());
+        std::process::exit(1);
+    };
+    boxed(item.clone())
+}
+
 /// Reads a `KeelBox`'s value without consuming the caller's reference —
 /// used to marshal namespace-call arguments (`const KeelBox**`, i.e.
 /// borrowed) into owned `Value`s.


### PR DESCRIPTION
Close #147

## Summary

- `KirType::List(ListId)` — structurally interned (like `list[int]` anywhere in a program dedupes to the same `ListId`), restricted to `int`/`float`/`bool`/`str` elements (struct/enum elements need `Value` marshaling that doesn't exist yet — rejected with a clear message).
- List literals lower to a chain of `CallTarget::Rt` calls (`keel_list_new` + one `keel_list_push` per element) — no dedicated `MakeList` node needed since push is already the primitive.
- `push`/`len`/`count` value methods, `xs[i]` indexing (bounds-checked at runtime), and `for x in xs` (a new `Stmt::ForEach`, distinct from the range-only `Stmt::ForIndex`).
- New `keel-rt-ffi` ABI: `keel_list_new`/`push`/`len`/`get`, plus `keel_unbox_int`/`float`/`bool` (codegen needs to unbox a boxed `Value` back to a raw LLVM scalar after `keel_list_get`).
- `keel_list_push` always clones the underlying `Vec` rather than doing refcount-gated in-place mutation — this exactly matches the interpreter's own `push` semantics (confirmed empirically: a bare `a.push(4)` statement doesn't mutate `a`'s binding, matching Keel's always-declares assignment scoping) and is what makes the aliasing test below correct by construction, not just by testing. It is not the eventual perf-optimized real CoW (needs a retain-on-alias/release-on-scope-exit RC pass that doesn't exist yet).
- New `keel-codegen/src/rt_call.rs` module hosts all `CallTarget::Rt` codegen and the boxed-value unboxing helper.

## Deferred

- **map/set**: split out to #162 — same ABI/lowering/codegen shape as list, deferred for PR size and review focus, not a technical blocker.
- **Out-of-bounds indexing**: `keel_list_get` exits the process with a message on OOB. The interpreter *raises* a catchable error instead; the compiled result/raise calling convention isn't wired up yet (#150), so this is an explicit, documented placeholder, not a silent divergence.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo clippy --workspace --all-targets --features build-backend -- -D warnings`
- [x] `cargo test --workspace` (all green)
- [x] `cargo test --workspace --features build-backend` (all green, including 3 new differential codegen-vs-interpreter tests in `crates/keel-codegen/tests/lists.rs`)
- [x] `cargo test --workspace --features build-backend --test conformance` x3 for stability
- [x] Golden `--emit=kir` dump fixture (`lists.keel`/`.kir`), stable across reruns
- [x] 40 tests in `keel-kir/tests/lower_errors.rs`, including 7 new list-specific rejection cases