### PR TITLE
keel-kir: when-as-expression in let/return position (#160)

### DIFF
--- a/crates/keel-codegen/src/func.rs
+++ b/crates/keel-codegen/src/func.rs
@@ -64,6 +64,12 @@ pub(crate) struct FuncCtx<'ctx, 'a> {
     /// see the module doc) means "exit 0 now" instead of `ret void`.
     pub(crate) is_toplevel: bool,
     pub(crate) locals: HashMap<LocalId, PointerValue<'ctx>>,
+    /// This function's `KirFunction::locals` metadata (name/declared type per
+    /// `LocalId`) — needed by `stmt.rs`'s `Stmt::Let { init: None, .. }` arm
+    /// (a `when`-as-expression result temp, issue #160) to recover the
+    /// local's declared type when there's no `init` expression to read it
+    /// from.
+    pub(crate) local_types: &'a [keel_kir::ir::Local],
     /// This function's own logical return type (`KirFunction::ret`) — needed
     /// by `raise.rs`'s `emit_ok_return` to box a `return`/fallthrough value
     /// into the result-ABI's payload slot.
@@ -138,6 +144,7 @@ pub(crate) fn emit_function<'ctx>(
         functions,
         is_toplevel: false,
         locals: HashMap::new(),
+        local_types: &func.locals,
         ret_ty: func.ret,
         can_raise: func.can_raise,
         catch_stack: Vec::new(),
@@ -186,6 +193,7 @@ pub(crate) fn emit_toplevel_function<'ctx>(
         functions,
         is_toplevel: true,
         locals: HashMap::new(),
+        local_types: &toplevel.locals,
         ret_ty: KirType::Unit,
         // `lower_program` rejects a `can_raise` toplevel (an uncaught raise
         // reaching the top level is a later M2/M3 concern — see its doc) —

--- a/crates/keel-codegen/src/stmt.rs
+++ b/crates/keel-codegen/src/stmt.rs
@@ -41,13 +41,24 @@ fn emit_stmt<'ctx>(
 ) -> Result<Option<(BasicValueEnum<'ctx>, KirType)>, CodegenError> {
     match stmt {
         Stmt::Let { local, init } => {
-            let value = expr::emit_expr(fcx, init)?;
-            let ty = layout::llvm_type(fcx.context, fcx.program, init.ty())?;
+            // `init: None` declares a `when`-as-expression result temp
+            // (issue #160) with no initial store — its declared type comes
+            // from `KirFunction::locals` (there's no `init` expression to
+            // read it from), and each arm's `Stmt::Assign` supplies the
+            // real value before the local is ever read.
+            let declared_ty = match init {
+                Some(init) => init.ty(),
+                None => fcx.local_types[*local].ty,
+            };
+            let ty = layout::llvm_type(fcx.context, fcx.program, declared_ty)?;
             let ptr = fcx
                 .builder
                 .build_alloca(ty, &format!("local.{local}"))
                 .map_err(llvm_err)?;
-            fcx.builder.build_store(ptr, value).map_err(llvm_err)?;
+            if let Some(init) = init {
+                let value = expr::emit_expr(fcx, init)?;
+                fcx.builder.build_store(ptr, value).map_err(llvm_err)?;
+            }
             fcx.locals.insert(*local, ptr);
             Ok(None)
         }

--- a/crates/keel-codegen/tests/when_expr.rs
+++ b/crates/keel-codegen/tests/when_expr.rs
@@ -1,0 +1,96 @@
+//! Exit criterion for issue #160: `when` used as an expression in `let`
+//! position (`result = when ... { ... }`) and `return` position compiles,
+//! links, and matches the interpreter — including
+//! `examples/when_expression.keel`'s `grade` task verbatim.
+
+use std::process::Command;
+
+use keel_codegen::BuildOptions;
+
+#[path = "support/mod.rs"]
+mod support;
+
+fn compile_and_run(source: &str) -> std::process::Output {
+    let kir = support::parse_check_and_lower(source);
+
+    let out_dir = tempfile::tempdir().expect("create temp out dir");
+    let opts = BuildOptions {
+        out_dir: out_dir.path().to_path_buf(),
+        runtime_link_args: support::runtime_link_args().clone(),
+    };
+    let bin = keel_codegen::compile(&kir, &opts).expect("compile must succeed");
+    Command::new(&bin).output().expect("run compiled binary")
+}
+
+fn assert_stdout_matches_interpreter(source: &str) -> Vec<u8> {
+    let compiled = compile_and_run(source);
+    let interpreted = support::run_interpreter(source);
+    assert_eq!(
+        String::from_utf8_lossy(&compiled.stdout),
+        String::from_utf8_lossy(&interpreted.stdout),
+        "compiled stdout must match the interpreter's"
+    );
+    compiled.stdout
+}
+
+#[test]
+fn when_expression_in_let_position_matches_the_interpreter() {
+    let source = r#"
+use std/io
+
+task grade(score: str) -> str {
+  result = when score {
+    "A" => "excellent"
+    "B" => "good"
+    "C" => "fair"
+    _ => "needs work"
+  }
+  return result
+}
+
+io.show(grade("A"))
+io.show(grade("D"))
+"#;
+    let stdout = assert_stdout_matches_interpreter(source);
+    assert_eq!(stdout, b"  excellent\n  needs work\n");
+}
+
+#[test]
+fn when_expression_in_return_position_matches_the_interpreter() {
+    let source = r#"
+use std/io
+
+task grade(score: str) -> str {
+  return when score {
+    "A" => "excellent"
+    _ => "needs work"
+  }
+}
+
+io.show(grade("A"))
+io.show(grade("Z"))
+"#;
+    assert_stdout_matches_interpreter(source);
+}
+
+#[test]
+fn when_expression_example_grade_task_matches_the_interpreter() {
+    // `examples/when_expression.keel`'s `grade` task verbatim.
+    let source = r#"
+use std/io
+
+task grade(score: str) -> str {
+  result = when score {
+    "A" => "excellent"
+    "B" => "good"
+    "C" => "fair"
+    _ => "needs work"
+  }
+  result
+}
+
+io.show(grade("A"))
+io.show(grade("D"))
+"#;
+    assert_stdout_matches_interpreter(source);
+}

--- a/crates/keel-kir/src/dump.rs
+++ b/crates/keel-kir/src/dump.rs
@@ -102,13 +102,20 @@ fn dump_stmt(
     match stmt {
         Stmt::Let { local, init } => {
             let l = &func.locals[*local];
-            let _ = writeln!(
-                out,
-                "let {}: {} = {}",
-                l.name,
-                fmt_ty(program, l.ty),
-                fmt_expr(program, func, init)
-            );
+            match init {
+                Some(init) => {
+                    let _ = writeln!(
+                        out,
+                        "let {}: {} = {}",
+                        l.name,
+                        fmt_ty(program, l.ty),
+                        fmt_expr(program, func, init)
+                    );
+                }
+                None => {
+                    let _ = writeln!(out, "let {}: {}", l.name, fmt_ty(program, l.ty));
+                }
+            }
         }
         Stmt::Assign { local, value } => {
             let l = &func.locals[*local];

--- a/crates/keel-kir/src/ir.rs
+++ b/crates/keel-kir/src/ir.rs
@@ -174,10 +174,15 @@ pub type Block = Vec<Stmt>;
 #[derive(Debug, Clone)]
 pub enum Stmt {
     /// `x = expr` — always declares a fresh local (Keel assignment scoping:
-    /// plain `=` shadows in the current scope).
+    /// plain `=` shadows in the current scope). `init: None` declares the
+    /// local without an initial value (`keel-codegen`'s `Stmt::Let` arm
+    /// still allocates storage but skips the initial store) — used only by
+    /// `when`-as-expression's let-position lowering (issue #160), where the
+    /// value depends on which arm runs: a subsequent `Stmt::Assign` in each
+    /// arm's branch supplies the real value before the local is ever read.
     Let {
         local: LocalId,
-        init: Expr,
+        init: Option<Expr>,
     },
     /// `x += expr` (and other augmented-assign ops) — desugared to a plain
     /// store against the *existing* local it resolved to; the RHS already

--- a/crates/keel-kir/src/lower/decl.rs
+++ b/crates/keel-kir/src/lower/decl.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 
 use keel_syntax::ast::TaskDecl;
 
+use super::stmt::TailSink;
 use super::{FnCtx, FuncSig, LowerCtx, LowerError, binding_ident, ty_expr_to_kir};
 use crate::ir::{EnumId, Expr, KirFunction, Param, StructId};
 use crate::span_table::SpanTable;
@@ -107,7 +108,8 @@ pub(crate) fn lower_task_body(
         params.push(Param { local, ty: *ty });
     }
 
-    let body = super::stmt::lower_block(&task.body, &mut ctx, lcx, table, sig.ret, true)?;
+    let body =
+        super::stmt::lower_block(&task.body, &mut ctx, lcx, table, sig.ret, TailSink::Return)?;
     if sig.ret != KirType::Unit && !super::stmt::block_terminates(&body) {
         return Err(LowerError::new(
             format!(

--- a/crates/keel-kir/src/lower/mod.rs
+++ b/crates/keel-kir/src/lower/mod.rs
@@ -426,13 +426,13 @@ pub fn lower_program(
     let mut body = Vec::new();
     for decl in &program.declarations {
         if let Decl::Stmt(stmt) = &decl.kind {
-            body.push(stmt::lower_stmt(
+            body.extend(stmt::lower_stmt(
                 stmt,
                 &mut ctx,
                 &lcx,
                 &mut span_table,
                 KirType::Unit,
-                false,
+                stmt::TailSink::Discard,
             )?);
         }
     }
@@ -553,7 +553,9 @@ fn stmt_escapes_uncaught(stmt: &crate::ir::Stmt, try_depth: usize, can_raise: &[
             block_escapes_uncaught(body, try_depth + 1, can_raise)
                 || block_escapes_uncaught(handler, try_depth, can_raise)
         }
-        Stmt::Let { init, .. } => expr_escapes_uncaught(init, try_depth, can_raise),
+        Stmt::Let { init, .. } => init
+            .as_ref()
+            .is_some_and(|init| expr_escapes_uncaught(init, try_depth, can_raise)),
         Stmt::Assign { value, .. } => expr_escapes_uncaught(value, try_depth, can_raise),
         Stmt::If {
             cond,

--- a/crates/keel-kir/src/lower/stmt.rs
+++ b/crates/keel-kir/src/lower/stmt.rs
@@ -1,13 +1,14 @@
 //! Statement lowering — the M0 scalar subset plus M1's `for`-over-ranges
 //! and M2's named-struct literals in `let`/`return` position, `when` as
 //! a statement (over a simple-enum or a str/int scrutinee with a wildcard
-//! arm — see [`lower_when_stmt`]), and `for x in xs` over a `list[T]`
-//! (lowered to [`keel_kir::ir::Stmt::ForEach`]): `let`/assign, `if`/`else`,
-//! `while`, `for x in a..b`, `for x in xs`, `return`, `when`, and bare
-//! expression statements. Everything else (`try`/`catch`, `raise`, `assert`,
-//! `break`/`continue`, `self.field = ...`, `for` with a `where` filter or a
-//! non-range, non-list iterable) is rejected; see module docs on
-//! `lower/mod.rs`.
+//! arm — see [`lower_when_stmt`]) and *as an expression* in `let`/`return`
+//! position (see [`TailSink::Assign`] and [`lower_when_expr_let`]), and
+//! `for x in xs` over a `list[T]` (lowered to [`keel_kir::ir::Stmt::ForEach`]):
+//! `let`/assign, `if`/`else`, `while`, `for x in a..b`, `for x in xs`,
+//! `return`, `when`, and bare expression statements. Everything else
+//! (`try`/`catch`, `raise`, `assert`, `break`/`continue`, `self.field = ...`,
+//! `for` with a `where` filter or a non-range, non-list iterable) is
+//! rejected; see module docs on `lower/mod.rs`.
 
 use keel_syntax::ast::{self, Node};
 use keel_syntax::lexer::Span;
@@ -19,54 +20,88 @@ use crate::types::KirType;
 
 use super::expr::{lower_expr, lower_expr_expecting, struct_spread_base};
 
-/// Lowers a `{ ... }` block in its own child scope. `is_tail` marks whether
-/// falling off the end of *this block* falls off the end of the enclosing
-/// task body — i.e. whether its last statement is in implicit-tail-return
-/// position (see [`lower_stmt`]'s `ast::Stmt::Expr` arm and the module doc
-/// on tail-position desugaring, issue #159). Only the block's own last
-/// statement inherits `is_tail`; every earlier statement gets `false`
-/// regardless of the block's own tailness.
+/// What a bare tail expression (the last statement of a block, reached in
+/// tail position — see [`lower_block`]) desugars into. Generalizes issue
+/// #159's `is_tail: bool` so the same tail-position plumbing serves both
+/// a task's own implicit return and issue #160's `when`-as-expression,
+/// which needs the arm's tail value written into a temporary rather than
+/// returned outright.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TailSink {
+    /// Not a tail position (or the enclosing function returns `Unit`) — a
+    /// bare tail expression is just evaluated for its side effect, same as
+    /// any other expression statement.
+    Discard,
+    /// The task's own implicit return (issue #159): a bare tail expression
+    /// becomes `return <expr>`.
+    Return,
+    /// A `when`-expression's result local (issue #160): a bare tail
+    /// expression becomes `<local> = <expr>` instead of a `return` — used
+    /// while lowering each arm of a `when` used as an expression, where the
+    /// arm's "tail value" is the value the whole `when`-expression produces,
+    /// not the enclosing function's return value.
+    Assign(LocalId),
+}
+
+/// Lowers a `{ ... }` block in its own child scope. `sink` is what the
+/// block's own last statement's tail position desugars into (see
+/// [`TailSink`]) — only that last statement inherits `sink`; every earlier
+/// statement gets [`TailSink::Discard`] regardless of the block's own
+/// tailness.
 pub(crate) fn lower_block(
     block: &ast::Block,
     ctx: &mut FnCtx,
     lcx: &LowerCtx<'_>,
     table: &mut SpanTable,
     ret_ty: KirType,
-    is_tail: bool,
+    sink: TailSink,
 ) -> Result<Block, LowerError> {
     ctx.push_scope();
     let last_idx = block.len().checked_sub(1);
     let mut out = Vec::with_capacity(block.len());
     for (i, stmt) in block.iter().enumerate() {
-        let stmt_is_tail = is_tail && Some(i) == last_idx;
-        out.push(lower_stmt(stmt, ctx, lcx, table, ret_ty, stmt_is_tail)?);
+        let stmt_sink = if Some(i) == last_idx {
+            sink
+        } else {
+            TailSink::Discard
+        };
+        out.extend(lower_stmt(stmt, ctx, lcx, table, ret_ty, stmt_sink)?);
     }
     ctx.pop_scope();
     Ok(out)
 }
 
-/// Lowers a single statement. Does not open its own scope — callers that
-/// need block scoping (`if`/`while` bodies) go through [`lower_block`]; the
-/// synthetic top-level function lowers its statements directly into the
-/// function's single root scope.
+/// Lowers a single statement, possibly to more than one [`ir::Stmt`] (a
+/// `let`/`return` whose value is a `when`-expression desugars to a
+/// declare-only `Let` followed by an `if`-chain that assigns into it, or
+/// the chain itself — see [`lower_when_expr_let`]). Does not open its own
+/// scope — callers that need block scoping (`if`/`while` bodies) go through
+/// [`lower_block`]; the synthetic top-level function lowers its statements
+/// directly into the function's single root scope.
 ///
-/// `is_tail` is only ever `true` for a statement that is the last statement
-/// of a block reached in tail position from the task's own body — `if`/
-/// `else` branches (and, transitively, `when` arms, already desugared to
-/// nested `if`s by [`lower_when_stmt`]) propagate their own `is_tail` into
-/// both branches; a `while`/`for` body is never a tail position (loops
-/// aren't exhaustive) and always lowers with `is_tail = false`.
+/// `sink` is only ever non-[`TailSink::Discard`] for a statement that is
+/// the last statement of a block reached in tail position from the task's
+/// own body (or from a `when`-expression's own tail position) — `if`/`else`
+/// branches (and, transitively, `when` arms, already desugared to nested
+/// `if`s by [`lower_when_stmt`]) propagate their own `sink` into both
+/// branches; a `while`/`for` body is never a tail position (loops aren't
+/// exhaustive) and always lowers with `sink = TailSink::Discard`.
 pub(crate) fn lower_stmt(
     stmt: &Node<ast::Stmt>,
     ctx: &mut FnCtx,
     lcx: &LowerCtx<'_>,
     table: &mut SpanTable,
     ret_ty: KirType,
-    is_tail: bool,
-) -> Result<ir::Stmt, LowerError> {
+    sink: TailSink,
+) -> Result<Vec<ir::Stmt>, LowerError> {
     match &stmt.kind {
         ast::Stmt::Let { binding, ty, value } => {
             let name = binding_ident(binding, &stmt.span)?;
+            if let ast::Expr::WhenExpr { subject, arms } = &value.kind {
+                return lower_when_expr_let(
+                    name, ty, subject, arms, ctx, lcx, table, ret_ty, &stmt.span,
+                );
+            }
             // An explicit annotation pins the expected type up front — this
             // is what lets a struct literal (which the checker always types
             // as an unnamed structural shape, see `lower/mod.rs`'s
@@ -92,7 +127,10 @@ pub(crate) fn lower_stmt(
             };
             let declared_ty = init.ty();
             let local = ctx.declare(name, declared_ty);
-            Ok(ir::Stmt::Let { local, init })
+            Ok(vec![ir::Stmt::Let {
+                local,
+                init: Some(init),
+            }])
         }
         ast::Stmt::AugAssign {
             name,
@@ -124,7 +162,7 @@ pub(crate) fn lower_stmt(
                 right: Box::new(rhs_expr),
                 ty: result_ty,
             };
-            Ok(ir::Stmt::Assign { local, value })
+            Ok(vec![ir::Stmt::Assign { local, value }])
         }
         ast::Stmt::Return(None) => {
             if ret_ty != KirType::Unit {
@@ -133,11 +171,31 @@ pub(crate) fn lower_stmt(
                     stmt.span.clone(),
                 ));
             }
-            Ok(ir::Stmt::Return(None))
+            Ok(vec![ir::Stmt::Return(None)])
         }
         ast::Stmt::Return(Some(value)) => {
+            if let ast::Expr::WhenExpr { subject, arms } = &value.kind {
+                // `return when ... { ... }` — each arm's tail value returns
+                // directly (no intermediate temp needed, unlike the `let`
+                // case): reuses the exact same chain-building machinery as
+                // `when` used as a statement (issue #146), just with
+                // `TailSink::Return` instead of whatever sink this `return`
+                // itself was lowered under (a `return` is always a genuine
+                // return regardless of its own tail position).
+                let chain = lower_when_stmt(
+                    subject,
+                    arms,
+                    ctx,
+                    lcx,
+                    table,
+                    ret_ty,
+                    TailSink::Return,
+                    &stmt.span,
+                )?;
+                return Ok(vec![chain]);
+            }
             let expr = lower_expr_expecting(value, ret_ty, ctx, lcx, table)?;
-            Ok(ir::Stmt::Return(Some(expr)))
+            Ok(vec![ir::Stmt::Return(Some(expr))])
         }
         ast::Stmt::If {
             cond,
@@ -151,16 +209,16 @@ pub(crate) fn lower_stmt(
                     cond.span.clone(),
                 ));
             }
-            let then_branch = lower_block(then_body, ctx, lcx, table, ret_ty, is_tail)?;
+            let then_branch = lower_block(then_body, ctx, lcx, table, ret_ty, sink)?;
             let else_branch = match else_body {
-                Some(body) => lower_block(body, ctx, lcx, table, ret_ty, is_tail)?,
+                Some(body) => lower_block(body, ctx, lcx, table, ret_ty, sink)?,
                 None => Vec::new(),
             };
-            Ok(ir::Stmt::If {
+            Ok(vec![ir::Stmt::If {
                 cond: cond_expr,
                 then_branch,
                 else_branch,
-            })
+            }])
         }
         ast::Stmt::While { cond, body } => {
             let cond_expr = lower_expr(cond, ctx, lcx, table)?;
@@ -170,25 +228,32 @@ pub(crate) fn lower_stmt(
                     cond.span.clone(),
                 ));
             }
-            let body = lower_block(body, ctx, lcx, table, ret_ty, false)?;
-            Ok(ir::Stmt::While {
+            let body = lower_block(body, ctx, lcx, table, ret_ty, TailSink::Discard)?;
+            Ok(vec![ir::Stmt::While {
                 cond: cond_expr,
                 body,
-            })
+            }])
         }
-        ast::Stmt::Expr(expr) => {
+        ast::Stmt::Expr(expr) => match sink {
+            TailSink::Discard => Ok(vec![ir::Stmt::Expr(lower_expr(expr, ctx, lcx, table)?)]),
             // A bare tail expression implicitly returns its value (mirrors
             // `exec_block`'s `StmtOutcome::Value` in the interpreter, issue
-            // #159) — but only when it's genuinely in tail position and the
-            // task actually returns a value; a `Unit`-returning task's tail
-            // expression is still just evaluated for its side effect.
-            if is_tail && ret_ty != KirType::Unit {
+            // #159) — but only when the task actually returns a value; a
+            // `Unit`-returning task's tail expression is still just
+            // evaluated for its side effect.
+            TailSink::Return if ret_ty != KirType::Unit => {
                 let value = lower_expr_expecting(expr, ret_ty, ctx, lcx, table)?;
-                Ok(ir::Stmt::Return(Some(value)))
-            } else {
-                Ok(ir::Stmt::Expr(lower_expr(expr, ctx, lcx, table)?))
+                Ok(vec![ir::Stmt::Return(Some(value))])
             }
-        }
+            TailSink::Return => Ok(vec![ir::Stmt::Expr(lower_expr(expr, ctx, lcx, table)?)]),
+            // A `when`-expression arm's tail value (issue #160) — written
+            // into the result local instead of returned.
+            TailSink::Assign(local) => {
+                let expected = ctx.locals[local].ty;
+                let value = lower_expr_expecting(expr, expected, ctx, lcx, table)?;
+                Ok(vec![ir::Stmt::Assign { local, value }])
+            }
+        },
         ast::Stmt::SelfAssign { .. } => Err(LowerError::unsupported(
             "self.field assignment",
             stmt.span.clone(),
@@ -220,14 +285,14 @@ pub(crate) fn lower_stmt(
                 let elem_ty = lcx.lists.borrow()[list_id];
                 ctx.push_scope();
                 let var = ctx.declare(name, elem_ty);
-                let body = lower_block(body, ctx, lcx, table, ret_ty, false)?;
+                let body = lower_block(body, ctx, lcx, table, ret_ty, TailSink::Discard)?;
                 ctx.pop_scope();
-                return Ok(ir::Stmt::ForEach {
+                return Ok(vec![ir::Stmt::ForEach {
                     var,
                     elem_ty,
                     list: iter_e,
                     body,
-                });
+                }]);
             };
             // Bounds are evaluated once, before `var` exists, so they lower
             // in the enclosing scope and cannot reference the loop variable.
@@ -247,32 +312,33 @@ pub(crate) fn lower_stmt(
             }
             ctx.push_scope();
             let var = ctx.declare(name, KirType::I64);
-            let body = lower_block(body, ctx, lcx, table, ret_ty, false)?;
+            let body = lower_block(body, ctx, lcx, table, ret_ty, TailSink::Discard)?;
             ctx.pop_scope();
-            Ok(ir::Stmt::ForIndex {
+            Ok(vec![ir::Stmt::ForIndex {
                 var,
                 low,
                 high,
                 body,
-            })
+            }])
         }
-        ast::Stmt::When { subject, arms } => {
-            lower_when_stmt(subject, arms, ctx, lcx, table, ret_ty, is_tail, &stmt.span)
-        }
-        ast::Stmt::TryCatch { body, catches } => {
-            lower_try_catch(body, catches, ctx, lcx, table, ret_ty, &stmt.span)
-        }
-        ast::Stmt::Raise(message) => lower_raise(message, ctx, lcx, table),
+        ast::Stmt::When { subject, arms } => Ok(vec![lower_when_stmt(
+            subject, arms, ctx, lcx, table, ret_ty, sink, &stmt.span,
+        )?]),
+        ast::Stmt::TryCatch { body, catches } => Ok(vec![lower_try_catch(
+            body, catches, ctx, lcx, table, ret_ty, &stmt.span,
+        )?]),
+        ast::Stmt::Raise(message) => Ok(vec![lower_raise(message, ctx, lcx, table)?]),
         ast::Stmt::Assert { .. } => Err(LowerError::unsupported("assert", stmt.span.clone())),
         ast::Stmt::Break => Err(LowerError::unsupported("break", stmt.span.clone())),
         ast::Stmt::Continue => Err(LowerError::unsupported("continue", stmt.span.clone())),
     }
 }
 
-/// Lowers `when subject { arms }` used as a statement (each arm runs for its
-/// side effect — `return`, a namespace call, etc. — not for a produced
-/// value; `when` *as an expression*, e.g. `x = when ... { ... }`, isn't
-/// lowered yet, see `lower/expr.rs`'s `WhenExpr` rejection).
+/// Lowers `when subject { arms }` used as a statement, or (via
+/// [`TailSink::Return`]/[`TailSink::Assign`]) as the chain backing `when`
+/// used as an expression (issue #160) — each arm's tail value desugars
+/// according to `sink` exactly like any other tail position (see
+/// [`lower_block`]).
 ///
 /// `subject` must be a plain identifier (a local/param already in scope),
 /// not an arbitrary expression: KIR's `Expr` is a tree with no let-binding
@@ -287,7 +353,7 @@ fn lower_when_stmt(
     lcx: &LowerCtx<'_>,
     table: &mut SpanTable,
     ret_ty: KirType,
-    is_tail: bool,
+    sink: TailSink,
     stmt_span: &Span,
 ) -> Result<ir::Stmt, LowerError> {
     let ast::Expr::Ident(name) = &subject.kind else {
@@ -317,7 +383,7 @@ fn lower_when_stmt(
         lcx,
         table,
         ret_ty,
-        is_tail,
+        sink,
         stmt_span,
     )
 }
@@ -338,7 +404,7 @@ fn build_when_chain(
     lcx: &LowerCtx<'_>,
     table: &mut SpanTable,
     ret_ty: KirType,
-    is_tail: bool,
+    sink: TailSink,
     stmt_span: &Span,
 ) -> Result<ir::Stmt, LowerError> {
     let arm = &arms[idx];
@@ -348,7 +414,7 @@ fn build_when_chain(
             guard.span.clone(),
         ));
     }
-    let then_branch = lower_block(&arm.body, ctx, lcx, table, ret_ty, is_tail)?;
+    let then_branch = lower_block(&arm.body, ctx, lcx, table, ret_ty, sink)?;
     let is_last = idx + 1 == arms.len();
     let cond = if is_last {
         ir::Expr::ConstBool(true)
@@ -375,7 +441,7 @@ fn build_when_chain(
             lcx,
             table,
             ret_ty,
-            is_tail,
+            sink,
             stmt_span,
         )?]
     };
@@ -384,6 +450,91 @@ fn build_when_chain(
         then_branch,
         else_branch,
     })
+}
+
+/// Lowers `name = when subject { arms }` / `name: ty = when subject { arms
+/// }` — issue #160's `when`-as-expression in `let` position (the shape
+/// `examples/when_expression.keel`'s `grade` task uses). Desugars to a
+/// declare-only `Stmt::Let { local, init: None }` (`keel-codegen`'s
+/// `Stmt::Let` arm allocates storage but skips the initial store when
+/// `init` is `None` — see `ir.rs`'s doc) followed by the same nested
+/// `if`-chain [`lower_when_stmt`] builds for the statement form, except
+/// each arm's tail value is written into `local` via [`TailSink::Assign`]
+/// instead of returned.
+///
+/// A call-argument or other nested-sub-expression position (`f(when ...
+/// {...})`, `1 + when ... {...}`) is *not* supported by this issue: KIR's
+/// `Expr` is a tree with no statement-sequencing of its own, so hoisting a
+/// `when`-expression out of an arbitrary nested position would need every
+/// `lower_expr`/`lower_expr_expecting` call site to thread out an
+/// accumulator of hoisted statements — real plumbing, out of proportion to
+/// what this issue's fixtures need (`let`/`return` position only); such a
+/// position still hits `lower/expr.rs`'s plain `WhenExpr` rejection.
+///
+/// With no annotation, the result type is inferred from the *first* arm's
+/// tail value, lowered once purely to read off its type and then discarded
+/// — the same "local structural inference" already used for list-literal
+/// element types (`lower/expr.rs`'s module doc) — rather than consulting
+/// `CheckArtifacts::expr_types` (which would need a new checker-`Ty` ->
+/// `KirType` converter this crate doesn't have yet, see `lower/mod.rs`'s
+/// `CheckArtifacts` doc). Every arm (including the first, lowered again for
+/// real) is then coerced against that inferred type via the same
+/// `TailSink::Assign` path `lower_stmt`'s `ast::Stmt::Expr` arm uses, so a
+/// type mismatch between arms surfaces as an ordinary `lower_expr_expecting`
+/// error, not a silent pick of one arm's type.
+#[allow(clippy::too_many_arguments)]
+fn lower_when_expr_let(
+    name: &str,
+    annotation: &Option<Node<ast::TypeExpr>>,
+    subject: &ast::SpannedExpr,
+    arms: &[ast::WhenArm],
+    ctx: &mut FnCtx,
+    lcx: &LowerCtx<'_>,
+    table: &mut SpanTable,
+    ret_ty: KirType,
+    stmt_span: &Span,
+) -> Result<Vec<ir::Stmt>, LowerError> {
+    if arms.is_empty() {
+        return Err(LowerError::new(
+            "`when` has no arms".to_string(),
+            subject.span.clone(),
+        ));
+    }
+    let result_ty = match annotation {
+        Some(ann) => ty_expr_to_kir(
+            ann,
+            lcx.structs_by_name,
+            lcx.enums_by_name,
+            lcx.lists,
+            lcx.nullables,
+        )?,
+        None => {
+            let probe = lower_block(&arms[0].body, ctx, lcx, table, ret_ty, TailSink::Discard)?;
+            match probe.last() {
+                Some(ir::Stmt::Expr(e)) => e.ty(),
+                _ => {
+                    return Err(LowerError::unsupported(
+                        "`when`-expression arm whose body doesn't end in a value-producing \
+                         expression",
+                        stmt_span.clone(),
+                    ));
+                }
+            }
+        }
+    };
+    let local = ctx.declare(name, result_ty);
+    let declare = ir::Stmt::Let { local, init: None };
+    let chain = lower_when_stmt(
+        subject,
+        arms,
+        ctx,
+        lcx,
+        table,
+        ret_ty,
+        TailSink::Assign(local),
+        stmt_span,
+    )?;
+    Ok(vec![declare, chain])
 }
 
 /// ORs together the per-pattern equality tests for one `when` arm (an arm
@@ -576,12 +727,12 @@ fn lower_try_catch(
     // itself proves. A `try`/`catch` whose own arms both explicitly
     // `return` already terminates fine — see `block_terminates`'s
     // `TryCatch` arm.
-    let body = lower_block(body, ctx, lcx, table, ret_ty, false)?;
+    let body = lower_block(body, ctx, lcx, table, ret_ty, TailSink::Discard)?;
 
     let binder_ty = KirType::Struct(struct_id);
     ctx.push_scope();
     let binder = ctx.declare(&catch.name, binder_ty);
-    let handler = lower_block(&catch.body, ctx, lcx, table, ret_ty, false)?;
+    let handler = lower_block(&catch.body, ctx, lcx, table, ret_ty, TailSink::Discard)?;
     ctx.pop_scope();
 
     Ok(ir::Stmt::TryCatch {
@@ -595,7 +746,7 @@ fn lower_try_catch(
 /// Whether every reachable path through `block` ends in a `return` or
 /// `raise` — the KIR-level mirror of `keel-codegen`'s `block_is_terminated`
 /// (an LLVM basic-block terminator check); this runs *before* codegen, over
-/// the tail-desugared body (see [`lower_block`]'s `is_tail` doc), so
+/// the tail-desugared body (see [`lower_block`]'s `sink` doc), so
 /// `lower_task_body` can reject a non-`none`-returning task whose body still
 /// doesn't return on some path with a clear `LowerError` instead of letting
 /// `finish_block`'s `build_unreachable` fallback silently miscompile it

--- a/crates/keel-kir/src/passes/verify.rs
+++ b/crates/keel-kir/src/passes/verify.rs
@@ -155,6 +155,13 @@ fn verify_stmt(program: &KirProgram, func: &KirFunction, stmt: &Stmt) -> Result<
     match stmt {
         Stmt::Let { local, init } => {
             check_local(func, *local)?;
+            let Some(init) = init else {
+                // `init: None` — a declare-only `when`-as-expression temp
+                // (issue #160); the result local's type is fixed at declare
+                // time from the `when`'s first arm (or annotation), and
+                // every arm's `Stmt::Assign` into it is checked below.
+                return Ok(());
+            };
             verify_expr(program, func, init)?;
             let declared = func.locals[*local].ty;
             if declared != init.ty() {

--- a/crates/keel-kir/tests/fixtures/when_expr.keel
+++ b/crates/keel-kir/tests/fixtures/when_expr.keel
@@ -1,0 +1,8 @@
+task grade(score: str) -> str {
+  result = when score {
+    "A" => "excellent"
+    "B" => "good"
+    _ => "needs work"
+  }
+  return result
+}

--- a/crates/keel-kir/tests/fixtures/when_expr.kir
+++ b/crates/keel-kir/tests/fixtures/when_expr.kir
@@ -1,0 +1,18 @@
+fn grade(score: str) -> str {
+  let result: str
+  if (score == "A") {
+    result = "excellent"
+  } else {
+    if (score == "B") {
+      result = "good"
+    } else {
+      if true {
+        result = "needs work"
+      }
+    }
+  }
+  return result
+}
+
+fn <toplevel>() -> none {
+}

--- a/crates/keel-kir/tests/lower_errors.rs
+++ b/crates/keel-kir/tests/lower_errors.rs
@@ -454,18 +454,24 @@ task f(n: int) -> str {
 }
 
 #[test]
-fn when_expression_position_is_still_rejected() {
-    // `when` as a value-producing expression (`x = when ... {...}`) isn't
-    // lowered yet — only the statement form (each arm terminating via
-    // `return`) is, see `lower/stmt.rs`'s `lower_when_stmt` doc.
+fn when_expression_as_a_call_argument_is_still_rejected() {
+    // `when` as an expression lowers in `let`/`return` position (issue
+    // #160), but a call-argument or other nested-sub-expression position
+    // would need every `lower_expr`/`lower_expr_expecting` call site to
+    // thread out hoisted statements — out of scope for that issue, see
+    // `lower/stmt.rs`'s `lower_when_expr_let` doc. Plain `lower_expr` still
+    // rejects a bare `WhenExpr` outright, so this position still errors.
     let msg = lower_err(
         r#"
-task grade(score: str) -> str {
-  result = when score {
-    "A" => "excellent"
-    _ => "needs work"
-  }
-  return result
+task describe(n: int) -> str {
+  return f(when n {
+    0 => "zero"
+    _ => "nonzero"
+  })
+}
+
+task f(s: str) -> str {
+  return s
 }
 "#,
     );
@@ -473,6 +479,22 @@ task grade(score: str) -> str {
         msg.contains("when` expression"),
         "unexpected message: {msg}"
     );
+}
+
+#[test]
+fn when_expression_with_mismatched_arm_types_is_rejected() {
+    let msg = lower_err(
+        r#"
+task f(n: int) -> str {
+  result = when n {
+    0 => "zero"
+    _ => 1
+  }
+  return result
+}
+"#,
+    );
+    assert!(msg.contains("expected"), "unexpected message: {msg}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- `when` used as a value-producing expression now lowers in `let` position (`result = when score {...}`) and `return` position (`return when score {...}`), reusing the tail-position (`TailSink`) machinery built in #169 (#159).
- `let`'s RHS desugars to a declare-only local followed by an `if`-chain that assigns each arm's value into it; `return` routes each arm's value straight back with no intermediate. With no type annotation, the result type is inferred structurally from the first arm (same "local structural inference" convention already used for list-literal element types), and every arm is coerced against it via the existing `lower_expr_expecting` path, so a type mismatch between arms is an ordinary lowering error.
- `Stmt::Let`'s `init` field is now `Option<Expr>` to support the declare-only case; `keel-codegen`'s `Stmt::Let` arm allocates storage but skips the initial store when `init` is `None`.

## Deferred

- **Call-argument and other nested-sub-expression positions** (`f(when ...)`, `1 + when ...`): the checker accepts them (verified directly against `check_program_with_artifacts`), but `keel-kir`'s `Expr` is a tree with no statement-sequencing channel to hoist a `when`-expression out of an arbitrary nested position without threading an accumulator through every `lower_expr`/`lower_expr_expecting` call site. Split out to #170 — same "split deferred scope into its own tracked issue" shape as #147 → #162.

## Stacked PR
This branches off `m2-tail-return-desugar` (#169) since `when`-as-expression reuses that PR's tail-position plumbing directly; now rebased onto `main` since #169 merged.

## Test plan
- [x] New `keel-kir` golden-dump fixture (`when_expr.keel`/`.kir`) pinning the desugared declare+if-chain shape
- [x] `lower_errors.rs`: replaced the now-obsolete "when-expression-position rejected" pin with a call-argument rejection case and a mismatched-arm-types case
- [x] New `keel-codegen` integration tests (`when_expr.rs`) for let-position, return-position, and `examples/when_expression.keel`'s `grade` task verbatim, each diffed byte-for-byte against the interpreter
- [x] `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` all clean

Closes #160