### PR TITLE
keel-kir + keel-codegen: nullable ?, ??, ?. end to end

### DIFF
--- a/crates/keel-codegen/src/expr.rs
+++ b/crates/keel-codegen/src/expr.rs
@@ -68,6 +68,18 @@ pub(crate) fn emit_expr<'ctx>(
             .const_int(*variant_index as u64, false)
             .into()),
         Expr::Index { list, index, ty } => crate::rt_call::emit_index(fcx, list, index, *ty),
+        Expr::NullLit { ty } => crate::nullable::emit_null_lit(fcx, *ty),
+        Expr::NullSome { value, ty } => crate::nullable::emit_null_some(fcx, value, *ty),
+        Expr::NullCoalesce {
+            nullable,
+            fallback,
+            ty,
+        } => crate::nullable::emit_null_coalesce(fcx, nullable, fallback, *ty),
+        Expr::NullFieldGet {
+            base,
+            field_index,
+            ty,
+        } => crate::nullable::emit_null_field_get(fcx, base, *field_index, *ty),
     }
 }
 
@@ -345,7 +357,7 @@ fn emit_binop<'ctx>(
             };
             Ok(result)
         }
-        KirType::Unit | KirType::Struct(_) | KirType::List(_) => {
+        KirType::Unit | KirType::Struct(_) | KirType::List(_) | KirType::Nullable(_) => {
             Err(unreachable_combo(op, operand_ty))
         }
     }

--- a/crates/keel-codegen/src/layout.rs
+++ b/crates/keel-codegen/src/layout.rs
@@ -46,6 +46,27 @@ pub(crate) fn llvm_type<'ctx>(
         }
         KirType::Enum(_) => Ok(context.i32_type().into()),
         KirType::List(_) => Ok(context.ptr_type(AddressSpace::default()).into()),
+        KirType::Nullable(id) => match program.nullables[id] {
+            // A nullable scalar has no spare pointer bit to steal, so it's
+            // an explicit `{ i1 has_value, T }` pair, by value.
+            KirType::I64 | KirType::F64 | KirType::Bool => {
+                let inner = llvm_type(context, program, program.nullables[id])?;
+                Ok(context
+                    .struct_type(&[context.bool_type().into(), inner], false)
+                    .into())
+            }
+            // A nullable struct/str/list is the same `ptr` as the
+            // non-nullable type — `none` is a null pointer for a struct, or
+            // a boxed `Value::None` for str/list (see `KirType::Nullable`'s
+            // doc); either way the LLVM-level representation is identical.
+            KirType::Struct(_) | KirType::Str | KirType::List(_) => {
+                Ok(context.ptr_type(AddressSpace::default()).into())
+            }
+            other => Err(CodegenError::Unsupported(format!(
+                "nullable `{other}` (only int/float/bool/str/list/struct inner types are \
+                 modeled — `is_nullable_inner_ty` should have rejected this at lowering time)"
+            ))),
+        },
     }
 }
 

--- a/crates/keel-codegen/src/lib.rs
+++ b/crates/keel-codegen/src/lib.rs
@@ -21,6 +21,7 @@ mod func;
 mod layout;
 mod link;
 mod ns_call;
+mod nullable;
 mod rt_call;
 mod stmt;
 

--- a/crates/keel-codegen/src/ns_call.rs
+++ b/crates/keel-codegen/src/ns_call.rs
@@ -114,6 +114,11 @@ pub(crate) fn emit_box_arg<'ctx>(
         // same representation `keel_rt_call_ns`/every `keel_list_*` expects)
         // — no extra boxing needed, same as `Str`.
         KirType::List(_) => Ok(emit_expr(fcx, arg)?.into_pointer_value()),
+        KirType::Nullable(_) => Err(CodegenError::Unsupported(
+            "nullable-typed argument to a namespace call (unwrap via `??` first — marshaling a \
+             nullable into a boxed Value is a later-M2/M3 concern)"
+                .to_string(),
+        )),
     }
 }
 

--- a/crates/keel-codegen/src/nullable.rs
+++ b/crates/keel-codegen/src/nullable.rs
@@ -1,0 +1,336 @@
+//! `T?` codegen — `Expr::NullLit`/`NullCoalesce`/`NullFieldGet`
+//! (`designs/llvm-compilation.md` §1.1's nullable representation split;
+//! §2.3: "`?.`/`??` -> explicit branches").
+//!
+//! Three representations, keyed off the nullable's *inner* type
+//! (`KirType::Nullable`'s doc has the full rationale):
+//! - **Scalar** (int/float/bool): an explicit `{ i1 has_value, T }` pair, by
+//!   value — no pointer to repurpose.
+//! - **Struct**: the same `ptr` as the non-nullable struct; `none` is a
+//!   plain null pointer (a native struct record is never `Value`-boxed, so
+//!   this costs nothing extra).
+//! - **Str/list**: also the same `ptr`, but `none` is a boxed `Value::None`
+//!   instead — str/list are already boxed `*const Value` pointers with no
+//!   null-pointer bit to spare (`keel-rt-ffi`'s `keel_box_none`/
+//!   `keel_is_none`).
+//!
+//! `?.`'s own null-check (whether the receiver *struct* is present) is
+//! always the cheap pointer-null check, regardless of what the accessed
+//! field's type is — only the field's *own* nullable-none-building (when
+//! the receiver is absent) or unwrapping (when present) depends on the
+//! field's type.
+
+use inkwell::AddressSpace;
+use inkwell::types::BasicTypeEnum;
+use inkwell::values::{BasicValueEnum, IntValue};
+
+use keel_kir::ir::{Expr, StructId};
+use keel_kir::types::KirType;
+
+use crate::CodegenError;
+use crate::func::FuncCtx;
+use crate::layout;
+use crate::ns_call::declare_or_get;
+use crate::rt_call::{call_ptr_fn, call_scalar_fn};
+
+fn llvm_err(e: impl std::fmt::Display) -> CodegenError {
+    CodegenError::Llvm(e.to_string())
+}
+
+fn nullable_inner<'ctx>(fcx: &FuncCtx<'ctx, '_>, ty: KirType) -> KirType {
+    let KirType::Nullable(id) = ty else {
+        unreachable!(
+            "caller only invokes this on a KirType::Nullable — keel-kir's verify pass \
+                      should have rejected anything else"
+        );
+    };
+    fcx.program.nullables[id]
+}
+
+/// Builds the `none` value of `ty` (always `KirType::Nullable(_)`).
+pub(crate) fn emit_null_lit<'ctx>(
+    fcx: &FuncCtx<'ctx, '_>,
+    ty: KirType,
+) -> Result<BasicValueEnum<'ctx>, CodegenError> {
+    let inner = nullable_inner(fcx, ty);
+    match inner {
+        KirType::I64 | KirType::F64 | KirType::Bool => {
+            let struct_ty = layout::llvm_type(fcx.context, fcx.program, ty)?.into_struct_type();
+            let zero: BasicValueEnum = match inner {
+                KirType::I64 => fcx.context.i64_type().const_zero().into(),
+                KirType::F64 => fcx.context.f64_type().const_zero().into(),
+                KirType::Bool => fcx.context.bool_type().const_zero().into(),
+                _ => unreachable!(),
+            };
+            let has_value = fcx.context.bool_type().const_zero();
+            Ok(struct_ty
+                .const_named_struct(&[has_value.into(), zero])
+                .into())
+        }
+        KirType::Struct(_) => Ok(fcx
+            .context
+            .ptr_type(AddressSpace::default())
+            .const_null()
+            .into()),
+        KirType::Str | KirType::List(_) => {
+            let ptr_type = fcx.context.ptr_type(AddressSpace::default());
+            let f = declare_or_get(fcx.module, "keel_box_none", || ptr_type.fn_type(&[], false));
+            call_ptr_fn(fcx, f, &[])
+        }
+        other => Err(CodegenError::Unsupported(format!(
+            "nullable `{other}` (only int/float/bool/str/list/struct inner types are modeled)"
+        ))),
+    }
+}
+
+/// Widens a plain, known-present `value` into `ty`'s (`KirType::Nullable`)
+/// "some" representation — the checker allows passing a non-nullable `T`
+/// wherever `T?` is expected (`Expr::NullSome`'s doc has the full
+/// rationale).
+pub(crate) fn emit_null_some<'ctx>(
+    fcx: &FuncCtx<'ctx, '_>,
+    value: &Expr,
+    ty: KirType,
+) -> Result<BasicValueEnum<'ctx>, CodegenError> {
+    let inner_ty = nullable_inner(fcx, ty);
+    let raw = crate::expr::emit_expr(fcx, value)?;
+    let nullable_llvm_ty = layout::llvm_type(fcx.context, fcx.program, ty)?;
+    emit_wrap_some(fcx, raw, inner_ty, nullable_llvm_ty)
+}
+
+/// Reports whether `val` (already-evaluated, of `inner_ty`'s nullable
+/// representation) is `none`.
+fn emit_is_none<'ctx>(
+    fcx: &FuncCtx<'ctx, '_>,
+    val: BasicValueEnum<'ctx>,
+    inner_ty: KirType,
+) -> Result<IntValue<'ctx>, CodegenError> {
+    match inner_ty {
+        KirType::I64 | KirType::F64 | KirType::Bool => {
+            let has_value = fcx
+                .builder
+                .build_extract_value(val.into_struct_value(), 0, "has_value")
+                .map_err(llvm_err)?
+                .into_int_value();
+            fcx.builder
+                .build_not(has_value, "is_none")
+                .map_err(llvm_err)
+        }
+        KirType::Struct(_) => fcx
+            .builder
+            .build_is_null(val.into_pointer_value(), "is_none")
+            .map_err(llvm_err),
+        KirType::Str | KirType::List(_) => {
+            let ptr_type = fcx.context.ptr_type(AddressSpace::default());
+            let f = declare_or_get(fcx.module, "keel_is_none", || {
+                fcx.context.i8_type().fn_type(&[ptr_type.into()], false)
+            });
+            let raw = call_scalar_fn(fcx, f, &[val.into()], "is_none_u8")?.into_int_value();
+            fcx.builder
+                .build_int_compare(
+                    inkwell::IntPredicate::NE,
+                    raw,
+                    fcx.context.i8_type().const_zero(),
+                    "is_none",
+                )
+                .map_err(llvm_err)
+        }
+        other => Err(CodegenError::Unsupported(format!(
+            "nullable `{other}` (only int/float/bool/str/list/struct inner types are modeled)"
+        ))),
+    }
+}
+
+/// Extracts the plain `inner_ty`-typed value out of a nullable's *known-
+/// present* ("some") representation — the inverse of [`emit_wrap_some`].
+/// A pointer-typed inner (str/list/struct) is already the right bits and
+/// passes through untouched; only a scalar pair needs unpacking.
+fn emit_unwrap_some<'ctx>(
+    fcx: &FuncCtx<'ctx, '_>,
+    val: BasicValueEnum<'ctx>,
+    inner_ty: KirType,
+) -> Result<BasicValueEnum<'ctx>, CodegenError> {
+    match inner_ty {
+        KirType::I64 | KirType::F64 | KirType::Bool => fcx
+            .builder
+            .build_extract_value(val.into_struct_value(), 1, "unwrap_some")
+            .map_err(llvm_err),
+        KirType::Struct(_) | KirType::Str | KirType::List(_) => Ok(val),
+        other => Err(CodegenError::Unsupported(format!(
+            "nullable `{other}` (only int/float/bool/str/list/struct inner types are modeled)"
+        ))),
+    }
+}
+
+/// Builds the nullable-`{ty}`'s "some" representation from a known-present,
+/// plain `inner_ty`-typed value — the inverse of [`emit_unwrap_some`].
+fn emit_wrap_some<'ctx>(
+    fcx: &FuncCtx<'ctx, '_>,
+    raw: BasicValueEnum<'ctx>,
+    inner_ty: KirType,
+    nullable_llvm_ty: BasicTypeEnum<'ctx>,
+) -> Result<BasicValueEnum<'ctx>, CodegenError> {
+    match inner_ty {
+        KirType::I64 | KirType::F64 | KirType::Bool => {
+            let struct_ty = nullable_llvm_ty.into_struct_type();
+            let has_value = fcx.context.bool_type().const_int(1, false);
+            let undef = struct_ty.get_undef();
+            let with_flag = fcx
+                .builder
+                .build_insert_value(undef, has_value, 0, "with_flag")
+                .map_err(llvm_err)?;
+            let with_value = fcx
+                .builder
+                .build_insert_value(with_flag, raw, 1, "with_value")
+                .map_err(llvm_err)?;
+            Ok(with_value.into_struct_value().into())
+        }
+        KirType::Struct(_) | KirType::Str | KirType::List(_) => Ok(raw),
+        other => Err(CodegenError::Unsupported(format!(
+            "nullable `{other}` (only int/float/bool/str/list/struct inner types are modeled)"
+        ))),
+    }
+}
+
+/// `nullable ?? fallback` — short-circuits: `fallback` is only evaluated
+/// (and only its basic block entered) when `nullable` is `none`.
+pub(crate) fn emit_null_coalesce<'ctx>(
+    fcx: &FuncCtx<'ctx, '_>,
+    nullable: &Expr,
+    fallback: &Expr,
+    ty: KirType,
+) -> Result<BasicValueEnum<'ctx>, CodegenError> {
+    let inner_ty = nullable_inner(fcx, nullable.ty());
+    let nullable_v = crate::expr::emit_expr(fcx, nullable)?;
+    let is_none = emit_is_none(fcx, nullable_v, inner_ty)?;
+
+    let result_llvm_ty = layout::llvm_type(fcx.context, fcx.program, ty)?;
+    let result_ptr = fcx
+        .builder
+        .build_alloca(result_llvm_ty, "nullcoalesce.result")
+        .map_err(llvm_err)?;
+
+    let some_bb = fcx
+        .context
+        .append_basic_block(fcx.function, "nullcoalesce.some");
+    let none_bb = fcx
+        .context
+        .append_basic_block(fcx.function, "nullcoalesce.none");
+    let merge_bb = fcx
+        .context
+        .append_basic_block(fcx.function, "nullcoalesce.merge");
+    fcx.builder
+        .build_conditional_branch(is_none, none_bb, some_bb)
+        .map_err(llvm_err)?;
+
+    fcx.builder.position_at_end(some_bb);
+    let some_val = emit_unwrap_some(fcx, nullable_v, inner_ty)?;
+    fcx.builder
+        .build_store(result_ptr, some_val)
+        .map_err(llvm_err)?;
+    fcx.builder
+        .build_unconditional_branch(merge_bb)
+        .map_err(llvm_err)?;
+
+    fcx.builder.position_at_end(none_bb);
+    let fallback_val = crate::expr::emit_expr(fcx, fallback)?;
+    fcx.builder
+        .build_store(result_ptr, fallback_val)
+        .map_err(llvm_err)?;
+    fcx.builder
+        .build_unconditional_branch(merge_bb)
+        .map_err(llvm_err)?;
+
+    fcx.builder.position_at_end(merge_bb);
+    fcx.builder
+        .build_load(result_llvm_ty, result_ptr, "nullcoalesce.load")
+        .map_err(llvm_err)
+}
+
+/// `base?.field` — `base` is a nullable-struct-typed expression;
+/// short-circuits to `none` (of the field's nullable type) without ever
+/// touching the field when `base` is `none`.
+pub(crate) fn emit_null_field_get<'ctx>(
+    fcx: &FuncCtx<'ctx, '_>,
+    base: &Expr,
+    field_index: usize,
+    ty: KirType,
+) -> Result<BasicValueEnum<'ctx>, CodegenError> {
+    let KirType::Struct(struct_id): KirType = nullable_inner(fcx, base.ty()) else {
+        return Err(CodegenError::Llvm(
+            "`?.` base's nullable inner type is not a struct — keel-kir's verify pass should \
+             have rejected this"
+                .to_string(),
+        ));
+    };
+    let base_ptr = crate::expr::emit_expr(fcx, base)?.into_pointer_value();
+    let is_none = fcx
+        .builder
+        .build_is_null(base_ptr, "base_is_none")
+        .map_err(llvm_err)?;
+
+    let result_llvm_ty = layout::llvm_type(fcx.context, fcx.program, ty)?;
+    let result_ptr = fcx
+        .builder
+        .build_alloca(result_llvm_ty, "nullfieldget.result")
+        .map_err(llvm_err)?;
+
+    let some_bb = fcx
+        .context
+        .append_basic_block(fcx.function, "nullfieldget.some");
+    let none_bb = fcx
+        .context
+        .append_basic_block(fcx.function, "nullfieldget.none");
+    let merge_bb = fcx
+        .context
+        .append_basic_block(fcx.function, "nullfieldget.merge");
+    fcx.builder
+        .build_conditional_branch(is_none, none_bb, some_bb)
+        .map_err(llvm_err)?;
+
+    fcx.builder.position_at_end(some_bb);
+    let some_val = emit_some_field(fcx, base_ptr, struct_id, field_index, ty, result_llvm_ty)?;
+    fcx.builder
+        .build_store(result_ptr, some_val)
+        .map_err(llvm_err)?;
+    fcx.builder
+        .build_unconditional_branch(merge_bb)
+        .map_err(llvm_err)?;
+
+    fcx.builder.position_at_end(none_bb);
+    let none_val = emit_null_lit(fcx, ty)?;
+    fcx.builder
+        .build_store(result_ptr, none_val)
+        .map_err(llvm_err)?;
+    fcx.builder
+        .build_unconditional_branch(merge_bb)
+        .map_err(llvm_err)?;
+
+    fcx.builder.position_at_end(merge_bb);
+    fcx.builder
+        .build_load(result_llvm_ty, result_ptr, "nullfieldget.load")
+        .map_err(llvm_err)
+}
+
+fn emit_some_field<'ctx>(
+    fcx: &FuncCtx<'ctx, '_>,
+    base_ptr: inkwell::values::PointerValue<'ctx>,
+    struct_id: StructId,
+    field_index: usize,
+    ty: KirType,
+    result_llvm_ty: BasicTypeEnum<'ctx>,
+) -> Result<BasicValueEnum<'ctx>, CodegenError> {
+    let layout_ty = layout::struct_layout_type(fcx.context, fcx.program, struct_id)?;
+    let field_index_u32 = u32::try_from(field_index).expect("struct field count fits u32");
+    let field_ptr = fcx
+        .builder
+        .build_struct_gep(layout_ty, base_ptr, field_index_u32, "field_ptr")
+        .map_err(llvm_err)?;
+    let field_ty = nullable_inner(fcx, ty);
+    let field_llvm_ty = layout::llvm_type(fcx.context, fcx.program, field_ty)?;
+    let raw_field = fcx
+        .builder
+        .build_load(field_llvm_ty, field_ptr, "field_load")
+        .map_err(llvm_err)?;
+    emit_wrap_some(fcx, raw_field, field_ty, result_llvm_ty)
+}

--- a/crates/keel-codegen/src/rt_call.rs
+++ b/crates/keel-codegen/src/rt_call.rs
@@ -144,15 +144,20 @@ pub(crate) fn unbox_value<'ctx>(
             Ok(b.into())
         }
         KirType::Str | KirType::List(_) => Ok(boxed.into()),
-        KirType::Unit | KirType::Struct(_) | KirType::Enum(_) => Err(CodegenError::Unsupported(
-            "a list element type other than int/float/bool/str (struct/enum elements need \
-             Value marshaling, a later M2/M3 concern)"
-                .to_string(),
-        )),
+        KirType::Unit | KirType::Struct(_) | KirType::Enum(_) | KirType::Nullable(_) => {
+            Err(CodegenError::Unsupported(
+                "a list element type other than int/float/bool/str (struct/enum/nullable \
+                 elements need Value marshaling, a later M2/M3 concern)"
+                    .to_string(),
+            ))
+        }
     }
 }
 
-fn call_ptr_fn<'ctx>(
+/// Calls a runtime-ABI function that always returns a `ptr` (a boxed
+/// `KeelBox` or similar), never void. Shared beyond this module's own
+/// `keel_list_*` calls by [`crate::nullable`] (`keel_box_none`).
+pub(crate) fn call_ptr_fn<'ctx>(
     fcx: &FuncCtx<'ctx, '_>,
     f: inkwell::values::FunctionValue<'ctx>,
     args: &[inkwell::values::BasicMetadataValueEnum<'ctx>],
@@ -169,7 +174,10 @@ fn call_ptr_fn<'ctx>(
     }
 }
 
-fn call_scalar_fn<'ctx>(
+/// Calls a runtime-ABI function that always returns a scalar, never void.
+/// Shared beyond this module's own `keel_unbox_*` calls by
+/// [`crate::nullable`] (`keel_is_none`).
+pub(crate) fn call_scalar_fn<'ctx>(
     fcx: &FuncCtx<'ctx, '_>,
     f: inkwell::values::FunctionValue<'ctx>,
     args: &[inkwell::values::BasicMetadataValueEnum<'ctx>],

--- a/crates/keel-codegen/tests/nullable.rs
+++ b/crates/keel-codegen/tests/nullable.rs
@@ -1,0 +1,70 @@
+//! Exit criterion for issue #148 (nullable `?`/`??`/`?.`): a program using
+//! `?.`, `??`, and a scalar nullable (`int?`) compiles, links, and matches
+//! the interpreter — including the case where the nullable is genuinely
+//! `none` at runtime, not just the non-null happy path.
+
+use std::process::Command;
+
+use keel_codegen::BuildOptions;
+
+#[path = "support/mod.rs"]
+mod support;
+
+fn compile_and_run(source: &str) -> std::process::Output {
+    let kir = support::parse_check_and_lower(source);
+
+    let out_dir = tempfile::tempdir().expect("create temp out dir");
+    let opts = BuildOptions {
+        out_dir: out_dir.path().to_path_buf(),
+        runtime_link_args: support::runtime_link_args().clone(),
+    };
+    let bin = keel_codegen::compile(&kir, &opts).expect("compile must succeed");
+    Command::new(&bin).output().expect("run compiled binary")
+}
+
+fn assert_matches_interpreter(source: &str, expected_stdout: &[u8]) {
+    let compiled = compile_and_run(source);
+    let interpreted = support::run_interpreter(source);
+
+    assert_eq!(
+        String::from_utf8_lossy(&compiled.stdout),
+        String::from_utf8_lossy(&interpreted.stdout),
+        "compiled stdout must match the interpreter's"
+    );
+    assert_eq!(compiled.stdout, expected_stdout);
+}
+
+#[test]
+fn null_coalesce_on_a_scalar_nullable_matches_the_interpreter_both_ways() {
+    let source = r#"
+use std/io
+
+task pick(n: int? = none) -> int {
+  return n ?? 0
+}
+
+io.show(pick(5))
+io.show(pick())
+"#;
+    assert_matches_interpreter(source, b"  5\n  0\n");
+}
+
+#[test]
+fn null_safe_field_access_matches_the_interpreter_both_ways() {
+    let source = r#"
+use std/io
+
+type Email {
+  subject: str
+}
+
+task greet(email: Email? = none) -> str {
+  return email?.subject ?? "(none)"
+}
+
+some_email: Email = { subject: "hello" }
+io.show(greet(some_email))
+io.show(greet())
+"#;
+    assert_matches_interpreter(source, b"  hello\n  (none)\n");
+}

--- a/crates/keel-kir/src/dump.rs
+++ b/crates/keel-kir/src/dump.rs
@@ -47,6 +47,7 @@ fn fmt_ty(program: &KirProgram, ty: KirType) -> String {
         KirType::Struct(id) => program.structs[id].name.clone(),
         KirType::Enum(id) => program.enums[id].name.clone(),
         KirType::List(id) => format!("list[{}]", fmt_ty(program, program.lists[id])),
+        KirType::Nullable(id) => format!("{}?", fmt_ty(program, program.nullables[id])),
         other => other.to_string(),
     }
 }
@@ -248,6 +249,30 @@ fn fmt_expr(program: &KirProgram, func: &KirFunction, expr: &Expr) -> String {
                 fmt_expr(program, func, list),
                 fmt_expr(program, func, index)
             )
+        }
+        Expr::NullLit { .. } => "none".to_string(),
+        Expr::NullSome { value, .. } => fmt_expr(program, func, value),
+        Expr::NullCoalesce {
+            nullable, fallback, ..
+        } => format!(
+            "({} ?? {})",
+            fmt_expr(program, func, nullable),
+            fmt_expr(program, func, fallback)
+        ),
+        Expr::NullFieldGet {
+            base, field_index, ..
+        } => {
+            let Expr::Local { ty, .. } = base.as_ref() else {
+                return format!("{}?.#{field_index}", fmt_expr(program, func, base));
+            };
+            let KirType::Nullable(nullable_id) = ty else {
+                return format!("{}?.#{field_index}", fmt_expr(program, func, base));
+            };
+            let KirType::Struct(struct_id) = program.nullables[*nullable_id] else {
+                return format!("{}?.#{field_index}", fmt_expr(program, func, base));
+            };
+            let field_name = &program.structs[struct_id].fields[*field_index].0;
+            format!("{}?.{field_name}", fmt_expr(program, func, base))
         }
     }
 }

--- a/crates/keel-kir/src/ir.rs
+++ b/crates/keel-kir/src/ir.rs
@@ -34,6 +34,11 @@ pub type EnumId = usize;
 /// program is the same `ListId` — see `lower/mod.rs`'s list-interning doc.
 pub type ListId = usize;
 
+/// Index into `KirProgram::nullables` — a *structural* intern id, same
+/// rationale as `ListId`: `int?` written anywhere in the program is the same
+/// `NullableId`.
+pub type NullableId = usize;
+
 /// A whole lowered program (currently: a single file's tasks + its
 /// top-level statements — multi-module lowering is deferred until the
 /// `keel-compiler` `ModuleGraph`/`CheckArtifacts` seam lands, see `lib.rs`).
@@ -62,6 +67,11 @@ pub struct KirProgram {
     /// marshaling that doesn't exist yet (deferred, see `lower/expr.rs`'s
     /// list-literal lowering doc).
     pub lists: Vec<KirType>,
+    /// Every distinct nullable inner type interned so far (structural, not
+    /// declaration order — see `NullableId`'s doc). Only int/float/bool/str/
+    /// list/struct inner types are modeled — see
+    /// `lower::is_nullable_inner_ty`.
+    pub nullables: Vec<KirType>,
     pub span_table: SpanTable,
 }
 
@@ -268,6 +278,45 @@ pub enum Expr {
         index: Box<Expr>,
         ty: KirType,
     },
+    /// The `none` value of a nullable type (`ty` is always `KirType::
+    /// Nullable(_)`) — only reachable via a `none` literal lowered against an
+    /// already-known expected nullable type (`lower_expr_expecting`; `none`
+    /// has no type of its own to infer bottom-up). Codegen builds the
+    /// representation matching `ty`'s inner type (§1.1: null pointer for a
+    /// nullable struct, a boxed `Value::None` for a nullable str/list, an
+    /// `{ i1 false, T }` pair for a nullable scalar).
+    NullLit {
+        ty: KirType,
+    },
+    /// Widens a plain, known-present `inner`-typed value into `ty`'s
+    /// (`KirType::Nullable(inner)`) "some" representation — the checker
+    /// allows passing a non-nullable `T` wherever `T?` is expected (`SPEC.md`
+    /// §4's nullable-safety rule is one-directional: unwrapping the *other*
+    /// way needs `?.`/`??`/an assert). A pointer-typed inner is already the
+    /// right bits (no wrapping, just a relabeled `KirType`); a scalar inner
+    /// becomes an `{ i1 true, T }` pair.
+    NullSome {
+        value: Box<Expr>,
+        ty: KirType,
+    },
+    /// `nullable ?? fallback` — short-circuits: `fallback` is only evaluated
+    /// when `nullable` is `none` (§2.3: "`?.`/`??` → explicit branches").
+    /// `ty` is `nullable`'s unwrapped inner type (== `fallback`'s type).
+    NullCoalesce {
+        nullable: Box<Expr>,
+        fallback: Box<Expr>,
+        ty: KirType,
+    },
+    /// `base?.field` — `base` is a nullable-struct-typed expression;
+    /// short-circuits to `none` without touching the field when `base` is
+    /// `none`. `ty` is `KirType::Nullable(field_ty)` (the field's own type,
+    /// re-wrapped) — resolved at lowering time via `StructLayout::
+    /// field_index`, same as `FieldGet`.
+    NullFieldGet {
+        base: Box<Expr>,
+        field_index: usize,
+        ty: KirType,
+    },
 }
 
 /// What an `Expr::Call` invokes.
@@ -317,7 +366,11 @@ impl Expr {
             | Expr::FieldGet { ty, .. } => *ty,
             Expr::MakeStruct { struct_id, .. } => KirType::Struct(*struct_id),
             Expr::MakeEnum { enum_id, .. } => KirType::Enum(*enum_id),
-            Expr::Index { ty, .. } => *ty,
+            Expr::Index { ty, .. }
+            | Expr::NullLit { ty }
+            | Expr::NullSome { ty, .. }
+            | Expr::NullCoalesce { ty, .. }
+            | Expr::NullFieldGet { ty, .. } => *ty,
         }
     }
 }

--- a/crates/keel-kir/src/lower/decl.rs
+++ b/crates/keel-kir/src/lower/decl.rs
@@ -22,6 +22,7 @@ pub(crate) fn signature_of(
     structs_by_name: &HashMap<String, StructId>,
     enums_by_name: &HashMap<String, EnumId>,
     lists: &std::cell::RefCell<Vec<KirType>>,
+    nullables: &std::cell::RefCell<Vec<KirType>>,
 ) -> Result<(Vec<KirType>, KirType), LowerError> {
     if !task.type_params.is_empty() {
         return Err(LowerError::unsupported(
@@ -56,10 +57,11 @@ pub(crate) fn signature_of(
             structs_by_name,
             enums_by_name,
             lists,
+            nullables,
         )?);
     }
     let ret = match &task.return_type {
-        Some(ty) => ty_expr_to_kir(ty, structs_by_name, enums_by_name, lists)?,
+        Some(ty) => ty_expr_to_kir(ty, structs_by_name, enums_by_name, lists, nullables)?,
         None => KirType::Unit,
     };
     Ok((params, ret))

--- a/crates/keel-kir/src/lower/expr.rs
+++ b/crates/keel-kir/src/lower/expr.rs
@@ -3,12 +3,15 @@
 //! calls to other lowered tasks) plus M1's stdlib namespace calls
 //! (`io.show(...)`, `log.info(...)` — see [`lower_call`]), M2's named-
 //! struct literals, spread-update, field access, simple-enum variant
-//! construction (`Priority.low`), and `list[T]` literals/`push`/`len`/
-//! indexing (`T` restricted to int/float/bool/str — see [`lower_list_lit`]).
-//! Everything else (casts, `if`/`when` as expressions, lambdas, set/tuple
-//! literals, string interpolation, `?.`/`??`, pipelines, duration literals,
-//! rich (payload-carrying) enum variants, non-list method calls/indexing)
-//! is rejected; see module docs on `lower/mod.rs`.
+//! construction (`Priority.low`), `list[T]` literals/`push`/`len`/indexing
+//! (`T` restricted to int/float/bool/str — see [`lower_list_lit`]), and
+//! nullable `?.`/`??`/a `none` literal against a known expected nullable
+//! type (inner restricted to int/float/bool/str/list/struct — see
+//! `lower/mod.rs`'s `is_nullable_inner_ty`). Everything else (casts, `if`/
+//! `when` as expressions, lambdas, set/tuple literals, string
+//! interpolation, `!`/`!.` null-assert, pipelines, duration literals, rich
+//! (payload-carrying) enum variants, non-list method calls/indexing) is
+//! rejected; see module docs on `lower/mod.rs`.
 
 use std::collections::HashMap;
 
@@ -66,7 +69,15 @@ pub(crate) fn infer_binop_ty(
             }
         }
         Eq | Neq => {
-            if left == right {
+            if matches!(left, KirType::Nullable(_)) || matches!(right, KirType::Nullable(_)) {
+                Err(LowerError::new(
+                    format!(
+                        "cannot compare nullable `{left}` and `{right}` for equality \
+                         (unwrap via `??` first)"
+                    ),
+                    span.clone(),
+                ))
+            } else if left == right {
                 Ok(KirType::Bool)
             } else {
                 Err(LowerError::new(
@@ -203,10 +214,37 @@ pub(crate) fn lower_expr(
                 ty,
             })
         }
-        ast::Expr::NullFieldAccess(..) => Err(LowerError::unsupported(
-            "null-safe field access",
-            expr.span.clone(),
-        )),
+        ast::Expr::NullFieldAccess(base, field) => {
+            let base_e = lower_expr(base, ctx, lcx, table)?;
+            let KirType::Nullable(nullable_id) = base_e.ty() else {
+                return Err(LowerError::unsupported(
+                    "`?.` on a non-nullable value (only a nullable-struct receiver is lowered \
+                     so far)",
+                    expr.span.clone(),
+                ));
+            };
+            let KirType::Struct(struct_id) = lcx.nullables.borrow()[nullable_id] else {
+                return Err(LowerError::unsupported(
+                    "`?.` on a nullable non-struct value (str/list/scalar field access isn't \
+                     meaningful — only a nullable struct has fields)",
+                    expr.span.clone(),
+                ));
+            };
+            let layout = &lcx.struct_layouts[struct_id];
+            let field_index = layout.field_index(field).ok_or_else(|| {
+                LowerError::new(
+                    format!("struct `{}` has no field `{field}`", layout.name),
+                    expr.span.clone(),
+                )
+            })?;
+            let field_ty = layout.fields[field_index].1;
+            let ty = KirType::Nullable(super::intern_nullable(lcx.nullables, field_ty));
+            Ok(Expr::NullFieldGet {
+                base: Box::new(base_e),
+                field_index,
+                ty,
+            })
+        }
         ast::Expr::NullAssert(_) => Err(LowerError::unsupported("null-assert", expr.span.clone())),
         ast::Expr::SelfAccess { .. } => {
             Err(LowerError::unsupported("self access", expr.span.clone()))
@@ -229,7 +267,22 @@ pub(crate) fn lower_expr(
         ast::Expr::ListLit(items) => lower_list_lit(items, &expr.span, ctx, lcx, table),
         ast::Expr::SetLit(_) => Err(LowerError::unsupported("set literal", expr.span.clone())),
         ast::Expr::TupleLit(_) => Err(LowerError::unsupported("tuple literal", expr.span.clone())),
-        ast::Expr::NullCoalesce(..) => Err(LowerError::unsupported("`??`", expr.span.clone())),
+        ast::Expr::NullCoalesce(nullable, fallback) => {
+            let nullable_e = lower_expr(nullable, ctx, lcx, table)?;
+            let KirType::Nullable(nullable_id) = nullable_e.ty() else {
+                return Err(LowerError::unsupported(
+                    "`??` on a non-nullable left-hand side",
+                    expr.span.clone(),
+                ));
+            };
+            let inner_ty = lcx.nullables.borrow()[nullable_id];
+            let fallback_e = lower_expr_expecting(fallback, inner_ty, ctx, lcx, table)?;
+            Ok(Expr::NullCoalesce {
+                nullable: Box::new(nullable_e),
+                fallback: Box::new(fallback_e),
+                ty: inner_ty,
+            })
+        }
         ast::Expr::Pipeline(..) => Err(LowerError::unsupported("`|>` pipeline", expr.span.clone())),
         ast::Expr::Range(..) => Err(LowerError::unsupported("range", expr.span.clone())),
         ast::Expr::MethodCall {
@@ -328,6 +381,44 @@ pub(crate) fn lower_expr_expecting(
             }
             _ => {}
         }
+    }
+    // `none` has no type of its own to infer bottom-up (`lower_expr` rejects
+    // it outright) — the checker only accepts a bare `none` literal where an
+    // expected nullable type already pins one (a param default, a `let`
+    // annotation, a call argument, a nullable struct field), so this is the
+    // only place it resolves.
+    if let KirType::Nullable(id) = expected {
+        if matches!(expr.kind, ast::Expr::None_) {
+            return Ok(Expr::NullLit { ty: expected });
+        }
+        // The checker allows passing a non-nullable `T` wherever `T?` is
+        // expected (widening, one-directional — the other way needs `?.`/
+        // `??`/an assert). Bottom-up lowering already handles anything
+        // that's *already* `Nullable(inner)`-typed (an identifier bound
+        // `T?`, `?.`/`??` results, …) as well as a plain `inner`-typed value
+        // that needs wrapping; a raw struct literal assigned directly to a
+        // nullable-struct position isn't supported yet (every M2 fixture
+        // binds the struct to a name first).
+        let inner_ty = lcx.nullables.borrow()[id];
+        let lowered = lower_expr(expr, ctx, lcx, table)?;
+        if lowered.ty() == expected {
+            return Ok(lowered);
+        }
+        if lowered.ty() == inner_ty {
+            return Ok(Expr::NullSome {
+                value: Box::new(lowered),
+                ty: expected,
+            });
+        }
+        return Err(LowerError::new(
+            format!(
+                "expected `{}` or `{}`, got `{}`",
+                describe_ty(expected, lcx),
+                describe_ty(inner_ty, lcx),
+                describe_ty(lowered.ty(), lcx)
+            ),
+            expr.span.clone(),
+        ));
     }
     let lowered = lower_expr(expr, ctx, lcx, table)?;
     if lowered.ty() != expected {

--- a/crates/keel-kir/src/lower/mod.rs
+++ b/crates/keel-kir/src/lower/mod.rs
@@ -51,7 +51,8 @@ use keel_syntax::ast::{Binding, Decl, Program, TypeDef, UseDecl, UseKind, UseSou
 use keel_syntax::lexer::Span;
 
 use crate::ir::{
-    EnumId, EnumLayout, FuncId, KirFunction, KirProgram, ListId, LocalId, StructId, StructLayout,
+    EnumId, EnumLayout, FuncId, KirFunction, KirProgram, ListId, LocalId, NullableId, StructId,
+    StructLayout,
 };
 use crate::span_table::SpanTable;
 use crate::types::KirType;
@@ -116,6 +117,8 @@ pub(crate) struct LowerCtx<'a> {
     /// See `lower_program`'s `lists` local for why this needs interior
     /// mutability (structurally discovered, not pre-declared).
     pub(crate) lists: &'a std::cell::RefCell<Vec<KirType>>,
+    /// Same interior-mutability rationale as `lists`, for `T?` shapes.
+    pub(crate) nullables: &'a std::cell::RefCell<Vec<KirType>>,
     /// Each task's per-parameter default-value expression (`None` for a
     /// parameter with no default), indexed by `FuncId`, parallel to that
     /// task's own param list. Lowered once per declaration in a separate,
@@ -225,6 +228,8 @@ pub fn lower_program(
     // `LowerCtx` otherwise fully immutable/shared (see its doc) while still
     // letting every lowering function grow this table via `intern_list`.
     let lists: std::cell::RefCell<Vec<KirType>> = std::cell::RefCell::new(Vec::new());
+    // Same structural-interning rationale as `lists`, for `T?` shapes.
+    let nullables: std::cell::RefCell<Vec<KirType>> = std::cell::RefCell::new(Vec::new());
 
     // Pass 1a: reserve a `StructId` for every named struct declaration
     // before resolving any field types, so a field can reference another
@@ -286,7 +291,13 @@ pub fn lower_program(
         for field in ast_fields {
             fields.push((
                 field.name.clone(),
-                ty_expr_to_kir(&field.ty, &structs_by_name, &enums_by_name, &lists)?,
+                ty_expr_to_kir(
+                    &field.ty,
+                    &structs_by_name,
+                    &enums_by_name,
+                    &lists,
+                    &nullables,
+                )?,
             ));
         }
         struct_layouts.push(StructLayout {
@@ -304,7 +315,7 @@ pub fn lower_program(
         match &decl.kind {
             Decl::Task(task) => {
                 let (params, ret) =
-                    decl::signature_of(task, &structs_by_name, &enums_by_name, &lists)?;
+                    decl::signature_of(task, &structs_by_name, &enums_by_name, &lists, &nullables)?;
                 let func_id = task_order.len();
                 task_order.push(task);
                 funcs.insert(
@@ -349,6 +360,7 @@ pub fn lower_program(
             enums_by_name: &enums_by_name,
             enum_layouts: &enum_layouts,
             lists: &lists,
+            nullables: &nullables,
             param_defaults: &empty_param_defaults,
             artifacts,
         };
@@ -368,6 +380,7 @@ pub fn lower_program(
         enums_by_name: &enums_by_name,
         enum_layouts: &enum_layouts,
         lists: &lists,
+        nullables: &nullables,
         param_defaults: &param_defaults,
         artifacts,
     };
@@ -410,6 +423,7 @@ pub fn lower_program(
         structs: struct_layouts,
         enums: enum_layouts,
         lists: lists.into_inner(),
+        nullables: nullables.into_inner(),
         span_table,
     })
 }
@@ -479,6 +493,7 @@ pub(crate) fn ty_expr_to_kir(
     structs_by_name: &HashMap<String, StructId>,
     enums_by_name: &HashMap<String, EnumId>,
     lists: &std::cell::RefCell<Vec<KirType>>,
+    nullables: &std::cell::RefCell<Vec<KirType>>,
 ) -> Result<KirType, LowerError> {
     use keel_syntax::ast::TypeExpr;
     match &ty.kind {
@@ -501,14 +516,38 @@ pub(crate) fn ty_expr_to_kir(
                 }
             }
         },
-        TypeExpr::Nullable(_) => Err(LowerError::unsupported("nullable type", ty.span.clone())),
+        TypeExpr::Nullable(inner) => {
+            // Same no-own-span situation as `TypeExpr::List` below.
+            let inner_node = keel_syntax::ast::Node::new((**inner).clone(), ty.span.clone());
+            let inner_ty = ty_expr_to_kir(
+                &inner_node,
+                structs_by_name,
+                enums_by_name,
+                lists,
+                nullables,
+            )?;
+            if !is_nullable_inner_ty(inner_ty) {
+                return Err(LowerError::unsupported(
+                    "nullable inner type other than int/float/bool/str/list/struct (enum and \
+                     nested-nullable inner types are a later M2/M3 concern)",
+                    ty.span.clone(),
+                ));
+            }
+            Ok(KirType::Nullable(intern_nullable(nullables, inner_ty)))
+        }
         TypeExpr::List(inner) => {
             // `TypeExpr::List` boxes a bare `TypeExpr`, not a `Node<TypeExpr>`
             // (no span of its own — see `keel-syntax`'s `ast::ty::TypeExpr`),
             // so diagnostics about the element type fall back to the whole
             // `list[...]` annotation's span.
             let inner_node = keel_syntax::ast::Node::new((**inner).clone(), ty.span.clone());
-            let elem_ty = ty_expr_to_kir(&inner_node, structs_by_name, enums_by_name, lists)?;
+            let elem_ty = ty_expr_to_kir(
+                &inner_node,
+                structs_by_name,
+                enums_by_name,
+                lists,
+                nullables,
+            )?;
             if !is_list_element_ty(elem_ty) {
                 return Err(LowerError::unsupported(
                     "list element type other than int/float/bool/str (struct/enum elements \
@@ -555,6 +594,37 @@ pub(crate) fn intern_list(lists: &std::cell::RefCell<Vec<KirType>>, elem: KirTyp
     }
     lists.push(elem);
     lists.len() - 1
+}
+
+/// `true` for the inner types a nullable (`T?`) can wrap today —
+/// int/float/bool/str/list/struct, per §1.1's representation split (see
+/// `KirType::Nullable`'s doc). `enum`/`none`/nested-nullable inner types are
+/// a later M2/M3 concern, rejected with a clear message rather than
+/// silently building a bad representation.
+pub(crate) fn is_nullable_inner_ty(ty: KirType) -> bool {
+    matches!(
+        ty,
+        KirType::I64
+            | KirType::F64
+            | KirType::Bool
+            | KirType::Str
+            | KirType::List(_)
+            | KirType::Struct(_)
+    )
+}
+
+/// Interns `inner` into `nullables`, returning its `NullableId` — same
+/// structural (not declaration-order) interning as [`intern_list`].
+pub(crate) fn intern_nullable(
+    nullables: &std::cell::RefCell<Vec<KirType>>,
+    inner: KirType,
+) -> NullableId {
+    let mut nullables = nullables.borrow_mut();
+    if let Some(id) = nullables.iter().position(|t| *t == inner) {
+        return id;
+    }
+    nullables.push(inner);
+    nullables.len() - 1
 }
 
 /// Extracts the plain identifier a `Binding` names, rejecting destructuring

--- a/crates/keel-kir/src/lower/stmt.rs
+++ b/crates/keel-kir/src/lower/stmt.rs
@@ -61,6 +61,7 @@ pub(crate) fn lower_stmt(
                     lcx.structs_by_name,
                     lcx.enums_by_name,
                     lcx.lists,
+                    lcx.nullables,
                 )?;
                 lower_expr_expecting(value, expected, ctx, lcx, table)?
             } else if let ast::Expr::StructSpreadUpdate { base, .. } = &value.kind {

--- a/crates/keel-kir/src/passes/verify.rs
+++ b/crates/keel-kir/src/passes/verify.rs
@@ -134,6 +134,16 @@ fn check_list(program: &KirProgram, id: crate::ir::ListId) -> Result<(), String>
     Ok(())
 }
 
+fn check_nullable(program: &KirProgram, id: crate::ir::NullableId) -> Result<(), String> {
+    if id >= program.nullables.len() {
+        return Err(format!(
+            "NullableId {id} out of range ({} nullables)",
+            program.nullables.len()
+        ));
+    }
+    Ok(())
+}
+
 fn verify_block(program: &KirProgram, func: &KirFunction, block: &Block) -> Result<(), String> {
     for stmt in block {
         verify_stmt(program, func, stmt)?;
@@ -374,6 +384,91 @@ fn verify_expr(program: &KirProgram, func: &KirFunction, expr: &Expr) -> Result<
             if declared_elem != *ty {
                 return Err(format!(
                     "index claims type {ty} but the list holds {declared_elem}"
+                ));
+            }
+            Ok(())
+        }
+        Expr::NullLit { ty } => {
+            let KirType::Nullable(id) = ty else {
+                return Err(format!("NullLit claims non-nullable type {ty}"));
+            };
+            check_nullable(program, *id)
+        }
+        Expr::NullSome { value, ty } => {
+            verify_expr(program, func, value)?;
+            let KirType::Nullable(id) = ty else {
+                return Err(format!("NullSome claims non-nullable type {ty}"));
+            };
+            check_nullable(program, *id)?;
+            let inner = program.nullables[*id];
+            if value.ty() != inner {
+                return Err(format!(
+                    "NullSome wraps a {} value but claims inner type {inner}",
+                    value.ty()
+                ));
+            }
+            Ok(())
+        }
+        Expr::NullCoalesce {
+            nullable,
+            fallback,
+            ty,
+        } => {
+            verify_expr(program, func, nullable)?;
+            verify_expr(program, func, fallback)?;
+            let KirType::Nullable(id) = nullable.ty() else {
+                return Err(format!(
+                    "`??` left-hand side is {}, expected a nullable",
+                    nullable.ty()
+                ));
+            };
+            check_nullable(program, id)?;
+            let inner = program.nullables[id];
+            if inner != *ty {
+                return Err(format!(
+                    "`??` claims type {ty} but the nullable's inner type is {inner}"
+                ));
+            }
+            if fallback.ty() != *ty {
+                return Err(format!("`??` fallback is {}, expected {ty}", fallback.ty()));
+            }
+            Ok(())
+        }
+        Expr::NullFieldGet {
+            base,
+            field_index,
+            ty,
+        } => {
+            verify_expr(program, func, base)?;
+            let KirType::Nullable(base_nullable_id) = base.ty() else {
+                return Err(format!("`?.` base is {}, expected a nullable", base.ty()));
+            };
+            check_nullable(program, base_nullable_id)?;
+            let KirType::Struct(struct_id) = program.nullables[base_nullable_id] else {
+                return Err(format!(
+                    "`?.` base's nullable inner type is {}, expected a struct",
+                    program.nullables[base_nullable_id]
+                ));
+            };
+            check_struct(program, struct_id)?;
+            let layout = &program.structs[struct_id];
+            if *field_index >= layout.fields.len() {
+                return Err(format!(
+                    "`?.` field index {field_index} out of range for `{}` ({} fields)",
+                    layout.name,
+                    layout.fields.len()
+                ));
+            }
+            let field_ty = layout.fields[*field_index].1;
+            let KirType::Nullable(result_nullable_id) = ty else {
+                return Err(format!("`?.` claims non-nullable type {ty}"));
+            };
+            check_nullable(program, *result_nullable_id)?;
+            let declared = program.nullables[*result_nullable_id];
+            if declared != field_ty {
+                return Err(format!(
+                    "`?.` on `{}.{}` claims inner type {declared} but the field is {field_ty}",
+                    layout.name, layout.fields[*field_index].0
                 ));
             }
             Ok(())

--- a/crates/keel-kir/src/types.rs
+++ b/crates/keel-kir/src/types.rs
@@ -8,7 +8,7 @@
 //! modeled yet; adding them is later-M2+ work, done alongside the lowering
 //! support that produces them.
 
-use crate::ir::{EnumId, KirProgram, ListId, StructId};
+use crate::ir::{EnumId, KirProgram, ListId, NullableId, StructId};
 
 /// A KIR-level type. Every KIR expression carries one.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -41,6 +41,18 @@ pub enum KirType {
     /// mutation `Value::List` (opaque to codegen; every operation is a
     /// `CallTarget::Rt` runtime call, `designs/llvm-compilation.md` §2.7).
     List(ListId),
+    /// `T?` (inner restricted to int/float/bool/str/list/struct — see
+    /// `KirProgram::nullables`'s doc and `lower::is_nullable_inner_ty`). Per
+    /// §1.1's representation split: a nullable *struct* is the same `ptr` as
+    /// the non-nullable struct, with a null pointer meaning `none` (a native
+    /// struct record is never `Value`-boxed, so null costs nothing extra); a
+    /// nullable str/list is also the same `ptr`, but `none` is a boxed
+    /// `Value::None` instead (str/list are already boxed `*const Value`
+    /// pointers with no null-pointer bit to spare — see `keel-rt-ffi`'s
+    /// `keel_box_none`/`keel_is_none`); a nullable scalar (int/float/bool)
+    /// has no pointer to repurpose at all, so it's an explicit
+    /// `{ i1 has_value, T }` pair, by value.
+    Nullable(NullableId),
 }
 
 impl KirType {
@@ -60,6 +72,7 @@ impl KirType {
             KirType::Struct(_) => "struct",
             KirType::Enum(_) => "enum",
             KirType::List(_) => "list",
+            KirType::Nullable(_) => "nullable",
         }
     }
 
@@ -80,6 +93,14 @@ impl KirType {
             KirType::Struct(id) => program.structs[id].is_heap(program),
             KirType::List(_) => true,
             KirType::I64 | KirType::F64 | KirType::Bool | KirType::Unit | KirType::Enum(_) => false,
+            // A nullable scalar is a by-value `{ i1, T }` pair, not a
+            // pointer — everything else nullable wraps a `ptr` (see
+            // `KirType::Nullable`'s doc). `is_nullable_inner_ty` guarantees
+            // no other inner type is ever interned.
+            KirType::Nullable(id) => !matches!(
+                program.nullables[id],
+                KirType::I64 | KirType::F64 | KirType::Bool
+            ),
         }
     }
 

--- a/crates/keel-kir/tests/fixtures/nullable.keel
+++ b/crates/keel-kir/tests/fixtures/nullable.keel
@@ -1,0 +1,17 @@
+type Email {
+  subject: str
+}
+
+task greet(email: Email? = none) -> str {
+  return email?.subject ?? "(none)"
+}
+
+task pick(n: int? = none) -> int {
+  return n ?? 0
+}
+
+some_email: Email = { subject: "hello" }
+greeted = greet(some_email)
+greeted_default = greet()
+picked = pick(5)
+picked_default = pick()

--- a/crates/keel-kir/tests/fixtures/nullable.kir
+++ b/crates/keel-kir/tests/fixtures/nullable.kir
@@ -1,0 +1,17 @@
+struct Email { subject: str }
+
+fn greet(email: Email?) -> str {
+  return (email?.subject ?? "(none)")
+}
+
+fn pick(n: int?) -> int {
+  return (n ?? 0)
+}
+
+fn <toplevel>() -> none {
+  let some_email: Email = Email { subject: "hello" }
+  let greeted: str = greet(some_email)
+  let greeted_default: str = greet(none)
+  let picked: int = pick(5)
+  let picked_default: int = pick(none)
+}

--- a/crates/keel-kir/tests/lower_errors.rs
+++ b/crates/keel-kir/tests/lower_errors.rs
@@ -635,3 +635,71 @@ x = f(1, 2, 3)
     );
     assert!(msg.contains("takes"), "unexpected message: {msg}");
 }
+
+#[test]
+fn null_safe_field_access_on_a_non_nullable_value_is_rejected() {
+    let msg = lower_err(
+        r#"
+type Email { subject: str }
+
+task f(email: Email) -> str? {
+  return email?.subject
+}
+"#,
+    );
+    assert!(
+        msg.contains("non-nullable value"),
+        "unexpected message: {msg}"
+    );
+}
+
+#[test]
+fn null_coalesce_on_a_non_nullable_left_hand_side_is_rejected() {
+    let msg = lower_err(
+        r#"
+task f() -> int {
+  return 1 ?? 0
+}
+"#,
+    );
+    assert!(
+        msg.contains("non-nullable left-hand side"),
+        "unexpected message: {msg}"
+    );
+}
+
+#[test]
+fn nullable_enum_inner_type_is_rejected() {
+    let msg = lower_err(
+        r#"
+type Priority = low | medium | high
+
+task f(p: Priority? = none) -> Priority {
+  return p ?? Priority.low
+}
+"#,
+    );
+    assert!(
+        msg.contains("nullable inner type"),
+        "unexpected message: {msg}"
+    );
+}
+
+#[test]
+fn equality_comparison_between_nullable_values_is_rejected() {
+    // `T?` has no single-value representation to compare bitwise/structurally
+    // for scalar inner types (the `{i1, T}` pair) — scope this issue to the
+    // nullable-value operators (`?.`, `??`) only; unwrap via `??` before
+    // comparing.
+    let msg = lower_err(
+        r#"
+task f(a: int? = none, b: int? = none) -> bool {
+  return a == b
+}
+"#,
+    );
+    assert!(
+        msg.contains("cannot compare nullable"),
+        "unexpected message: {msg}"
+    );
+}

--- a/crates/keel-rt-ffi/src/abi/mod.rs
+++ b/crates/keel-rt-ffi/src/abi/mod.rs
@@ -44,6 +44,32 @@ pub extern "C" fn keel_box_bool(v: u8) -> *const Value {
     Arc::into_raw(Arc::new(Value::Bool(v != 0)))
 }
 
+/// Boxes `none` — the `none` sentinel for a pointer-typed nullable (`str?`/
+/// `list[T]?`), whose non-null values are already boxed `*const Value`
+/// pointers (`Value::String`/`Value::List`) with no null-pointer bit to
+/// spare. A nullable *struct* doesn't need this: a native struct record is
+/// never `Value`-boxed, so a plain null pointer already means `none` there
+/// (`designs/llvm-compilation.md` §1.1) — see [`keel_is_none`] for the
+/// matching check. See [`keel_box_int`] for ownership.
+#[unsafe(no_mangle)]
+pub extern "C" fn keel_box_none() -> *const Value {
+    Arc::into_raw(Arc::new(Value::None))
+}
+
+/// Reports whether a boxed pointer-typed nullable (`str?`/`list[T]?`) is
+/// `none` — the counterpart check to [`keel_box_none`]. Never called on a
+/// nullable *struct* (a null pointer there is checked directly, no runtime
+/// call needed).
+///
+/// # Safety
+///
+/// `ptr` must be a live `KeelBox` (see [`borrow`]) — any variant, since
+/// checking is exactly "is this variant `Value::None`".
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn keel_is_none(ptr: *const Value) -> u8 {
+    u8::from(matches!(unsafe { &*ptr }, Value::None))
+}
+
 /// Boxes a UTF-8 string constant, copying `len` bytes starting at `ptr` into
 /// an owned `Value::String`. See [`keel_box_int`] for ownership.
 ///


### PR DESCRIPTION
## Summary

- Adds `KirType::Nullable`, structurally interned like `List`, with the three representations from `designs/llvm-compilation.md` §1.1:
  - scalar inner types (int/float/bool) — by-value `{ i1 has_value, T }` pair
  - struct inner types — plain null pointer (a struct record is never `Value`-boxed, so this is free)
  - str/list inner types — a boxed `Value::None` via two new `keel-rt-ffi` calls (`keel_box_none`/`keel_is_none`), since those are already boxed pointers with no spare null-pointer bit to steal
- Desugars `?.` and `??` to explicit branches at lowering time (§2.3), plus a bare `none` literal against a known nullable-expected type.
- Handles the checker-validated widening case (a plain, non-nullable value flowing into a nullable-expected position, e.g. passing an `Email` where `Email?` is expected) via a new `NullSome` node — this surfaced only once the golden-dump fixture exercised a real call site.
- Rejects equality comparison between nullable values at lowering (no single-value representation to compare structurally for the scalar pair) with a message pointing at `??` first.
- Extends the KIR dump, golden-dump fixture/test, and `passes/verify.rs`.
- Deferred (tracked by rejection tests, not silently dropped): enum and nested-nullable inner types, nullable-typed arguments to namespace calls. `?` propagation on a nullable value is explicitly out of scope per the issue text (a separate concern from `?` on the result-ABI).

## Test plan

- [x] Golden-dump fixture (`nullable.keel`/`.kir`) stable across reruns
- [x] Codegen integration tests (`crates/keel-codegen/tests/nullable.rs`): scalar `??` and struct `?.`/`??`, both matching the interpreter on the some and none paths
- [x] `lower_errors.rs`: rejection tests for `?.`/`??` on non-nullable operands, nullable enum inner type, and nullable equality comparison
- [x] `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings` (default and `--features build-backend`)
- [x] `cargo test --workspace` (default and `--features build-backend`)
- [x] Conformance suite (`--test conformance`), 3x for stability

Close #148