### PR TITLE
keel-kir + keel-codegen: raise/try/catch result calling convention

### DIFF
--- a/crates/keel-codegen/src/expr.rs
+++ b/crates/keel-codegen/src/expr.rs
@@ -170,6 +170,7 @@ fn emit_call<'ctx>(
     };
     let callee = fcx.functions[func_id]
         .expect("declare_functions declares every non-toplevel FuncId before any body is emitted");
+    let callee_can_raise = fcx.program.functions[func_id].can_raise;
 
     let mut arg_values: Vec<BasicMetadataValueEnum> = Vec::with_capacity(args.len());
     for arg in args {
@@ -181,15 +182,22 @@ fn emit_call<'ctx>(
         .build_call(callee, &arg_values, "call")
         .map_err(llvm_err)?;
 
-    match call.try_as_basic_value() {
-        ValueKind::Basic(v) => Ok(v),
+    let result = match call.try_as_basic_value() {
+        ValueKind::Basic(v) => v,
         // A Unit-returning (void) call. `ty` is Unit too (verified KIR), so
         // no caller ever inspects this value — the exit-code convention in
         // `func.rs` and every other consumer branch on `ty` first.
         ValueKind::Instruction(_) => {
             debug_assert_eq!(ty, KirType::Unit);
-            Ok(fcx.context.bool_type().const_zero().into())
+            debug_assert!(!callee_can_raise, "a can_raise callee never returns void");
+            return Ok(fcx.context.bool_type().const_zero().into());
         }
+    };
+
+    if callee_can_raise {
+        crate::raise::emit_call_result_branch(fcx, result, ty)
+    } else {
+        Ok(result)
     }
 }
 

--- a/crates/keel-codegen/src/func.rs
+++ b/crates/keel-codegen/src/func.rs
@@ -25,6 +25,7 @@
 
 use std::collections::HashMap;
 
+use inkwell::basic_block::BasicBlock;
 use inkwell::builder::Builder;
 use inkwell::context::Context;
 use inkwell::module::Module;
@@ -63,6 +64,23 @@ pub(crate) struct FuncCtx<'ctx, 'a> {
     /// see the module doc) means "exit 0 now" instead of `ret void`.
     pub(crate) is_toplevel: bool,
     pub(crate) locals: HashMap<LocalId, PointerValue<'ctx>>,
+    /// This function's own logical return type (`KirFunction::ret`) — needed
+    /// by `raise.rs`'s `emit_ok_return` to box a `return`/fallthrough value
+    /// into the result-ABI's payload slot.
+    pub(crate) ret_ty: KirType,
+    /// Whether this function returns the result-ABI wrapper instead of a
+    /// plain `ret_ty`-typed value (`KirFunction::can_raise` — see its doc
+    /// and `designs/llvm-compilation.md` §2.5). Always `false` for
+    /// `toplevel` (`lower_program` rejects a `can_raise` toplevel).
+    pub(crate) can_raise: bool,
+    /// Stack of currently active `try` scopes in this function, innermost
+    /// last: `(handler basic block, catch binder's already-allocated
+    /// `alloca`)`. A `can_raise` call's `is_err` branch
+    /// (`expr.rs`'s `emit_call`) jumps to the top entry's handler block
+    /// (storing the error payload into its binder first) if non-empty, or
+    /// propagates via this function's own error return otherwise — see
+    /// `stmt.rs`'s `emit_try_catch`.
+    pub(crate) catch_stack: Vec<(BasicBlock<'ctx>, PointerValue<'ctx>)>,
 }
 
 /// Declares (signature only, no body) every `KirFunction` except
@@ -83,10 +101,14 @@ pub(crate) fn declare_functions<'ctx>(
             .iter()
             .map(|p| crate::layout::llvm_type(context, program, p.ty).map(Into::into))
             .collect::<Result<Vec<_>, _>>()?;
-        let fn_type = match func.ret {
-            KirType::Unit => context.void_type().fn_type(&param_types, false),
-            other => {
-                crate::layout::llvm_type(context, program, other)?.fn_type(&param_types, false)
+        let fn_type = if func.can_raise {
+            crate::raise::result_abi_type(context).fn_type(&param_types, false)
+        } else {
+            match func.ret {
+                KirType::Unit => context.void_type().fn_type(&param_types, false),
+                other => {
+                    crate::layout::llvm_type(context, program, other)?.fn_type(&param_types, false)
+                }
             }
         };
         functions[id] = Some(module.add_function(&func.name, fn_type, None));
@@ -116,6 +138,9 @@ pub(crate) fn emit_function<'ctx>(
         functions,
         is_toplevel: false,
         locals: HashMap::new(),
+        ret_ty: func.ret,
+        can_raise: func.can_raise,
+        catch_stack: Vec::new(),
     };
 
     for (i, param) in func.params.iter().enumerate() {
@@ -161,6 +186,12 @@ pub(crate) fn emit_toplevel_function<'ctx>(
         functions,
         is_toplevel: true,
         locals: HashMap::new(),
+        ret_ty: KirType::Unit,
+        // `lower_program` rejects a `can_raise` toplevel (an uncaught raise
+        // reaching the top level is a later M2/M3 concern — see its doc) —
+        // this is always `false` in practice, never read.
+        can_raise: false,
+        catch_stack: Vec::new(),
     };
     let last = stmt::emit_block(&mut fcx, &toplevel.body)?;
 
@@ -218,12 +249,21 @@ pub(crate) fn block_is_terminated(builder: &Builder) -> bool {
 /// task to return (this crate does not re-derive that guarantee — see
 /// AGENTS.md "trust internal invariants"), so `unreachable` is the correct
 /// terminator for a scalar-returning function's fallthrough: a well-typed
-/// program never actually reaches it.
+/// program never actually reaches it. A `can_raise` function's `ret_ty ==
+/// Unit` fallthrough still needs a real value, though — its LLVM return
+/// type is the result-ABI struct, not `void` — so that case emits the
+/// success branch instead of a bare `ret void`.
 fn finish_block(fcx: &FuncCtx, ret_ty: KirType) -> Result<(), CodegenError> {
     if block_is_terminated(fcx.builder) {
         return Ok(());
     }
-    if ret_ty == KirType::Unit {
+    if fcx.can_raise {
+        if ret_ty == KirType::Unit {
+            crate::raise::emit_ok_return(fcx, KirType::Unit, None)?;
+        } else {
+            fcx.builder.build_unreachable().map_err(llvm_err)?;
+        }
+    } else if ret_ty == KirType::Unit {
         fcx.builder.build_return(None).map_err(llvm_err)?;
     } else {
         fcx.builder.build_unreachable().map_err(llvm_err)?;

--- a/crates/keel-codegen/src/lib.rs
+++ b/crates/keel-codegen/src/lib.rs
@@ -22,6 +22,7 @@ mod layout;
 mod link;
 mod ns_call;
 mod nullable;
+mod raise;
 mod rt_call;
 mod stmt;
 

--- a/crates/keel-codegen/src/raise.rs
+++ b/crates/keel-codegen/src/raise.rs
@@ -1,0 +1,230 @@
+//! `raise`/`try`/`catch` codegen — the result calling convention for
+//! `CallTarget::Fn` calls to a `can_raise` function (`designs/llvm-
+//! compilation.md` §2.5). Every `can_raise` function's LLVM return type is
+//! `{ i1 is_err, ptr payload }`: `payload` is always a boxed `*const Value`
+//! on success (reusing `keel_box_*`/`unbox_value` — an int/float/bool
+//! success value is boxed, a str/list/struct success value is already a
+//! native `ptr` and passes through untouched, `none` boxes `Value::None`)
+//! and the synthetic `UserRaised` struct pointer (already a native `ptr` —
+//! see `ir.rs`'s `Stmt::TryCatch` doc) on error.
+//!
+//! This struct is purely internal to the LLVM module — it never crosses
+//! into `keel-rt-ffi`, so it isn't `#[repr(C)]`/shared with `KeelRes` (the
+//! analogous shape `CallTarget::Ns` calls use — a distinct, untouched-by-
+//! this-issue path; see `ns_dispatch.rs`'s doc on why namespace calls don't
+//! participate in this convention yet).
+
+use inkwell::AddressSpace;
+use inkwell::context::Context;
+use inkwell::types::StructType;
+use inkwell::values::{BasicValueEnum, PointerValue};
+
+use keel_kir::ir::Expr;
+use keel_kir::types::KirType;
+
+use crate::CodegenError;
+use crate::func::{FuncCtx, llvm_err};
+use crate::ns_call::declare_or_get;
+use crate::rt_call::{call_ptr_fn, unbox_value};
+
+/// The `{ i1 is_err, ptr payload }` result-ABI struct type every
+/// `can_raise` function returns, regardless of its own logical return type.
+pub(crate) fn result_abi_type<'ctx>(context: &'ctx Context) -> StructType<'ctx> {
+    context.struct_type(
+        &[
+            context.bool_type().into(),
+            context.ptr_type(AddressSpace::default()).into(),
+        ],
+        false,
+    )
+}
+
+/// Builds a `{ is_err, payload }` result-ABI value (a runtime `payload`
+/// composed via `build_insert_value`, same pattern as `nullable.rs`'s
+/// `emit_wrap_some` for the scalar-nullable `{ i1, T }` pair).
+fn build_result<'ctx>(
+    fcx: &FuncCtx<'ctx, '_>,
+    is_err: bool,
+    payload: PointerValue<'ctx>,
+) -> Result<BasicValueEnum<'ctx>, CodegenError> {
+    let struct_ty = result_abi_type(fcx.context);
+    let undef = struct_ty.get_undef();
+    let flag = fcx.context.bool_type().const_int(u64::from(is_err), false);
+    let with_flag = fcx
+        .builder
+        .build_insert_value(undef, flag, 0, "res.flag")
+        .map_err(llvm_err)?;
+    let with_payload = fcx
+        .builder
+        .build_insert_value(with_flag, payload, 1, "res.payload")
+        .map_err(llvm_err)?;
+    Ok(with_payload.into_struct_value().into())
+}
+
+/// Boxes a `can_raise` function's success value into the result-ABI's
+/// uniformly-`ptr` payload slot. `value` is `None` only for `ty ==
+/// KirType::Unit`. `ty` is restricted (by `keel-kir`'s `compute_can_raise`)
+/// to int/float/bool/str/list/none — struct/enum/nullable success values
+/// need `Value` marshaling that doesn't exist yet, a later M2/M3 concern.
+pub(crate) fn emit_box_result_value<'ctx>(
+    fcx: &FuncCtx<'ctx, '_>,
+    ty: KirType,
+    value: Option<BasicValueEnum<'ctx>>,
+) -> Result<PointerValue<'ctx>, CodegenError> {
+    let ptr_type = fcx.context.ptr_type(AddressSpace::default());
+    match ty {
+        KirType::Unit => {
+            let f = declare_or_get(fcx.module, "keel_box_none", || ptr_type.fn_type(&[], false));
+            Ok(call_ptr_fn(fcx, f, &[])?.into_pointer_value())
+        }
+        KirType::I64 => {
+            let v = value
+                .expect("non-Unit ty always carries a value")
+                .into_int_value();
+            let f = declare_or_get(fcx.module, "keel_box_int", || {
+                ptr_type.fn_type(&[fcx.context.i64_type().into()], false)
+            });
+            Ok(call_ptr_fn(fcx, f, &[v.into()])?.into_pointer_value())
+        }
+        KirType::F64 => {
+            let v = value
+                .expect("non-Unit ty always carries a value")
+                .into_float_value();
+            let f = declare_or_get(fcx.module, "keel_box_float", || {
+                ptr_type.fn_type(&[fcx.context.f64_type().into()], false)
+            });
+            Ok(call_ptr_fn(fcx, f, &[v.into()])?.into_pointer_value())
+        }
+        KirType::Bool => {
+            let v = value
+                .expect("non-Unit ty always carries a value")
+                .into_int_value();
+            // `keel_box_bool` takes a `u8` (see abi/mod.rs) — Bool is `i1`
+            // on the LLVM side (layout.rs), so widen it first.
+            let v8 = fcx
+                .builder
+                .build_int_z_extend(v, fcx.context.i8_type(), "bool_to_u8")
+                .map_err(llvm_err)?;
+            let f = declare_or_get(fcx.module, "keel_box_bool", || {
+                ptr_type.fn_type(&[fcx.context.i8_type().into()], false)
+            });
+            Ok(call_ptr_fn(fcx, f, &[v8.into()])?.into_pointer_value())
+        }
+        KirType::Str | KirType::List(_) | KirType::Struct(_) => Ok(value
+            .expect("non-Unit ty always carries a value")
+            .into_pointer_value()),
+        other => Err(CodegenError::Unsupported(format!(
+            "a can-raise function returning `{other}` (struct/enum/nullable success values need \
+             Value marshaling, a later M2/M3 concern — keel-kir's compute_can_raise should have \
+             rejected this)"
+        ))),
+    }
+}
+
+/// Inverse of `emit_box_result_value` — unboxes a `can_raise` call's
+/// success payload back to `ty`'s native representation. Delegates to
+/// `rt_call::unbox_value` for the cases it already handles correctly
+/// (that function is list-element-unboxing scoped, so `Unit`/`Struct`
+/// — never valid list elements — are handled here instead, not folded
+/// into its own match).
+pub(crate) fn emit_unbox_result_value<'ctx>(
+    fcx: &FuncCtx<'ctx, '_>,
+    ptr: PointerValue<'ctx>,
+    ty: KirType,
+) -> Result<BasicValueEnum<'ctx>, CodegenError> {
+    match ty {
+        // Matches `expr.rs`'s existing void-call convention: a Unit-typed
+        // value is never inspected by any caller, only ever discarded.
+        KirType::Unit => Ok(fcx.context.bool_type().const_zero().into()),
+        KirType::Struct(_) => Ok(ptr.into()),
+        KirType::I64 | KirType::F64 | KirType::Bool | KirType::Str | KirType::List(_) => {
+            unbox_value(fcx, ptr, ty)
+        }
+        other => Err(CodegenError::Unsupported(format!(
+            "a can-raise function returning `{other}` (struct/enum/nullable success values need \
+             Value marshaling, a later M2/M3 concern)"
+        ))),
+    }
+}
+
+/// Builds `{ is_err: 0, payload: boxed(value) }` and emits `return` with it
+/// — the success path of a `can_raise` function's result-ABI, from both an
+/// explicit `return` (`stmt.rs`'s `emit_return`) and control falling off
+/// the end of a `none`-returning `can_raise` function (`func.rs`'s
+/// `finish_block`).
+pub(crate) fn emit_ok_return<'ctx>(
+    fcx: &FuncCtx<'ctx, '_>,
+    ty: KirType,
+    value: Option<BasicValueEnum<'ctx>>,
+) -> Result<(), CodegenError> {
+    let payload = emit_box_result_value(fcx, ty, value)?;
+    let result = build_result(fcx, false, payload)?;
+    fcx.builder.build_return(Some(&result)).map_err(llvm_err)?;
+    Ok(())
+}
+
+/// Emits `raise error` (`stmt.rs`'s `emit_raise`) — evaluates the already-
+/// constructed `UserRaised` struct value (`error`, an `Expr::MakeStruct` —
+/// see `ir.rs`'s `Stmt::Raise` doc) and immediately returns the current
+/// (always `can_raise`) function's error branch with it.
+pub(crate) fn emit_raise<'ctx>(fcx: &FuncCtx<'ctx, '_>, error: &Expr) -> Result<(), CodegenError> {
+    let error_ptr = crate::expr::emit_expr(fcx, error)?.into_pointer_value();
+    let result = build_result(fcx, true, error_ptr)?;
+    fcx.builder.build_return(Some(&result)).map_err(llvm_err)?;
+    Ok(())
+}
+
+/// Emits the `is_err` branch after a call to a `can_raise` `CallTarget::Fn`
+/// callee (`expr.rs`'s `emit_call`): the error arm either stores the
+/// payload into the innermost active `try`'s binder and jumps to its
+/// handler (`fcx.catch_stack`'s top entry), or — if no `try` is active —
+/// propagates by returning this function's own error branch with the same
+/// payload (always sound: an uncaught call to a `can_raise` callee is
+/// exactly what makes *this* function `can_raise` too, per `keel-kir`'s
+/// `compute_can_raise`). Returns the unboxed success value, with the
+/// builder positioned at the "ok" continuation block — composes with
+/// whatever expression context the call appeared in, same as a plain call.
+pub(crate) fn emit_call_result_branch<'ctx>(
+    fcx: &FuncCtx<'ctx, '_>,
+    result: BasicValueEnum<'ctx>,
+    ret_ty: KirType,
+) -> Result<BasicValueEnum<'ctx>, CodegenError> {
+    let result = result.into_struct_value();
+    let is_err = fcx
+        .builder
+        .build_extract_value(result, 0, "call.is_err")
+        .map_err(llvm_err)?
+        .into_int_value();
+    let payload = fcx
+        .builder
+        .build_extract_value(result, 1, "call.payload")
+        .map_err(llvm_err)?
+        .into_pointer_value();
+
+    let err_bb = fcx.context.append_basic_block(fcx.function, "call.err");
+    let ok_bb = fcx.context.append_basic_block(fcx.function, "call.ok");
+    fcx.builder
+        .build_conditional_branch(is_err, err_bb, ok_bb)
+        .map_err(llvm_err)?;
+
+    fcx.builder.position_at_end(err_bb);
+    match fcx.catch_stack.last() {
+        Some(&(handler_bb, binder_ptr)) => {
+            fcx.builder
+                .build_store(binder_ptr, payload)
+                .map_err(llvm_err)?;
+            fcx.builder
+                .build_unconditional_branch(handler_bb)
+                .map_err(llvm_err)?;
+        }
+        None => {
+            let propagated = build_result(fcx, true, payload)?;
+            fcx.builder
+                .build_return(Some(&propagated))
+                .map_err(llvm_err)?;
+        }
+    }
+
+    fcx.builder.position_at_end(ok_bb);
+    emit_unbox_result_value(fcx, payload, ret_ty)
+}

--- a/crates/keel-codegen/src/stmt.rs
+++ b/crates/keel-codegen/src/stmt.rs
@@ -95,6 +95,19 @@ fn emit_stmt<'ctx>(
             emit_return(fcx, value.as_ref())?;
             Ok(None)
         }
+        Stmt::Raise { error, .. } => {
+            crate::raise::emit_raise(fcx, error)?;
+            Ok(None)
+        }
+        Stmt::TryCatch {
+            body,
+            binder,
+            binder_ty,
+            handler,
+        } => {
+            emit_try_catch(fcx, body, *binder, *binder_ty, handler)?;
+            Ok(None)
+        }
     }
 }
 
@@ -332,6 +345,14 @@ fn emit_return<'ctx>(
         fcx.builder.build_return(Some(&zero)).map_err(llvm_err)?;
         return Ok(());
     }
+    if fcx.can_raise {
+        let ret_ty = fcx.ret_ty;
+        let v = match value {
+            Some(e) => Some(expr::emit_expr(fcx, e)?),
+            None => None,
+        };
+        return crate::raise::emit_ok_return(fcx, ret_ty, v);
+    }
     match value {
         Some(e) => {
             let v = expr::emit_expr(fcx, e)?;
@@ -341,5 +362,50 @@ fn emit_return<'ctx>(
             fcx.builder.build_return(None).map_err(llvm_err)?;
         }
     }
+    Ok(())
+}
+
+/// `try { body } catch binder: binder_ty { handler }`. `body`'s own
+/// `can_raise` call sites (`expr.rs`'s `emit_call`) check
+/// `fcx.catch_stack`'s top entry — pushed here, before `body` is emitted,
+/// so nested calls see it — and branch to `handler_bb` on error, having
+/// already stored the payload into the binder's `alloca`; a normal
+/// (non-erroring) `body` falls through to `merge_bb`, skipping the handler
+/// entirely.
+fn emit_try_catch<'ctx>(
+    fcx: &mut FuncCtx<'ctx, '_>,
+    body: &Block,
+    binder: keel_kir::ir::LocalId,
+    binder_ty: KirType,
+    handler: &Block,
+) -> Result<(), CodegenError> {
+    let binder_llvm_ty = layout::llvm_type(fcx.context, fcx.program, binder_ty)?;
+    let binder_ptr = fcx
+        .builder
+        .build_alloca(binder_llvm_ty, &format!("local.{binder}"))
+        .map_err(llvm_err)?;
+    fcx.locals.insert(binder, binder_ptr);
+
+    let handler_bb = fcx.context.append_basic_block(fcx.function, "try.catch");
+    let merge_bb = fcx.context.append_basic_block(fcx.function, "try.merge");
+
+    fcx.catch_stack.push((handler_bb, binder_ptr));
+    emit_block(fcx, body)?;
+    fcx.catch_stack.pop();
+    if !block_is_terminated(fcx.builder) {
+        fcx.builder
+            .build_unconditional_branch(merge_bb)
+            .map_err(llvm_err)?;
+    }
+
+    fcx.builder.position_at_end(handler_bb);
+    emit_block(fcx, handler)?;
+    if !block_is_terminated(fcx.builder) {
+        fcx.builder
+            .build_unconditional_branch(merge_bb)
+            .map_err(llvm_err)?;
+    }
+
+    fcx.builder.position_at_end(merge_bb);
     Ok(())
 }

--- a/crates/keel-codegen/tests/raise_try_catch.rs
+++ b/crates/keel-codegen/tests/raise_try_catch.rs
@@ -1,0 +1,122 @@
+//! Exit criterion for issue #150 (raise/try/catch result calling
+//! convention): a program where a task `raise`s, a caller catches it via
+//! `try`/`catch`, and a separate call site uses automatic propagation
+//! (an uncaught call to a `can_raise` function) to propagate the same
+//! error compiles, links, and matches the interpreter's error message.
+
+use std::process::Command;
+
+use keel_codegen::BuildOptions;
+
+#[path = "support/mod.rs"]
+mod support;
+
+fn compile_and_run(source: &str) -> std::process::Output {
+    let kir = support::parse_check_and_lower(source);
+
+    let out_dir = tempfile::tempdir().expect("create temp out dir");
+    let opts = BuildOptions {
+        out_dir: out_dir.path().to_path_buf(),
+        runtime_link_args: support::runtime_link_args().clone(),
+    };
+    let bin = keel_codegen::compile(&kir, &opts).expect("compile must succeed");
+    Command::new(&bin).output().expect("run compiled binary")
+}
+
+fn assert_matches_interpreter(source: &str, expected_stdout: &[u8]) {
+    let compiled = compile_and_run(source);
+    let interpreted = support::run_interpreter(source);
+
+    assert_eq!(
+        String::from_utf8_lossy(&compiled.stdout),
+        String::from_utf8_lossy(&interpreted.stdout),
+        "compiled stdout must match the interpreter's"
+    );
+    assert_eq!(compiled.stdout, expected_stdout);
+}
+
+#[test]
+fn raise_propagates_through_an_uncaught_caller_and_is_caught_further_up_matching_the_interpreter() {
+    let source = r#"
+use std/io
+
+task a() -> int {
+  raise "boom"
+}
+
+task b() -> int {
+  return a()
+}
+
+task c() -> int {
+  try {
+    result = b()
+    return result
+  } catch e: Error {
+    io.show(e.message)
+    return -1
+  }
+}
+
+io.show(c())
+"#;
+    assert_matches_interpreter(source, b"  boom\n  -1\n");
+}
+
+#[test]
+fn try_catch_around_a_direct_raise_matches_the_interpreter() {
+    let source = r#"
+use std/io
+
+task risky(should_raise: bool) -> int {
+  if should_raise {
+    raise "nope"
+  }
+  return 42
+}
+
+task run_it(should_raise: bool) -> int {
+  try {
+    return risky(should_raise)
+  } catch e: Error {
+    io.show(e.message)
+    return -1
+  }
+}
+
+io.show(run_it(false))
+io.show(run_it(true))
+"#;
+    assert_matches_interpreter(source, b"  42\n  nope\n  -1\n");
+}
+
+#[test]
+fn a_unit_returning_can_raise_task_falling_through_matches_the_interpreter() {
+    // Exercises the success (non-error) path of a `none`-returning
+    // `can_raise` function — falling off the end without an explicit
+    // `return` still has to produce a well-formed result-ABI value
+    // (`func.rs`'s `finish_block` can_raise+Unit branch), not just the
+    // error path the other two tests already cover.
+    let source = r#"
+use std/io
+
+task maybe_raise(should_raise: bool) {
+  if should_raise {
+    raise "unit-raise"
+  }
+}
+
+task use_it(should_raise: bool) {
+  try {
+    maybe_raise(should_raise)
+    io.show("no error")
+  } catch e: Error {
+    io.show(e.message)
+  }
+}
+
+use_it(false)
+use_it(true)
+"#;
+    assert_matches_interpreter(source, b"  no error\n  unit-raise\n");
+}

--- a/crates/keel-kir/src/dump.rs
+++ b/crates/keel-kir/src/dump.rs
@@ -62,9 +62,10 @@ fn dump_function(out: &mut String, program: &KirProgram, func: &KirFunction) {
         })
         .collect::<Vec<_>>()
         .join(", ");
+    let can_raise = if func.can_raise { " can_raise" } else { "" };
     let _ = writeln!(
         out,
-        "fn {}({params}) -> {} {{",
+        "fn {}({params}) -> {}{can_raise} {{",
         func.name,
         fmt_ty(program, func.ret)
     );
@@ -176,6 +177,24 @@ fn dump_stmt(
         }
         Stmt::Expr(expr) => {
             let _ = writeln!(out, "{}", fmt_expr(program, func, expr));
+        }
+        Stmt::Raise { error, .. } => {
+            let _ = writeln!(out, "raise {}", fmt_expr(program, func, error));
+        }
+        Stmt::TryCatch {
+            body,
+            binder,
+            binder_ty,
+            handler,
+        } => {
+            let name = &func.locals[*binder].name;
+            let _ = writeln!(out, "try {{");
+            dump_block(out, program, func, body, depth + 1);
+            indent(out, depth);
+            let _ = writeln!(out, "}} catch {}: {} {{", name, fmt_ty(program, *binder_ty));
+            dump_block(out, program, func, handler, depth + 1);
+            indent(out, depth);
+            out.push_str("}\n");
         }
     }
 }

--- a/crates/keel-kir/src/ir.rs
+++ b/crates/keel-kir/src/ir.rs
@@ -134,6 +134,19 @@ pub struct KirFunction {
     pub name: String,
     pub params: Vec<Param>,
     pub ret: KirType,
+    /// Whether this function's compiled signature returns the result-ABI
+    /// wrapper (`{ i1 is_err, T success, UserRaised error }`) instead of a
+    /// plain `ret`-typed value — set by the whole-program `can_raise`
+    /// fixpoint (`lower/mod.rs`'s `compute_can_raise`) over `CallTarget::Fn`
+    /// call sites only (`designs/llvm-compilation.md` §2.5). A function is
+    /// `can_raise` iff it directly executes `Stmt::Raise`, or makes an
+    /// uncaught call (not inside a matching `Stmt::TryCatch`) to another
+    /// `can_raise` function. `CallTarget::Ns`/`CallTarget::Rt` calls don't
+    /// participate — no M1/M2 namespace method actually produces `is_err`
+    /// yet, so propagating through them would mark nearly every task
+    /// `can_raise` and cascade to the toplevel entry point's fixed `-> i32`
+    /// ABI; a later M2/M3 concern once a namespace method needs it.
+    pub can_raise: bool,
     /// Every local this function declares, including params (params occupy
     /// the first `params.len()` slots, in order) and every `let`-introduced
     /// shadow. Declaration order = `LocalId` order.
@@ -213,6 +226,34 @@ pub enum Stmt {
     Return(Option<Expr>),
     /// Expression evaluated for its side effect (e.g. a bare call).
     Expr(Expr),
+    /// `raise expr` — `error` is already the constructed synthetic
+    /// `UserRaised { message: str }` value (an `Expr::MakeStruct`, reusing
+    /// that lowering/codegen wholesale rather than inventing a parallel
+    /// error-construction path; see `lower/stmt.rs`). `expr` itself must
+    /// already be `Str`-typed (the interpreter's non-`str` `Display`-
+    /// coercion path is a later M2/M3 concern). Always terminates the
+    /// current function with the result-ABI's error branch — the enclosing
+    /// function is therefore always `can_raise`.
+    Raise {
+        error: Expr,
+        span: SpanId,
+    },
+    /// `try { body } catch binder: Error|UserRaised { handler }` — only a
+    /// single catch clause of type `Error` or `UserRaised` is supported
+    /// (both bind the same synthetic `UserRaised { message: str }` shape,
+    /// since `raise` only ever produces `UserRaised`); this collapses
+    /// "caught" to "lexically inside this try's body" with no type lattice
+    /// to evaluate. `binder_ty` is always `KirType::Struct(id)` for the
+    /// synthetic `UserRaised` layout — carried directly (same convention as
+    /// `ForEach`'s `elem_ty`) so codegen never needs a `func.locals` lookup
+    /// to allocate the binder. Multiple catch clauses, and clauses over any
+    /// other error type name, are rejected at lowering.
+    TryCatch {
+        body: Block,
+        binder: LocalId,
+        binder_ty: KirType,
+        handler: Block,
+    },
 }
 
 #[derive(Debug, Clone)]

--- a/crates/keel-kir/src/lower/decl.rs
+++ b/crates/keel-kir/src/lower/decl.rs
@@ -114,6 +114,9 @@ pub(crate) fn lower_task_body(
         name: task.name.clone(),
         params,
         ret: sig.ret,
+        // Placeholder — `lower_program`'s `compute_can_raise` fills in the
+        // real value once every function's body is lowered.
+        can_raise: false,
         locals: ctx.locals,
         body,
     })

--- a/crates/keel-kir/src/lower/mod.rs
+++ b/crates/keel-kir/src/lower/mod.rs
@@ -51,8 +51,8 @@ use keel_syntax::ast::{Binding, Decl, Program, TypeDef, UseDecl, UseKind, UseSou
 use keel_syntax::lexer::Span;
 
 use crate::ir::{
-    EnumId, EnumLayout, FuncId, KirFunction, KirProgram, ListId, LocalId, NullableId, StructId,
-    StructLayout,
+    Block, EnumId, EnumLayout, FuncId, KirFunction, KirProgram, ListId, LocalId, NullableId,
+    StructId, StructLayout,
 };
 use crate::span_table::SpanTable;
 use crate::types::KirType;
@@ -133,6 +133,13 @@ pub(crate) struct LowerCtx<'a> {
     /// …) — see the module doc's `CheckArtifacts` section.
     #[allow(dead_code)]
     pub(crate) artifacts: &'a CheckArtifacts,
+    /// The synthetic `UserRaised { message: str }` struct's id, if the
+    /// program uses `raise`/`try`/`catch` anywhere (`lower_program`'s Pass
+    /// 1c) — `None` otherwise. `Stmt::Raise`/`Stmt::TryCatch` lowering
+    /// (`lower/stmt.rs`) only ever runs when this is `Some`, since their
+    /// AST counterparts can't be reached in a program the scan found none
+    /// in.
+    pub(crate) user_raised_struct_id: Option<StructId>,
 }
 
 /// Describes `ty` for a diagnostic message. Same as `KirType`'s own
@@ -307,6 +314,24 @@ pub fn lower_program(
         });
     }
 
+    // Pass 1c: register the synthetic `UserRaised { message: str }` struct
+    // — the shape every caught error binds to (`raise` only ever produces
+    // `UserRaised`; `catch e: Error` and `catch e: UserRaised` both bind
+    // it) — only if the program actually uses `raise`/`try`/`catch`
+    // anywhere. Unconditionally registering it would add a phantom struct
+    // to every program's golden dump, including ones that never raise.
+    let user_raised_struct_id: Option<StructId> = if program_uses_raise_or_try(program) {
+        let id = struct_layouts.len();
+        struct_layouts.push(StructLayout {
+            id,
+            name: "UserRaised".to_string(),
+            fields: vec![("message".to_string(), KirType::Str)],
+        });
+        Some(id)
+    } else {
+        None
+    };
+
     // Pass 2: collect every task signature (so calls resolve regardless of
     // declaration order — forward references, mutual/self recursion) and
     // every `use std/<name>` namespace binding (so namespace calls resolve
@@ -363,6 +388,7 @@ pub fn lower_program(
             nullables: &nullables,
             param_defaults: &empty_param_defaults,
             artifacts,
+            user_raised_struct_id,
         };
         for task in &task_order {
             let sig = &funcs[&task.name];
@@ -383,6 +409,7 @@ pub fn lower_program(
         nullables: &nullables,
         param_defaults: &param_defaults,
         artifacts,
+        user_raised_struct_id,
     };
 
     // Pass 3: lower each task body now that `lcx` is complete.
@@ -413,9 +440,28 @@ pub fn lower_program(
         name: "<toplevel>".to_string(),
         params: Vec::new(),
         ret: KirType::Unit,
+        // Placeholder — `compute_can_raise` fills in the real value for
+        // every function below, once every body (and thus every
+        // `Stmt::Raise`/`CallTarget::Fn` call site) is known.
+        can_raise: false,
         locals: ctx.locals,
         body,
     });
+
+    compute_can_raise(&mut functions)?;
+    if functions[toplevel_id].can_raise {
+        return Err(LowerError::new(
+            "an uncaught `raise` (or call to a function that can raise) reaches the top level \
+             — wrap it in `try`/`catch` (propagating past the top level, changing \
+             `keel_user_toplevel`'s fixed entry-point signature, is a later M2/M3 concern)"
+                .to_string(),
+            program
+                .declarations
+                .last()
+                .map(|d| d.span.clone())
+                .unwrap_or(0..0),
+        ));
+    }
 
     Ok(KirProgram {
         functions,
@@ -426,6 +472,167 @@ pub fn lower_program(
         nullables: nullables.into_inner(),
         span_table,
     })
+}
+
+/// Computes `can_raise` for every function, mutating it in place: a
+/// function is `can_raise` iff it directly executes `Stmt::Raise` outside
+/// any of its own `try` bodies, or makes an uncaught `CallTarget::Fn` call
+/// (same condition) to another `can_raise` function — a fixpoint over the
+/// call graph, since that "another function" may itself only be known
+/// `can_raise` from a later function in declaration order (forward/mutual
+/// recursion). A full re-scan per round (rather than a worklist) is simplest
+/// and plenty fast for these program sizes; converges in at most
+/// `functions.len()` rounds. Also rejects a `can_raise` function whose
+/// return type isn't one the result-ABI's uniformly-boxed payload
+/// representation models (`raise.rs`'s `emit_box_result_value`, on the
+/// `keel-codegen` side): `Struct`/`Enum`/`Nullable` need `Value` marshaling
+/// that doesn't exist yet, a later M2/M3 concern (the synthetic
+/// `UserRaised` struct itself is fine — it's never a function's own `ret`).
+fn compute_can_raise(functions: &mut [KirFunction]) -> Result<(), LowerError> {
+    let mut can_raise = vec![false; functions.len()];
+    loop {
+        let mut changed = false;
+        for (i, f) in functions.iter().enumerate() {
+            if !can_raise[i] && block_escapes_uncaught(&f.body, 0, &can_raise) {
+                can_raise[i] = true;
+                changed = true;
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+    for (f, cr) in functions.iter_mut().zip(can_raise) {
+        f.can_raise = cr;
+        if cr
+            && matches!(
+                f.ret,
+                KirType::Struct(_) | KirType::Enum(_) | KirType::Nullable(_)
+            )
+        {
+            return Err(LowerError::new(
+                format!(
+                    "task `{}` can raise and returns `{}` — only int/float/bool/str/list/none \
+                     return types are modeled for a can-raise function yet (struct/enum/nullable \
+                     need `Value` marshaling, a later M2/M3 concern)",
+                    f.name, f.ret
+                ),
+                0..0,
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Whether any statement in `block` escapes this function uncaught (see
+/// `compute_can_raise`) — `try_depth` counts how many of this function's own
+/// enclosing `try` bodies (not the AST's lexical nesting depth in general,
+/// just `Stmt::TryCatch.body` specifically) the current position is inside;
+/// `0` means "not caught by anything in this function," so a `raise`/an
+/// uncaught call there really does need this function's own `can_raise`.
+fn block_escapes_uncaught(block: &Block, try_depth: usize, can_raise: &[bool]) -> bool {
+    block
+        .iter()
+        .any(|s| stmt_escapes_uncaught(s, try_depth, can_raise))
+}
+
+fn stmt_escapes_uncaught(stmt: &crate::ir::Stmt, try_depth: usize, can_raise: &[bool]) -> bool {
+    use crate::ir::Stmt;
+    match stmt {
+        Stmt::Raise { .. } => try_depth == 0,
+        Stmt::TryCatch { body, handler, .. } => {
+            // `body`'s own raises/calls are caught by *this* try (this
+            // function's `catch` clause is always `Error`/`UserRaised` —
+            // see `ir.rs`'s `Stmt::TryCatch` doc — so every error this
+            // function itself raises or receives is absorbed here); a
+            // failure that already escaped an inner, nested try (deeper
+            // `try_depth`) still stops right here too. `handler` runs at the
+            // *current* depth — it isn't itself protected by the try it's
+            // attached to.
+            block_escapes_uncaught(body, try_depth + 1, can_raise)
+                || block_escapes_uncaught(handler, try_depth, can_raise)
+        }
+        Stmt::Let { init, .. } => expr_escapes_uncaught(init, try_depth, can_raise),
+        Stmt::Assign { value, .. } => expr_escapes_uncaught(value, try_depth, can_raise),
+        Stmt::If {
+            cond,
+            then_branch,
+            else_branch,
+        } => {
+            expr_escapes_uncaught(cond, try_depth, can_raise)
+                || block_escapes_uncaught(then_branch, try_depth, can_raise)
+                || block_escapes_uncaught(else_branch, try_depth, can_raise)
+        }
+        Stmt::While { cond, body } => {
+            expr_escapes_uncaught(cond, try_depth, can_raise)
+                || block_escapes_uncaught(body, try_depth, can_raise)
+        }
+        Stmt::ForIndex {
+            low, high, body, ..
+        } => {
+            expr_escapes_uncaught(low, try_depth, can_raise)
+                || expr_escapes_uncaught(high, try_depth, can_raise)
+                || block_escapes_uncaught(body, try_depth, can_raise)
+        }
+        Stmt::ForEach { list, body, .. } => {
+            expr_escapes_uncaught(list, try_depth, can_raise)
+                || block_escapes_uncaught(body, try_depth, can_raise)
+        }
+        Stmt::Return(Some(e)) => expr_escapes_uncaught(e, try_depth, can_raise),
+        Stmt::Return(None) => false,
+        Stmt::Expr(e) => expr_escapes_uncaught(e, try_depth, can_raise),
+    }
+}
+
+/// Whether `expr` (or anything nested inside it) is a `CallTarget::Fn` call
+/// to an already-known `can_raise` function, at `try_depth == 0`. Recurses
+/// into every `Expr` variant's own sub-expressions — a `can_raise` call
+/// buried inside a `BinOp`/argument list/etc. still needs this function's
+/// own result-ABI, and still needs its `is_err` branch checked at codegen
+/// time regardless of how deeply nested it is (`keel-codegen`'s
+/// `emit_call` does this inline, so no restriction on *where* a `can_raise`
+/// call may appear is needed here beyond the try-depth check itself).
+fn expr_escapes_uncaught(expr: &crate::ir::Expr, try_depth: usize, can_raise: &[bool]) -> bool {
+    use crate::ir::Expr;
+    match expr {
+        Expr::ConstInt(_)
+        | Expr::ConstFloat(_)
+        | Expr::ConstBool(_)
+        | Expr::ConstStr(_)
+        | Expr::Local { .. }
+        | Expr::MakeEnum { .. }
+        | Expr::NullLit { .. } => false,
+        Expr::UnOp { operand, .. } => expr_escapes_uncaught(operand, try_depth, can_raise),
+        Expr::NullSome { value, .. } => expr_escapes_uncaught(value, try_depth, can_raise),
+        Expr::BinOp { left, right, .. } => {
+            expr_escapes_uncaught(left, try_depth, can_raise)
+                || expr_escapes_uncaught(right, try_depth, can_raise)
+        }
+        Expr::NullCoalesce {
+            nullable, fallback, ..
+        } => {
+            expr_escapes_uncaught(nullable, try_depth, can_raise)
+                || expr_escapes_uncaught(fallback, try_depth, can_raise)
+        }
+        Expr::Index { list, index, .. } => {
+            expr_escapes_uncaught(list, try_depth, can_raise)
+                || expr_escapes_uncaught(index, try_depth, can_raise)
+        }
+        Expr::FieldGet { base, .. } | Expr::NullFieldGet { base, .. } => {
+            expr_escapes_uncaught(base, try_depth, can_raise)
+        }
+        Expr::MakeStruct { fields, .. } => fields
+            .iter()
+            .any(|f| expr_escapes_uncaught(f, try_depth, can_raise)),
+        Expr::Call { target, args, .. } => {
+            let self_escapes =
+                try_depth == 0 && matches!(target, crate::ir::CallTarget::Fn(id) if can_raise[*id]);
+            self_escapes
+                || args
+                    .iter()
+                    .any(|a| expr_escapes_uncaught(a, try_depth, can_raise))
+        }
+    }
 }
 
 /// Lowers a `use` declaration into a `ns_bindings` entry (bound identifier
@@ -480,6 +687,52 @@ fn decl_kind_name(decl: &Decl) -> &'static str {
         Decl::Agent(_) => "agent declaration",
         Decl::Use(_) => "use declaration",
         Decl::Stmt(_) => "statement",
+    }
+}
+
+/// Whether `program` uses `raise`/`try`/`catch` anywhere in a task body or
+/// a top-level statement — gates whether the synthetic `UserRaised` struct
+/// (see `lower_program`'s Pass 1c) is registered at all.
+fn program_uses_raise_or_try(program: &Program) -> bool {
+    program.declarations.iter().any(|decl| match &decl.kind {
+        Decl::Task(task) => block_uses_raise_or_try(&task.body),
+        Decl::Stmt(stmt) => stmt_uses_raise_or_try(&stmt.kind),
+        Decl::Type(_)
+        | Decl::Interface(_)
+        | Decl::Impl(_)
+        | Decl::Test(_)
+        | Decl::Extern(_)
+        | Decl::Agent(_)
+        | Decl::Use(_) => false,
+    })
+}
+
+fn block_uses_raise_or_try(block: &keel_syntax::ast::Block) -> bool {
+    block.iter().any(|stmt| stmt_uses_raise_or_try(&stmt.kind))
+}
+
+fn stmt_uses_raise_or_try(stmt: &keel_syntax::ast::Stmt) -> bool {
+    use keel_syntax::ast::Stmt;
+    match stmt {
+        Stmt::Raise(_) | Stmt::TryCatch { .. } => true,
+        Stmt::If {
+            then_body,
+            else_body,
+            ..
+        } => {
+            block_uses_raise_or_try(then_body)
+                || else_body.as_ref().is_some_and(block_uses_raise_or_try)
+        }
+        Stmt::While { body, .. } | Stmt::For { body, .. } => block_uses_raise_or_try(body),
+        Stmt::When { arms, .. } => arms.iter().any(|arm| block_uses_raise_or_try(&arm.body)),
+        Stmt::Let { .. }
+        | Stmt::SelfAssign { .. }
+        | Stmt::Return(_)
+        | Stmt::AugAssign { .. }
+        | Stmt::Assert { .. }
+        | Stmt::Break
+        | Stmt::Continue
+        | Stmt::Expr(_) => false,
     }
 }
 

--- a/crates/keel-kir/src/lower/stmt.rs
+++ b/crates/keel-kir/src/lower/stmt.rs
@@ -230,8 +230,10 @@ pub(crate) fn lower_stmt(
         ast::Stmt::When { subject, arms } => {
             lower_when_stmt(subject, arms, ctx, lcx, table, ret_ty, &stmt.span)
         }
-        ast::Stmt::TryCatch { .. } => Err(LowerError::unsupported("try/catch", stmt.span.clone())),
-        ast::Stmt::Raise(_) => Err(LowerError::unsupported("raise", stmt.span.clone())),
+        ast::Stmt::TryCatch { body, catches } => {
+            lower_try_catch(body, catches, ctx, lcx, table, ret_ty, &stmt.span)
+        }
+        ast::Stmt::Raise(message) => lower_raise(message, ctx, lcx, table),
         ast::Stmt::Assert { .. } => Err(LowerError::unsupported("assert", stmt.span.clone())),
         ast::Stmt::Break => Err(LowerError::unsupported("break", stmt.span.clone())),
         ast::Stmt::Continue => Err(LowerError::unsupported("continue", stmt.span.clone())),
@@ -455,4 +457,96 @@ fn lower_pattern_test(
             stmt_span.clone(),
         )),
     }
+}
+
+/// Lowers `raise expr` to the synthetic `UserRaised { message: str }`
+/// struct's construction (reusing `Expr::MakeStruct` wholesale — see
+/// `ir.rs`'s `Stmt::Raise` doc). `expr` must already be `Str`-typed; the
+/// interpreter's non-`str` `Display`-coercion path (`raise 42` becomes
+/// `"42"`) is a later M2/M3 concern.
+fn lower_raise(
+    message: &ast::SpannedExpr,
+    ctx: &mut FnCtx,
+    lcx: &LowerCtx<'_>,
+    table: &mut SpanTable,
+) -> Result<ir::Stmt, LowerError> {
+    let message_e = lower_expr(message, ctx, lcx, table)?;
+    if message_e.ty() != KirType::Str {
+        return Err(LowerError::new(
+            format!(
+                "`raise` of a `{}` value (only a `str` message is supported; the interpreter's \
+                 non-`str` `Display`-coercion path is a later M2/M3 concern)",
+                super::describe_ty(message_e.ty(), lcx)
+            ),
+            message.span.clone(),
+        ));
+    }
+    let struct_id = lcx
+        .user_raised_struct_id
+        .expect("program_uses_raise_or_try found this Stmt::Raise, so the synthetic struct exists");
+    let span = table.intern(message.span.clone());
+    Ok(ir::Stmt::Raise {
+        error: ir::Expr::MakeStruct {
+            struct_id,
+            fields: vec![message_e],
+        },
+        span,
+    })
+}
+
+/// Lowers `try { body } catch binder: Ty { handler }`. Only a single catch
+/// clause of type `Error` or `UserRaised` is supported — both bind the same
+/// synthetic `UserRaised` shape, since `raise` only ever produces one (see
+/// `ir.rs`'s `Stmt::TryCatch` doc); multiple clauses, or a clause over any
+/// other type name, are rejected rather than silently only-partially
+/// modeled.
+fn lower_try_catch(
+    body: &ast::Block,
+    catches: &[ast::CatchClause],
+    ctx: &mut FnCtx,
+    lcx: &LowerCtx<'_>,
+    table: &mut SpanTable,
+    ret_ty: KirType,
+    stmt_span: &Span,
+) -> Result<ir::Stmt, LowerError> {
+    let [catch] = catches else {
+        return Err(LowerError::unsupported(
+            "multiple catch clauses (only a single `catch e: Error` or `catch e: UserRaised` \
+             clause is supported until per-namespace error kinds are modeled, a later M2/M3 \
+             concern)",
+            stmt_span.clone(),
+        ));
+    };
+    let ast::TypeExpr::Named(caught_name) = &catch.ty.kind else {
+        return Err(LowerError::unsupported(
+            "catch clause over a non-named type",
+            catch.ty.span.clone(),
+        ));
+    };
+    if caught_name != "Error" && caught_name != "UserRaised" {
+        return Err(LowerError::unsupported(
+            "catch clause over an error type other than `Error`/`UserRaised` (per-namespace \
+             error kinds — FileError, HttpError, … — aren't modeled by the compiled backend \
+             yet, a later M2/M3 concern)",
+            catch.ty.span.clone(),
+        ));
+    }
+    let struct_id = lcx.user_raised_struct_id.expect(
+        "program_uses_raise_or_try found this Stmt::TryCatch, so the synthetic struct exists",
+    );
+
+    let body = lower_block(body, ctx, lcx, table, ret_ty)?;
+
+    let binder_ty = KirType::Struct(struct_id);
+    ctx.push_scope();
+    let binder = ctx.declare(&catch.name, binder_ty);
+    let handler = lower_block(&catch.body, ctx, lcx, table, ret_ty)?;
+    ctx.pop_scope();
+
+    Ok(ir::Stmt::TryCatch {
+        body,
+        binder,
+        binder_ty,
+        handler,
+    })
 }

--- a/crates/keel-kir/src/passes/verify.rs
+++ b/crates/keel-kir/src/passes/verify.rs
@@ -267,6 +267,51 @@ fn verify_stmt(program: &KirProgram, func: &KirFunction, stmt: &Stmt) -> Result<
             Ok(())
         }
         Stmt::Expr(expr) => verify_expr(program, func, expr),
+        Stmt::Raise { error, .. } => {
+            verify_expr(program, func, error)?;
+            let KirType::Struct(struct_id) = error.ty() else {
+                return Err(format!("raise error is {}, expected a struct", error.ty()));
+            };
+            check_struct(program, struct_id)?;
+            verify_user_raised_shape(program, struct_id)
+        }
+        Stmt::TryCatch {
+            body,
+            binder,
+            binder_ty,
+            handler,
+        } => {
+            check_local(func, *binder)?;
+            verify_block(program, func, body)?;
+            let declared = func.locals[*binder].ty;
+            if declared != *binder_ty {
+                return Err(format!(
+                    "catch binder {binder} is declared {declared} but binder_ty claims {binder_ty}"
+                ));
+            }
+            let KirType::Struct(struct_id) = *binder_ty else {
+                return Err(format!("catch binder_ty is {binder_ty}, expected a struct"));
+            };
+            check_struct(program, struct_id)?;
+            verify_user_raised_shape(program, struct_id)?;
+            verify_block(program, func, handler)
+        }
+    }
+}
+
+/// Both `Stmt::Raise`'s constructed error value and `Stmt::TryCatch`'s
+/// binder must be the synthetic `UserRaised { message: str }` shape (see
+/// `ir.rs`'s `Stmt::TryCatch` doc) — checked structurally rather than by a
+/// hardcoded id, since `verify` has no `LowerCtx` to compare against.
+fn verify_user_raised_shape(program: &KirProgram, struct_id: StructId) -> Result<(), String> {
+    let layout = &program.structs[struct_id];
+    match layout.fields.as_slice() {
+        [(name, KirType::Str)] if name == "message" => Ok(()),
+        _ => Err(format!(
+            "struct `{}` used as a raise/catch error value doesn't have the expected \
+             `{{ message: str }}` shape",
+            layout.name
+        )),
     }
 }
 

--- a/crates/keel-kir/tests/fixtures/raise_try_catch.keel
+++ b/crates/keel-kir/tests/fixtures/raise_try_catch.keel
@@ -1,0 +1,16 @@
+task a() -> int {
+  raise "boom"
+}
+
+task b() -> int {
+  return a()
+}
+
+task c() -> int {
+  try {
+    result = b()
+    return result
+  } catch e: Error {
+    return -1
+  }
+}

--- a/crates/keel-kir/tests/fixtures/raise_try_catch.kir
+++ b/crates/keel-kir/tests/fixtures/raise_try_catch.kir
@@ -1,0 +1,21 @@
+struct UserRaised { message: str }
+
+fn a() -> int can_raise {
+  raise UserRaised { message: "boom" }
+}
+
+fn b() -> int can_raise {
+  return a()
+}
+
+fn c() -> int {
+  try {
+    let result: int = b()
+    return result
+  } catch e: UserRaised {
+    return (-1)
+  }
+}
+
+fn <toplevel>() -> none {
+}

--- a/crates/keel-kir/tests/lower_errors.rs
+++ b/crates/keel-kir/tests/lower_errors.rs
@@ -723,3 +723,107 @@ task f(p: Point) -> str {
         "unexpected message: {msg}"
     );
 }
+
+#[test]
+fn multiple_catch_clauses_are_rejected() {
+    // Only a single `catch e: Error`/`catch e: UserRaised` clause is
+    // supported — both bind the same synthetic `UserRaised` shape, since
+    // `raise` only ever produces one; per-namespace error kinds (a second,
+    // distinct clause could meaningfully match) aren't modeled yet.
+    let msg = lower_err(
+        r#"
+task f() -> int {
+  try {
+    raise "x"
+  } catch e: UserRaised {
+    return 1
+  } catch e: Error {
+    return 2
+  }
+  return 0
+}
+"#,
+    );
+    assert!(
+        msg.contains("multiple catch clauses"),
+        "unexpected message: {msg}"
+    );
+}
+
+#[test]
+fn catch_clause_over_a_non_error_type_is_rejected() {
+    // Per-namespace error kinds (FileError, HttpError, ...) aren't modeled
+    // by the compiled backend yet — only `Error`/`UserRaised` bind the
+    // synthetic shape this issue's `raise` produces.
+    let msg = lower_err(
+        r#"
+task f() -> int {
+  try {
+    raise "x"
+  } catch e: FileError {
+    return 1
+  }
+  return 0
+}
+"#,
+    );
+    assert!(
+        msg.contains("error type other than `Error`/`UserRaised`"),
+        "unexpected message: {msg}"
+    );
+}
+
+#[test]
+fn raise_of_a_non_str_value_is_rejected() {
+    // The interpreter's non-`str` `Display`-coercion path (`raise 42`
+    // becomes `"42"`) is a later M2/M3 concern — only a `str` message
+    // lowers in this issue.
+    let msg = lower_err(
+        r#"
+task f() -> int {
+  raise 42
+}
+"#,
+    );
+    assert!(msg.contains("`raise` of a"), "unexpected message: {msg}");
+}
+
+#[test]
+fn a_can_raise_task_returning_a_struct_is_rejected() {
+    // The result-ABI's success payload is uniformly boxed via
+    // `keel_box_*`/`unbox_value` — struct/enum/nullable return types need
+    // `Value` marshaling that doesn't exist yet.
+    let msg = lower_err(
+        r#"
+type Point { x: int, y: int }
+
+task f() -> Point {
+  raise "x"
+}
+"#,
+    );
+    assert!(
+        msg.contains("can raise and returns"),
+        "unexpected message: {msg}"
+    );
+}
+
+#[test]
+fn an_uncaught_raise_reaching_the_top_level_is_rejected() {
+    // Propagating past the top level would need to change
+    // `keel_user_toplevel`'s fixed `-> i32` entry-point signature — a later
+    // M2/M3 concern; wrap in `try`/`catch` instead.
+    let msg = lower_err(
+        r#"
+task a() -> int {
+  raise "x"
+}
+
+x = a()
+"#,
+    );
+    assert!(
+        msg.contains("reaches the top level"),
+        "unexpected message: {msg}"
+    );
+}


### PR DESCRIPTION
## Summary

- Every task that can raise — directly via `raise`, or by making an uncaught call to another can-raise task — now compiles to a result-ABI signature instead of its plain return type: `{ i1 is_err, ptr payload }`, uniformly boxed on both branches so it reuses the existing `keel_box_*`/`unbox_value` machinery rather than adding a parallel one.
- `can_raise` is computed by a whole-program fixpoint over the `CallTarget::Fn` call graph (handles forward/mutual recursion). `CallTarget::Ns` calls are deliberately untouched — no M1/M2 namespace method actually produces `is_err` yet, so propagating through them would mark nearly every task `can_raise` and cascade to the toplevel entry point, breaking its fixed `-> i32` exit-code ABI. A `raise`/an uncaught call only counts toward `can_raise` if it isn't already inside one of the function's own `try` bodies, so a locally caught error doesn't force its enclosing function to participate.
- `raise`'s error value reuses the struct-literal machinery wholesale: it builds a synthetic `UserRaised { message: str }` struct (registered only when a program actually uses `raise`/`try`/`catch`, so unrelated golden dumps stay unaffected) — the same shape `catch e: Error`/`catch e: UserRaised` binds to, so `e.message` field access is ordinary struct-field codegen with zero special-casing.
- `try`/`catch` codegen: a `can_raise` call's `is_err` branch (inline at the call site, regardless of how deeply it's nested in an expression — this composes naturally with LLVM basic blocks, no syntactic position restriction needed) either stores the payload into the innermost active `try`'s binder and jumps to its handler, or propagates by returning the current function's own error branch if no `try` is active.
- Extends the KIR dump (`fn ... can_raise {` marker), golden-dump fixture/test, and `passes/verify.rs`.
- Deferred, rejected at lowering rather than silently dropped: multiple catch clauses, a catch clause over any error type other than `Error`/`UserRaised` (per-namespace error kinds aren't modeled), raising a non-`str` value (the interpreter's `Display`-coercion path), a can-raise task returning a struct/enum/nullable (needs `Value` marshaling that doesn't exist yet), and an uncaught raise reaching the top level (would need to change `keel_user_toplevel`'s fixed entry-point signature).

## Test plan

- [x] Golden-dump fixture (`raise_try_catch.keel`/`.kir`) stable across reruns — confirms the fixpoint correctly marks `a`/`b` as `can_raise` and `c`/toplevel as not (`c`'s own `try`/`catch` absorbs everything)
- [x] Codegen integration tests (`crates/keel-codegen/tests/raise_try_catch.rs`): propagation through an uncaught caller then caught further up, a direct `raise` inside a `try`, and a `none`-returning `can_raise` task falling through on the success path — all matching the interpreter byte-for-byte
- [x] `lower_errors.rs`: 5 new rejection tests for the deferrals above
- [x] `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings` (default and `--features build-backend`)
- [x] `cargo test --workspace` (default and `--features build-backend`) — confirms no regression in existing direct-call (`CallTarget::Fn`) codegen paths, since `emit_call` now branches on every callee's `can_raise` flag
- [x] Conformance suite (`--test conformance`), 3x for stability

Close #150