### PR TITLE
keel-kir + keel-codegen: string interpolation end to end

### DIFF
--- a/crates/keel-codegen/src/expr.rs
+++ b/crates/keel-codegen/src/expr.rs
@@ -11,6 +11,8 @@ use keel_kir::types::KirType;
 use crate::CodegenError;
 use crate::func::FuncCtx;
 use crate::layout;
+use crate::ns_call::declare_or_get;
+use crate::rt_call::call_ptr_fn;
 
 fn llvm_err(e: impl std::fmt::Display) -> CodegenError {
     CodegenError::Llvm(e.to_string())
@@ -309,6 +311,15 @@ fn emit_binop<'ctx>(
             Ok(result)
         }
         KirType::Str => match op {
+            BinOp::Add => {
+                let l = lv.into_pointer_value();
+                let r = rv.into_pointer_value();
+                let ptr_type = fcx.context.ptr_type(AddressSpace::default());
+                let f = declare_or_get(fcx.module, "keel_str_concat", || {
+                    ptr_type.fn_type(&[ptr_type.into(), ptr_type.into()], false)
+                });
+                call_ptr_fn(fcx, f, &[l.into(), r.into()])
+            }
             BinOp::Eq | BinOp::Neq => {
                 let l = lv.into_pointer_value();
                 let r = rv.into_pointer_value();
@@ -337,9 +348,7 @@ fn emit_binop<'ctx>(
                         .into()
                 })
             }
-            _ => Err(CodegenError::Unsupported(
-                "str concatenation (string interpolation lands in a later M2 issue)".to_string(),
-            )),
+            _ => Err(unreachable_combo(op, operand_ty)),
         },
         KirType::Enum(_) => {
             let l = lv.into_int_value();

--- a/crates/keel-codegen/src/rt_call.rs
+++ b/crates/keel-codegen/src/rt_call.rs
@@ -61,6 +61,42 @@ pub(crate) fn emit_rt_call<'ctx>(
                 ValueKind::Instruction(_) => unreachable!("keel_list_len returns i64, never void"),
             }
         }
+        RtFn::IntToStr => {
+            let [value] = args else {
+                unreachable!("verified KIR: RtFn::IntToStr always takes exactly 1 arg");
+            };
+            let v = crate::expr::emit_expr(fcx, value)?.into_int_value();
+            let f = declare_or_get(fcx.module, "keel_int_to_str", || {
+                ptr_type.fn_type(&[fcx.context.i64_type().into()], false)
+            });
+            call_ptr_fn(fcx, f, &[v.into()])
+        }
+        RtFn::FloatToStr => {
+            let [value] = args else {
+                unreachable!("verified KIR: RtFn::FloatToStr always takes exactly 1 arg");
+            };
+            let v = crate::expr::emit_expr(fcx, value)?.into_float_value();
+            let f = declare_or_get(fcx.module, "keel_float_to_str", || {
+                ptr_type.fn_type(&[fcx.context.f64_type().into()], false)
+            });
+            call_ptr_fn(fcx, f, &[v.into()])
+        }
+        RtFn::BoolToStr => {
+            let [value] = args else {
+                unreachable!("verified KIR: RtFn::BoolToStr always takes exactly 1 arg");
+            };
+            let v = crate::expr::emit_expr(fcx, value)?.into_int_value();
+            // `keel_bool_to_str` takes a `u8` (see abi/mod.rs) — Bool is `i1`
+            // on the LLVM side (layout.rs), so widen it first.
+            let v8 = fcx
+                .builder
+                .build_int_z_extend(v, fcx.context.i8_type(), "bool_to_u8")
+                .map_err(llvm_err)?;
+            let f = declare_or_get(fcx.module, "keel_bool_to_str", || {
+                ptr_type.fn_type(&[fcx.context.i8_type().into()], false)
+            });
+            call_ptr_fn(fcx, f, &[v8.into()])
+        }
     }
 }
 

--- a/crates/keel-codegen/tests/string_interp.rs
+++ b/crates/keel-codegen/tests/string_interp.rs
@@ -1,0 +1,62 @@
+//! Exit criterion for issue #149 (string interpolation): a program
+//! interpolating int/float/bool values into a string (e.g. `"total: {x +
+//! y}"`) compiles, links, and produces byte-identical output to the
+//! interpreter.
+
+use std::process::Command;
+
+use keel_codegen::BuildOptions;
+
+#[path = "support/mod.rs"]
+mod support;
+
+fn compile_and_run(source: &str) -> std::process::Output {
+    let kir = support::parse_check_and_lower(source);
+
+    let out_dir = tempfile::tempdir().expect("create temp out dir");
+    let opts = BuildOptions {
+        out_dir: out_dir.path().to_path_buf(),
+        runtime_link_args: support::runtime_link_args().clone(),
+    };
+    let bin = keel_codegen::compile(&kir, &opts).expect("compile must succeed");
+    Command::new(&bin).output().expect("run compiled binary")
+}
+
+fn assert_matches_interpreter(source: &str, expected_stdout: &[u8]) {
+    let compiled = compile_and_run(source);
+    let interpreted = support::run_interpreter(source);
+
+    assert_eq!(
+        String::from_utf8_lossy(&compiled.stdout),
+        String::from_utf8_lossy(&interpreted.stdout),
+        "compiled stdout must match the interpreter's"
+    );
+    assert_eq!(compiled.stdout, expected_stdout);
+}
+
+#[test]
+fn interpolating_an_arithmetic_expression_matches_the_interpreter() {
+    let source = r#"
+use std/io
+
+task total_line(x: int, y: int) -> str {
+  return "total: {x + y}"
+}
+
+io.show(total_line(2, 3))
+"#;
+    assert_matches_interpreter(source, b"  total: 5\n");
+}
+
+#[test]
+fn interpolating_multiple_slots_and_types_matches_the_interpreter() {
+    let source = r#"
+use std/io
+
+name = "Ada"
+pi = 3.5
+ready = true
+io.show("Hello, {name}! pi={pi} ready={ready}")
+"#;
+    assert_matches_interpreter(source, b"  Hello, Ada! pi=3.5 ready=true\n");
+}

--- a/crates/keel-kir/src/dump.rs
+++ b/crates/keel-kir/src/dump.rs
@@ -302,6 +302,9 @@ fn rt_fn_name(rt_fn: crate::ir::RtFn) -> &'static str {
         crate::ir::RtFn::ListNew => "list_new",
         crate::ir::RtFn::ListPush => "list_push",
         crate::ir::RtFn::ListLen => "list_len",
+        crate::ir::RtFn::IntToStr => "int_to_str",
+        crate::ir::RtFn::FloatToStr => "float_to_str",
+        crate::ir::RtFn::BoolToStr => "bool_to_str",
     }
 }
 

--- a/crates/keel-kir/src/ir.rs
+++ b/crates/keel-kir/src/ir.rs
@@ -348,6 +348,13 @@ pub enum RtFn {
     ListPush,
     /// `keel_list_len(list) -> int`.
     ListLen,
+    /// `keel_int_to_str(int) -> str` — one interpolation slot's to-string
+    /// conversion (`designs/llvm-compilation.md` §2.3).
+    IntToStr,
+    /// `keel_float_to_str(float) -> str`. See [`RtFn::IntToStr`].
+    FloatToStr,
+    /// `keel_bool_to_str(bool) -> str`. See [`RtFn::IntToStr`].
+    BoolToStr,
 }
 
 impl Expr {

--- a/crates/keel-kir/src/lower/expr.rs
+++ b/crates/keel-kir/src/lower/expr.rs
@@ -7,11 +7,14 @@
 //! (`T` restricted to int/float/bool/str — see [`lower_list_lit`]), and
 //! nullable `?.`/`??`/a `none` literal against a known expected nullable
 //! type (inner restricted to int/float/bool/str/list/struct — see
-//! `lower/mod.rs`'s `is_nullable_inner_ty`). Everything else (casts, `if`/
-//! `when` as expressions, lambdas, set/tuple literals, string
-//! interpolation, `!`/`!.` null-assert, pipelines, duration literals, rich
-//! (payload-carrying) enum variants, non-list method calls/indexing) is
-//! rejected; see module docs on `lower/mod.rs`.
+//! `lower/mod.rs`'s `is_nullable_inner_ty`), and string interpolation
+//! (desugars to `str` concatenation plus a per-slot to-string runtime call —
+//! slots restricted to int/float/bool/str, format specs deferred — see
+//! [`lower_string_lit`]). Everything else (casts, `if`/`when` as
+//! expressions, lambdas, set/tuple literals, `!`/`!.` null-assert,
+//! pipelines, duration literals, rich (payload-carrying) enum variants,
+//! non-list method calls/indexing) is rejected; see module docs on
+//! `lower/mod.rs`.
 
 use std::collections::HashMap;
 
@@ -119,7 +122,7 @@ pub(crate) fn lower_expr(
         ast::Expr::Integer(v) => Ok(Expr::ConstInt(*v)),
         ast::Expr::Float(v) => Ok(Expr::ConstFloat(*v)),
         ast::Expr::Bool(v) => Ok(Expr::ConstBool(*v)),
-        ast::Expr::StringLit(parts) => lower_string_lit(parts, &expr.span),
+        ast::Expr::StringLit(parts) => lower_string_lit(parts, &expr.span, ctx, lcx, table),
         ast::Expr::Ident(name) => {
             let local = ctx.resolve(name).ok_or_else(|| {
                 LowerError::new(format!("unknown identifier `{name}`"), expr.span.clone())
@@ -578,17 +581,83 @@ fn lower_struct_spread(
     Ok(Expr::MakeStruct { struct_id, fields })
 }
 
-/// String interpolation is sugar (desugars to concat calls per §2.3) and is
-/// deferred past M0; only a single non-interpolated literal segment lowers.
-fn lower_string_lit(parts: &[ast::StringPart], span: &Span) -> Result<Expr, LowerError> {
-    match parts {
-        [ast::StringPart::Literal(s)] => Ok(Expr::ConstStr(s.clone())),
-        [] => Ok(Expr::ConstStr(String::new())),
-        _ => Err(LowerError::unsupported(
-            "string interpolation",
-            span.clone(),
-        )),
+/// Desugars a (possibly interpolated) string literal to a chain of `+`
+/// (`str` concatenation, `BinOp::Add`) over its literal segments and
+/// interpolation slots (§2.3: "string interpolation → concat calls") — an
+/// `int`/`float`/`bool`-typed slot is first converted via the matching
+/// `RtFn::*ToStr` runtime call; a `str`-typed slot is spliced in as-is.
+/// Slots with a format spec (`{expr:spec}`) and slots of any other type
+/// (struct/enum-to-string is a later M2/M3 concern — coordinate with
+/// #145/#146 rather than block on them) are rejected, not silently dropped.
+fn lower_string_lit(
+    parts: &[ast::StringPart],
+    span: &Span,
+    ctx: &mut FnCtx,
+    lcx: &LowerCtx<'_>,
+    table: &mut SpanTable,
+) -> Result<Expr, LowerError> {
+    if parts.is_empty() {
+        return Ok(Expr::ConstStr(String::new()));
     }
+
+    let span_id = table.intern(span.clone());
+    let mut acc: Option<Expr> = None;
+    for part in parts {
+        let piece = match part {
+            ast::StringPart::Literal(s) => Expr::ConstStr(s.clone()),
+            ast::StringPart::ParseError(raw) => {
+                return Err(LowerError::new(
+                    format!("invalid expression in string interpolation: `{raw}`"),
+                    span.clone(),
+                ));
+            }
+            ast::StringPart::Interpolation(e, spec) => {
+                if spec.is_some() {
+                    return Err(LowerError::unsupported(
+                        "string-interpolation format spec (`{expr:spec}`)",
+                        e.span.clone(),
+                    ));
+                }
+                let lowered = lower_expr(e, ctx, lcx, table)?;
+                let rt_fn = match lowered.ty() {
+                    KirType::Str => None,
+                    KirType::I64 => Some(ir::RtFn::IntToStr),
+                    KirType::F64 => Some(ir::RtFn::FloatToStr),
+                    KirType::Bool => Some(ir::RtFn::BoolToStr),
+                    other => {
+                        return Err(LowerError::new(
+                            format!(
+                                "interpolating a `{}` value is not supported by the scalar-subset \
+                                 KIR lowering (M0) (only int/float/bool/str values may be \
+                                 interpolated — struct/enum to-string is a later M2/M3 concern)",
+                                describe_ty(other, lcx)
+                            ),
+                            e.span.clone(),
+                        ));
+                    }
+                };
+                match rt_fn {
+                    None => lowered,
+                    Some(rt_fn) => Expr::Call {
+                        target: CallTarget::Rt(rt_fn),
+                        args: vec![lowered],
+                        ty: KirType::Str,
+                        span: span_id,
+                    },
+                }
+            }
+        };
+        acc = Some(match acc {
+            None => piece,
+            Some(prev) => Expr::BinOp {
+                op: ir::BinOp::Add,
+                left: Box::new(prev),
+                right: Box::new(piece),
+                ty: KirType::Str,
+            },
+        });
+    }
+    Ok(acc.expect("parser never produces an empty StringPart list"))
 }
 
 /// Lowers a direct call to another lowered task. `namespace.method(...)`

--- a/crates/keel-kir/src/passes/verify.rs
+++ b/crates/keel-kir/src/passes/verify.rs
@@ -616,5 +616,29 @@ fn verify_rt_call(
             }
             Ok(())
         }
+        RtFn::IntToStr | RtFn::FloatToStr | RtFn::BoolToStr => {
+            let [value] = args else {
+                return Err(format!(
+                    "rt.{{int,float,bool}}_to_str takes 1 arg, got {}",
+                    args.len()
+                ));
+            };
+            let expected_arg_ty = match rt_fn {
+                RtFn::IntToStr => KirType::I64,
+                RtFn::FloatToStr => KirType::F64,
+                RtFn::BoolToStr => KirType::Bool,
+                _ => unreachable!("outer match already narrowed to the *ToStr arms"),
+            };
+            if value.ty() != expected_arg_ty {
+                return Err(format!(
+                    "rt.*_to_str argument is {} but this variant expects {expected_arg_ty}",
+                    value.ty()
+                ));
+            }
+            if ty != KirType::Str {
+                return Err(format!("rt.*_to_str result is {ty}, expected str"));
+            }
+            Ok(())
+        }
     }
 }

--- a/crates/keel-kir/tests/fixtures/string_interp.keel
+++ b/crates/keel-kir/tests/fixtures/string_interp.keel
@@ -1,0 +1,8 @@
+task total_line(x: int, y: int) -> str {
+  return "total: {x + y}"
+}
+
+name = "Ada"
+pi = 3.5
+ready = true
+greeting = "Hello, {name}! pi={pi} ready={ready}"

--- a/crates/keel-kir/tests/fixtures/string_interp.kir
+++ b/crates/keel-kir/tests/fixtures/string_interp.kir
@@ -1,0 +1,10 @@
+fn total_line(x: int, y: int) -> str {
+  return ("total: " + rt.int_to_str((x + y)))
+}
+
+fn <toplevel>() -> none {
+  let name: str = "Ada"
+  let pi: float = 3.5
+  let ready: bool = true
+  let greeting: str = ((((("Hello, " + name) + "! pi=") + rt.float_to_str(pi)) + " ready=") + rt.bool_to_str(ready))
+}

--- a/crates/keel-kir/tests/lower_errors.rs
+++ b/crates/keel-kir/tests/lower_errors.rs
@@ -86,21 +86,6 @@ task f() -> int {
 }
 
 #[test]
-fn string_interpolation_is_rejected() {
-    let msg = lower_err(
-        r#"
-task greet(name: str) -> str {
-  return "hi {name}"
-}
-"#,
-    );
-    assert!(
-        msg.contains("string interpolation"),
-        "unexpected message: {msg}"
-    );
-}
-
-#[test]
 fn struct_literal_is_rejected() {
     let msg = lower_err(
         r#"
@@ -700,6 +685,41 @@ task f(a: int? = none, b: int? = none) -> bool {
     );
     assert!(
         msg.contains("cannot compare nullable"),
+        "unexpected message: {msg}"
+    );
+}
+
+#[test]
+fn string_interpolation_format_spec_is_rejected() {
+    // `{expr:spec}` alignment/precision formatting is a distinct feature
+    // from the concat-chain desugaring this issue implements — deferred,
+    // not silently ignored.
+    let msg = lower_err(
+        r#"
+task f(pi: float) -> str {
+  return "{pi:.2f}"
+}
+"#,
+    );
+    assert!(msg.contains("format spec"), "unexpected message: {msg}");
+}
+
+#[test]
+fn string_interpolation_of_a_struct_value_is_rejected() {
+    // Struct/enum-to-string needs `Value` marshaling that doesn't exist
+    // yet (coordinate with #145/#146 rather than block on them) — only
+    // int/float/bool/str slots lower in this issue.
+    let msg = lower_err(
+        r#"
+type Point { x: int, y: int }
+
+task f(p: Point) -> str {
+  return "point: {p}"
+}
+"#,
+    );
+    assert!(
+        msg.contains("struct/enum to-string"),
         "unexpected message: {msg}"
     );
 }

--- a/crates/keel-rt-ffi/src/abi/mod.rs
+++ b/crates/keel-rt-ffi/src/abi/mod.rs
@@ -105,6 +105,55 @@ pub unsafe extern "C" fn keel_str_eq(a: *const Value, b: *const Value) -> u8 {
     u8::from(a == b)
 }
 
+/// Concatenates two boxed strings without consuming either caller's
+/// reference — backs `keel-codegen`'s `str + str` (plain concatenation and
+/// desugared string interpolation both lower to this same operator; see
+/// `keel-kir`'s `lower_string_lit`). Returns a **fresh** boxed string; `a`
+/// and `b` are untouched, matching `keel_list_push`'s always-clone
+/// convention. See [`keel_box_int`] for the returned reference's ownership.
+///
+/// # Safety
+///
+/// `a` and `b` must each be a live `KeelBox` whose underlying `Value` is
+/// `Value::String` — always true for a `str`-typed KIR expression, which is
+/// the only thing `keel-codegen` ever passes here.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn keel_str_concat(a: *const Value, b: *const Value) -> *const Value {
+    let (Value::String(a), Value::String(b)) = (unsafe { &*a }, unsafe { &*b }) else {
+        unreachable!(
+            "keel-codegen only calls keel_str_concat on str-typed (Value::String) operands"
+        );
+    };
+    boxed(Value::String(format!("{a}{b}")))
+}
+
+/// Converts an `int` to its boxed `str` representation, matching the
+/// interpreter's `Value::Integer` `Display` impl exactly (`{n}`) — backs a
+/// scalar string-interpolation slot's to-string conversion. See
+/// [`keel_box_int`] for the returned reference's ownership.
+#[unsafe(no_mangle)]
+pub extern "C" fn keel_int_to_str(v: i64) -> *const Value {
+    boxed(Value::String(v.to_string()))
+}
+
+/// Converts a `float` to its boxed `str` representation, matching the
+/// interpreter's `Value::Float` `Display` impl exactly (`{n}`, Rust's
+/// shortest round-tripping representation — same formatting the
+/// interpreter's own `write!(f, "{n}")` produces). See [`keel_int_to_str`].
+#[unsafe(no_mangle)]
+pub extern "C" fn keel_float_to_str(v: f64) -> *const Value {
+    boxed(Value::String(v.to_string()))
+}
+
+/// Converts a `bool` (`0`/nonzero, matching [`keel_box_bool`]'s convention)
+/// to its boxed `str` representation (`"true"`/`"false"`), matching the
+/// interpreter's `Value::Bool` `Display` impl exactly. See
+/// [`keel_int_to_str`].
+#[unsafe(no_mangle)]
+pub extern "C" fn keel_bool_to_str(v: u8) -> *const Value {
+    boxed(Value::String((v != 0).to_string()))
+}
+
 /// Unboxes an `int` — `keel-codegen` only ever calls this (and its
 /// `keel_unbox_float`/`keel_unbox_bool` siblings) on a box it knows (from
 /// the expression's `KirType`) holds that scalar kind.


### PR DESCRIPTION
## Summary

- Desugars an interpolated string literal (`"total: {x + y}"`) to a chain of `str` concatenation over its literal segments and interpolation slots (§2.3: "string interpolation → concat calls").
- Reuses the existing `BinOp::Add` on `Str` node for concatenation — `infer_binop_ty` already type-inferred `Str + Str -> Str` for plain `+` concatenation, but `emit_binop`'s codegen side was an explicit stub ("string interpolation lands in a later M2 issue"); this PR fills it in with a new `keel_str_concat` runtime call, so plain string `+` and desugared interpolation share the same codegen path.
- Adds a per-slot to-string conversion for `int`/`float`/`bool` interpolation slots via three new `RtFn` variants (`IntToStr`/`FloatToStr`/`BoolToStr`) and their `keel-rt-ffi` entry points (`keel_int_to_str`/`keel_float_to_str`/`keel_bool_to_str`), matching the interpreter's `Value` `Display` formatting exactly (verified: Rust's default `f64` Display and the interpreter's `write!(f, "{n}")` produce identical output).
- A `str`-typed slot is spliced directly into the concat chain with no conversion.
- Extends the KIR dump, golden-dump fixture/test, and `passes/verify.rs`.
- Deferred (rejected at lowering, not silently dropped): format specs (`{expr:spec}` alignment/precision — a distinct feature from the concat-chain desugaring here) and interpolating a struct/enum value (needs `Value` marshaling that doesn't exist yet — coordinates with #145/#146 rather than blocking on them).

## Test plan

- [x] Golden-dump fixture (`string_interp.keel`/`.kir`) stable across reruns
- [x] Codegen integration tests (`crates/keel-codegen/tests/string_interp.rs`): an arithmetic expression slot, and a multi-slot/multi-type literal (str/float/bool), both matching the interpreter byte-for-byte
- [x] `lower_errors.rs`: rejection tests for a format spec and a struct-value interpolation slot; removed the now-obsolete blanket "string interpolation is rejected" test
- [x] `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings` (default and `--features build-backend`)
- [x] `cargo test --workspace` (default and `--features build-backend`)
- [x] Conformance suite (`--test conformance`), 3x for stability

Close #149