### PR TITLE
keel-kir + keel-codegen: task default parameter values end to end

### DIFF
--- a/crates/keel-codegen/tests/default_params.rs
+++ b/crates/keel-codegen/tests/default_params.rs
@@ -1,0 +1,70 @@
+//! Exit criterion for issue #164 (task default parameter values): a task
+//! declared with a trailing defaulted parameter, called both with the
+//! argument supplied and with it omitted, compiles, links, and matches the
+//! interpreter for both call shapes.
+
+use std::process::Command;
+
+use keel_codegen::BuildOptions;
+
+#[path = "support/mod.rs"]
+mod support;
+
+fn compile_and_run(source: &str) -> std::process::Output {
+    let kir = support::parse_check_and_lower(source);
+
+    let out_dir = tempfile::tempdir().expect("create temp out dir");
+    let opts = BuildOptions {
+        out_dir: out_dir.path().to_path_buf(),
+        runtime_link_args: support::runtime_link_args().clone(),
+    };
+    let bin = keel_codegen::compile(&kir, &opts).expect("compile must succeed");
+    Command::new(&bin).output().expect("run compiled binary")
+}
+
+fn assert_matches_interpreter(source: &str, expected_stdout: &[u8]) {
+    let compiled = compile_and_run(source);
+    let interpreted = support::run_interpreter(source);
+
+    assert_eq!(
+        String::from_utf8_lossy(&compiled.stdout),
+        String::from_utf8_lossy(&interpreted.stdout),
+        "compiled stdout must match the interpreter's"
+    );
+    assert_eq!(compiled.stdout, expected_stdout);
+}
+
+#[test]
+fn omitted_and_supplied_trailing_default_args_match_the_interpreter() {
+    // `name` is unused by the return value on purpose — str concatenation
+    // isn't wired up in keel-codegen yet (a separate, later M2 gap), so
+    // this sticks to returning the defaulted str param directly rather
+    // than combining it with `name`.
+    let source = r#"
+use std/io
+
+task greeting_for(name: str, greeting: str = "Hello") -> str {
+  return greeting
+}
+
+io.show(greeting_for("Ada", "Hi"))
+io.show(greeting_for("Ada"))
+"#;
+    assert_matches_interpreter(source, b"  Hi\n  Hello\n");
+}
+
+#[test]
+fn multiple_trailing_defaults_can_be_partially_omitted() {
+    let source = r#"
+use std/io
+
+task line(x: int, y: int = 0, z: int = 0) -> int {
+  return x + y + z
+}
+
+io.show(line(1, 2, 3))
+io.show(line(1, 2))
+io.show(line(1))
+"#;
+    assert_matches_interpreter(source, b"  6\n  3\n  1\n");
+}

--- a/crates/keel-kir/src/lower/decl.rs
+++ b/crates/keel-kir/src/lower/decl.rs
@@ -7,14 +7,16 @@ use std::collections::HashMap;
 use keel_syntax::ast::TaskDecl;
 
 use super::{FnCtx, FuncSig, LowerCtx, LowerError, binding_ident, ty_expr_to_kir};
-use crate::ir::{EnumId, KirFunction, Param, StructId};
+use crate::ir::{EnumId, Expr, KirFunction, Param, StructId};
 use crate::span_table::SpanTable;
 use crate::types::KirType;
 
 /// Extracts `(param_types, return_type)` from a task's AST signature.
-/// Rejects generics, variadics, and default params — none are in the M0
-/// scalar subset (generics need `mono.rs`; variadics/defaults need the
-/// container ABI and desugaring `sugar.rs` doesn't do yet).
+/// Rejects generics and variadics — neither is in the M0 scalar subset
+/// (generics need `mono.rs`; variadics need the container ABI). Default
+/// parameter values are allowed here (just their *type*, matching the
+/// declared param) — see [`lower_param_defaults`] for lowering the default
+/// *expressions* themselves.
 pub(crate) fn signature_of(
     task: &TaskDecl,
     structs_by_name: &HashMap<String, StructId>,
@@ -27,6 +29,7 @@ pub(crate) fn signature_of(
             task.name_span.clone(),
         ));
     }
+    let mut seen_default = false;
     let mut params = Vec::with_capacity(task.params.len());
     for param in &task.params {
         if param.variadic {
@@ -35,9 +38,15 @@ pub(crate) fn signature_of(
                 param.name_span.clone(),
             ));
         }
+        // Call-site omitted-arg filling (`lower_call`) only fills a
+        // *trailing* run of defaulted params — the checker doesn't enforce
+        // this ordering itself, so KIR does, rather than silently mis-
+        // filling a non-trailing default.
         if param.default.is_some() {
+            seen_default = true;
+        } else if seen_default {
             return Err(LowerError::unsupported(
-                "default parameter value",
+                "a non-default parameter after a defaulted one (defaults must be trailing)",
                 param.name_span.clone(),
             ));
         }
@@ -54,6 +63,31 @@ pub(crate) fn signature_of(
         None => KirType::Unit,
     };
     Ok((params, ret))
+}
+
+/// Lowers each parameter's default-value expression (if any) against the
+/// parameter's own declared type, once per declaration — not per call site,
+/// see `lower/mod.rs`'s `param_defaults` doc. Uses a fresh, param-free
+/// `FnCtx`: a default expression may not reference the task's own other
+/// parameters (none of this codebase's examples need that, and it would
+/// otherwise need per-call-site re-lowering instead of a lower-once cache).
+pub(crate) fn lower_param_defaults(
+    task: &TaskDecl,
+    sig_params: &[KirType],
+    lcx: &LowerCtx<'_>,
+    table: &mut SpanTable,
+) -> Result<Vec<Option<Expr>>, LowerError> {
+    let mut ctx = FnCtx::new();
+    task.params
+        .iter()
+        .zip(sig_params)
+        .map(|(param, ty)| match &param.default {
+            Some(expr) => Ok(Some(super::expr::lower_expr_expecting(
+                expr, *ty, &mut ctx, lcx, table,
+            )?)),
+            None => Ok(None),
+        })
+        .collect()
 }
 
 /// Lowers a task's body given its already-computed signature.

--- a/crates/keel-kir/src/lower/expr.rs
+++ b/crates/keel-kir/src/lower/expr.rs
@@ -521,19 +521,25 @@ fn lower_call(
     let sig = lcx.funcs.get(name).ok_or_else(|| {
         LowerError::new(format!("unknown function `{name}`"), callee.span.clone())
     })?;
+    let defaults = &lcx.param_defaults[&sig.func_id];
+    let required = defaults.iter().filter(|d| d.is_none()).count();
 
-    if args.len() != sig.params.len() {
+    if args.len() > sig.params.len() || args.len() < required {
         return Err(LowerError::new(
             format!(
                 "`{name}` takes {} argument(s), got {}",
-                sig.params.len(),
+                if required == sig.params.len() {
+                    required.to_string()
+                } else {
+                    format!("{required}-{}", sig.params.len())
+                },
                 args.len()
             ),
             call_span.clone(),
         ));
     }
 
-    let mut lowered_args = Vec::with_capacity(args.len());
+    let mut lowered_args = Vec::with_capacity(sig.params.len());
     for (arg, expected_ty) in args.iter().zip(&sig.params) {
         if arg.name.is_some() || arg.spread {
             return Err(LowerError::unsupported(
@@ -548,6 +554,17 @@ fn lower_call(
             lcx,
             table,
         )?);
+    }
+    // Every param beyond the supplied args is missing one — the arity check
+    // above already proved each has a default (`lower_param_defaults` clones
+    // the same pre-lowered `Expr` into every omitting call site, since KIR
+    // `Expr` trees aren't shared/interned).
+    for default in &defaults[args.len()..] {
+        lowered_args.push(
+            default
+                .clone()
+                .expect("arity check above proved every trailing param here has a default"),
+        );
     }
 
     Ok(Expr::Call {

--- a/crates/keel-kir/src/lower/mod.rs
+++ b/crates/keel-kir/src/lower/mod.rs
@@ -116,6 +116,13 @@ pub(crate) struct LowerCtx<'a> {
     /// See `lower_program`'s `lists` local for why this needs interior
     /// mutability (structurally discovered, not pre-declared).
     pub(crate) lists: &'a std::cell::RefCell<Vec<KirType>>,
+    /// Each task's per-parameter default-value expression (`None` for a
+    /// parameter with no default), indexed by `FuncId`, parallel to that
+    /// task's own param list. Lowered once per declaration in a separate,
+    /// param-free scope — see `lower_program`'s pass 2c — not per call site;
+    /// [`crate::lower::expr::lower_call`] clones the stored `Expr` into each
+    /// call that omits a trailing arg.
+    pub(crate) param_defaults: &'a HashMap<FuncId, Vec<Option<crate::ir::Expr>>>,
     /// Not consumed yet — #145 (named structs) resolves everything through
     /// context-threaded expected types instead (see `expr::lower_expr_expecting`).
     /// Becomes load-bearing for a construct the checker must resolve and
@@ -323,6 +330,36 @@ pub fn lower_program(
         }
     }
 
+    // Pass 2c: lower each task's parameter default-value expressions, now
+    // that every task signature and namespace binding is known (in case a
+    // default references either). Done via a bootstrap `LowerCtx` with an
+    // empty `param_defaults` — a default expression may not itself omit a
+    // defaulted argument of another call (an obscure case none of this
+    // codebase's examples need); everything else about default expressions
+    // (calls, namespace methods, literals) resolves normally. Each default
+    // is lowered once, in a fresh param-free `FnCtx`, not per call site.
+    let empty_param_defaults: HashMap<FuncId, Vec<Option<crate::ir::Expr>>> = HashMap::new();
+    let mut param_defaults: HashMap<FuncId, Vec<Option<crate::ir::Expr>>> = HashMap::new();
+    {
+        let bootstrap_lcx = LowerCtx {
+            funcs: &funcs,
+            ns_bindings: &ns_bindings,
+            structs_by_name: &structs_by_name,
+            struct_layouts: &struct_layouts,
+            enums_by_name: &enums_by_name,
+            enum_layouts: &enum_layouts,
+            lists: &lists,
+            param_defaults: &empty_param_defaults,
+            artifacts,
+        };
+        for task in &task_order {
+            let sig = &funcs[&task.name];
+            let defaults =
+                decl::lower_param_defaults(task, &sig.params, &bootstrap_lcx, &mut span_table)?;
+            param_defaults.insert(sig.func_id, defaults);
+        }
+    }
+
     let lcx = LowerCtx {
         funcs: &funcs,
         ns_bindings: &ns_bindings,
@@ -331,6 +368,7 @@ pub fn lower_program(
         enums_by_name: &enums_by_name,
         enum_layouts: &enum_layouts,
         lists: &lists,
+        param_defaults: &param_defaults,
         artifacts,
     };
 

--- a/crates/keel-kir/tests/fixtures/default_params.keel
+++ b/crates/keel-kir/tests/fixtures/default_params.keel
@@ -1,0 +1,6 @@
+task greet(name: str, greeting: str = "Hello") -> str {
+  return greeting + ", " + name + "!"
+}
+
+with_greeting = greet("Ada", "Hi")
+without_greeting = greet("Ada")

--- a/crates/keel-kir/tests/fixtures/default_params.kir
+++ b/crates/keel-kir/tests/fixtures/default_params.kir
@@ -1,0 +1,8 @@
+fn greet(name: str, greeting: str) -> str {
+  return (((greeting + ", ") + name) + "!")
+}
+
+fn <toplevel>() -> none {
+  let with_greeting: str = greet("Ada", "Hi")
+  let without_greeting: str = greet("Ada", "Hello")
+}

--- a/crates/keel-kir/tests/lower_errors.rs
+++ b/crates/keel-kir/tests/lower_errors.rs
@@ -592,3 +592,46 @@ task f() -> int {
         "unexpected message: {msg}"
     );
 }
+
+#[test]
+fn non_default_parameter_after_a_defaulted_one_is_rejected() {
+    let msg = lower_err(
+        r#"
+task f(a: int = 1, b: int) -> int {
+  return a + b
+}
+"#,
+    );
+    assert!(
+        msg.contains("defaults must be trailing"),
+        "unexpected message: {msg}"
+    );
+}
+
+#[test]
+fn call_omitting_a_non_default_argument_is_rejected() {
+    let msg = lower_err(
+        r#"
+task f(a: int, b: int = 2) -> int {
+  return a + b
+}
+
+x = f()
+"#,
+    );
+    assert!(msg.contains("takes"), "unexpected message: {msg}");
+}
+
+#[test]
+fn call_with_too_many_arguments_is_still_rejected() {
+    let msg = lower_err(
+        r#"
+task f(a: int, b: int = 2) -> int {
+  return a + b
+}
+
+x = f(1, 2, 3)
+"#,
+    );
+    assert!(msg.contains("takes"), "unexpected message: {msg}");
+}

--- a/crates/keel-runtime/src/interpreter/call.rs
+++ b/crates/keel-runtime/src/interpreter/call.rs
@@ -165,6 +165,14 @@ impl Interpreter {
             } else if let Some(v) = positional.get(pos_idx) {
                 pos_idx += 1;
                 (*v).clone()
+            } else if let Some(default) = &p.default {
+                // Mirrors `start_agent`'s state-field defaults: a fresh,
+                // param-free scope (a default may not reference the task's
+                // own other parameters).
+                let mut tmp_env = Environment::new();
+                match self.eval_expr(default, &mut tmp_env).await? {
+                    ExprFlow::Value(v) | ExprFlow::Return(v) => v,
+                }
             } else {
                 Value::None
             };


### PR DESCRIPTION
Close #164

## Summary

- Each parameter's default-value expression is lowered once per task declaration (in a fresh, param-free scope — a default may not reference the task's own other parameters) and stored alongside the task's signature, keyed by `FuncId`.
- `lower_call` fills in the stored default `Expr` for any trailing argument a call site omits, after confirming every missing param actually has one. Named/spread arguments are still unsupported (unchanged, separate scope) — this only unblocks the omitted-trailing-positional-arg shape.
- Defaults must be trailing: a non-default parameter declared after a defaulted one is rejected at lowering time, since call-site filling only handles omitted suffixes and the parser itself doesn't enforce this ordering.
- Extended the KIR golden-dump fixtures and `lower_errors.rs` (3 new tests: non-trailing default rejected, omitting a non-default arg rejected, too many args still rejected).

## Included fix (found while building the oracle test)

`interpreter/call.rs`'s `call_task_inner` substituted a hardcoded `Value::None` for *any* omitted argument, never actually evaluating the parameter's declared default expression — so a non-`none` default (e.g. `greeting: str = "Hello"`, called with the arg omitted) silently produced `none` instead of `"Hello"`. Confirmed via a direct interpreter run before touching anything. Fixed to evaluate the default in a fresh scope, mirroring how `start_agent`'s state-field defaults already work. All 429 existing `keel-runtime` tests plus the full conformance suite stayed green after the fix.

## Why this issue exists

Split out of #148 (nullable `?`/`??`/`?.`) during scoping: the checker only accepts a bare `none` literal in a parameter's default-value position (`let x: int? = none`, `return none`, and `none` as a call argument all fail to typecheck today), so a defaulted parameter called with the argument omitted is the only in-scope vehicle to construct a genuine scalar-nullable `none` at runtime for #148's exit criterion.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo clippy --workspace --all-targets --features build-backend -- -D warnings`
- [x] `cargo test --workspace` (all green)
- [x] `cargo test --workspace --features build-backend` (all green, including 2 new differential codegen-vs-interpreter tests in `crates/keel-codegen/tests/default_params.rs`)
- [x] `cargo test --workspace --features build-backend --test conformance` x3 for stability
- [x] Golden `--emit=kir` dump fixture (`default_params.keel`/`.kir`), stable across reruns
- [x] 43 tests in `keel-kir/tests/lower_errors.rs`