### PR TITLE
keel-kir + keel-codegen: map/set containers, construct+read subset (#162)

### DIFF
--- a/crates/keel-codegen/src/expr.rs
+++ b/crates/keel-codegen/src/expr.rs
@@ -166,7 +166,7 @@ fn emit_call<'ctx>(
         CallTarget::Ns { ns_id, method_id } => {
             return crate::ns_call::emit_ns_call(fcx, ns_id, method_id, args, span);
         }
-        CallTarget::Rt(rt_fn) => return crate::rt_call::emit_rt_call(fcx, rt_fn, args),
+        CallTarget::Rt(rt_fn) => return crate::rt_call::emit_rt_call(fcx, rt_fn, args, ty),
     };
     let callee = fcx.functions[func_id]
         .expect("declare_functions declares every non-toplevel FuncId before any body is emitted");
@@ -374,9 +374,12 @@ fn emit_binop<'ctx>(
             };
             Ok(result)
         }
-        KirType::Unit | KirType::Struct(_) | KirType::List(_) | KirType::Nullable(_) => {
-            Err(unreachable_combo(op, operand_ty))
-        }
+        KirType::Unit
+        | KirType::Struct(_)
+        | KirType::List(_)
+        | KirType::Map(_)
+        | KirType::Set(_)
+        | KirType::Nullable(_) => Err(unreachable_combo(op, operand_ty)),
     }
 }
 

--- a/crates/keel-codegen/src/layout.rs
+++ b/crates/keel-codegen/src/layout.rs
@@ -45,7 +45,9 @@ pub(crate) fn llvm_type<'ctx>(
             }
         }
         KirType::Enum(_) => Ok(context.i32_type().into()),
-        KirType::List(_) => Ok(context.ptr_type(AddressSpace::default()).into()),
+        KirType::List(_) | KirType::Map(_) | KirType::Set(_) => {
+            Ok(context.ptr_type(AddressSpace::default()).into())
+        }
         KirType::Nullable(id) => match program.nullables[id] {
             // A nullable scalar has no spare pointer bit to steal, so it's
             // an explicit `{ i1 has_value, T }` pair, by value.

--- a/crates/keel-codegen/src/ns_call.rs
+++ b/crates/keel-codegen/src/ns_call.rs
@@ -110,10 +110,13 @@ pub(crate) fn emit_box_arg<'ctx>(
              Value is a later-M2/M3 concern)"
                 .to_string(),
         )),
-        // A `list[T]` value is already a boxed `*const Value` (`Value::List`,
-        // same representation `keel_rt_call_ns`/every `keel_list_*` expects)
-        // — no extra boxing needed, same as `Str`.
-        KirType::List(_) => Ok(emit_expr(fcx, arg)?.into_pointer_value()),
+        // A `list[T]`/`map[str, V]`/`set[T]` value is already a boxed
+        // `*const Value` (`Value::List`/`Value::Map`, same representation
+        // `keel_rt_call_ns`/every `keel_list_*`/`keel_map_*` expects) — no
+        // extra boxing needed, same as `Str`.
+        KirType::List(_) | KirType::Map(_) | KirType::Set(_) => {
+            Ok(emit_expr(fcx, arg)?.into_pointer_value())
+        }
         KirType::Nullable(_) => Err(CodegenError::Unsupported(
             "nullable-typed argument to a namespace call (unwrap via `??` first — marshaling a \
              nullable into a boxed Value is a later-M2/M3 concern)"

--- a/crates/keel-codegen/src/nullable.rs
+++ b/crates/keel-codegen/src/nullable.rs
@@ -37,7 +37,7 @@ fn llvm_err(e: impl std::fmt::Display) -> CodegenError {
     CodegenError::Llvm(e.to_string())
 }
 
-fn nullable_inner<'ctx>(fcx: &FuncCtx<'ctx, '_>, ty: KirType) -> KirType {
+pub(crate) fn nullable_inner<'ctx>(fcx: &FuncCtx<'ctx, '_>, ty: KirType) -> KirType {
     let KirType::Nullable(id) = ty else {
         unreachable!(
             "caller only invokes this on a KirType::Nullable — keel-kir's verify pass \
@@ -164,7 +164,7 @@ fn emit_unwrap_some<'ctx>(
 
 /// Builds the nullable-`{ty}`'s "some" representation from a known-present,
 /// plain `inner_ty`-typed value — the inverse of [`emit_unwrap_some`].
-fn emit_wrap_some<'ctx>(
+pub(crate) fn emit_wrap_some<'ctx>(
     fcx: &FuncCtx<'ctx, '_>,
     raw: BasicValueEnum<'ctx>,
     inner_ty: KirType,

--- a/crates/keel-codegen/src/rt_call.rs
+++ b/crates/keel-codegen/src/rt_call.rs
@@ -25,6 +25,7 @@ pub(crate) fn emit_rt_call<'ctx>(
     fcx: &FuncCtx<'ctx, '_>,
     rt_fn: RtFn,
     args: &[Expr],
+    ty: KirType,
 ) -> Result<BasicValueEnum<'ctx>, CodegenError> {
     let ptr_type = fcx.context.ptr_type(AddressSpace::default());
 
@@ -97,7 +98,180 @@ pub(crate) fn emit_rt_call<'ctx>(
             });
             call_ptr_fn(fcx, f, &[v8.into()])
         }
+        RtFn::MapNew => {
+            let f = declare_or_get(fcx.module, "keel_map_new", || ptr_type.fn_type(&[], false));
+            call_ptr_fn(fcx, f, &[])
+        }
+        RtFn::MapInsert => {
+            let [map, key, val] = args else {
+                unreachable!("verified KIR: RtFn::MapInsert always takes exactly 3 args");
+            };
+            let map_ptr = crate::expr::emit_expr(fcx, map)?.into_pointer_value();
+            let key_ptr = emit_box_arg(fcx, key)?;
+            let val_ptr = emit_box_arg(fcx, val)?;
+            let f = declare_or_get(fcx.module, "keel_map_insert", || {
+                ptr_type.fn_type(&[ptr_type.into(), ptr_type.into(), ptr_type.into()], false)
+            });
+            call_ptr_fn(fcx, f, &[map_ptr.into(), key_ptr.into(), val_ptr.into()])
+        }
+        RtFn::MapGet => {
+            let [map, key] = args else {
+                unreachable!("verified KIR: RtFn::MapGet always takes exactly 2 args");
+            };
+            let map_ptr = crate::expr::emit_expr(fcx, map)?.into_pointer_value();
+            let key_ptr = emit_box_arg(fcx, key)?;
+            let f = declare_or_get(fcx.module, "keel_map_get", || {
+                ptr_type.fn_type(&[ptr_type.into(), ptr_type.into()], false)
+            });
+            let result_boxed =
+                call_ptr_fn(fcx, f, &[map_ptr.into(), key_ptr.into()])?.into_pointer_value();
+            emit_map_get_result(fcx, result_boxed, ty)
+        }
+        RtFn::MapLen => {
+            let [map] = args else {
+                unreachable!("verified KIR: RtFn::MapLen always takes exactly 1 arg");
+            };
+            let map_ptr = crate::expr::emit_expr(fcx, map)?.into_pointer_value();
+            let f = declare_or_get(fcx.module, "keel_map_len", || {
+                fcx.context.i64_type().fn_type(&[ptr_type.into()], false)
+            });
+            let call = fcx
+                .builder
+                .build_call(f, &[map_ptr.into()], "map_len")
+                .map_err(llvm_err)?;
+            match call.try_as_basic_value() {
+                ValueKind::Basic(v) => Ok(v),
+                ValueKind::Instruction(_) => unreachable!("keel_map_len returns i64, never void"),
+            }
+        }
+        RtFn::MapContains => {
+            let [map, key] = args else {
+                unreachable!("verified KIR: RtFn::MapContains always takes exactly 2 args");
+            };
+            let map_ptr = crate::expr::emit_expr(fcx, map)?.into_pointer_value();
+            let key_ptr = emit_box_arg(fcx, key)?;
+            let f = declare_or_get(fcx.module, "keel_map_contains", || {
+                fcx.context
+                    .i8_type()
+                    .fn_type(&[ptr_type.into(), ptr_type.into()], false)
+            });
+            let raw = call_scalar_fn(fcx, f, &[map_ptr.into(), key_ptr.into()], "map_contains_u8")?
+                .into_int_value();
+            let b = fcx
+                .builder
+                .build_int_truncate(raw, fcx.context.bool_type(), "map_contains")
+                .map_err(llvm_err)?;
+            Ok(b.into())
+        }
+        RtFn::MapKeys => {
+            let [map] = args else {
+                unreachable!("verified KIR: RtFn::MapKeys always takes exactly 1 arg");
+            };
+            let map_ptr = crate::expr::emit_expr(fcx, map)?.into_pointer_value();
+            let f = declare_or_get(fcx.module, "keel_map_keys", || {
+                ptr_type.fn_type(&[ptr_type.into()], false)
+            });
+            call_ptr_fn(fcx, f, &[map_ptr.into()])
+        }
+        RtFn::MapValues => {
+            let [map] = args else {
+                unreachable!("verified KIR: RtFn::MapValues always takes exactly 1 arg");
+            };
+            let map_ptr = crate::expr::emit_expr(fcx, map)?.into_pointer_value();
+            let f = declare_or_get(fcx.module, "keel_map_values", || {
+                ptr_type.fn_type(&[ptr_type.into()], false)
+            });
+            call_ptr_fn(fcx, f, &[map_ptr.into()])
+        }
+        // `set[T]` shares `list[T]`'s exact runtime representation (see
+        // `KirType::Set`'s doc) — these two variants exist only so
+        // `keel-kir`'s verify pass can require the *static* result type to
+        // be `KirType::Set`, not `KirType::List`; codegen calls the
+        // identical `keel_list_*` symbols `RtFn::ListNew`/`ListPush` do.
+        RtFn::SetNew => {
+            let f = declare_or_get(fcx.module, "keel_list_new", || ptr_type.fn_type(&[], false));
+            call_ptr_fn(fcx, f, &[])
+        }
+        RtFn::SetInsert => {
+            let [set, elem] = args else {
+                unreachable!("verified KIR: RtFn::SetInsert always takes exactly 2 args");
+            };
+            let set_ptr = crate::expr::emit_expr(fcx, set)?.into_pointer_value();
+            let elem_ptr = emit_box_arg(fcx, elem)?;
+            let f = declare_or_get(fcx.module, "keel_list_push", || {
+                ptr_type.fn_type(&[ptr_type.into(), ptr_type.into()], false)
+            });
+            call_ptr_fn(fcx, f, &[set_ptr.into(), elem_ptr.into()])
+        }
     }
+}
+
+/// Wraps `keel_map_get`'s boxed `*const Value` result (a boxed `Value::None`
+/// on a missing key, the boxed value otherwise) into `ty`'s
+/// (`KirType::Nullable`) representation — `keel_is_none` distinguishes the
+/// two cases, then either unboxes-and-wraps or builds a fresh `none`,
+/// mirroring `crate::nullable`'s own `?.`/`??` branch-and-merge shape.
+fn emit_map_get_result<'ctx>(
+    fcx: &FuncCtx<'ctx, '_>,
+    boxed: inkwell::values::PointerValue<'ctx>,
+    ty: KirType,
+) -> Result<BasicValueEnum<'ctx>, CodegenError> {
+    let value_ty = crate::nullable::nullable_inner(fcx, ty);
+    let ptr_type = fcx.context.ptr_type(AddressSpace::default());
+
+    let is_none_fn = declare_or_get(fcx.module, "keel_is_none", || {
+        fcx.context.i8_type().fn_type(&[ptr_type.into()], false)
+    });
+    let raw_is_none =
+        call_scalar_fn(fcx, is_none_fn, &[boxed.into()], "map_get_is_none_u8")?.into_int_value();
+    let is_none = fcx
+        .builder
+        .build_int_compare(
+            inkwell::IntPredicate::NE,
+            raw_is_none,
+            fcx.context.i8_type().const_zero(),
+            "map_get_is_none",
+        )
+        .map_err(llvm_err)?;
+
+    let result_llvm_ty = crate::layout::llvm_type(fcx.context, fcx.program, ty)?;
+    let result_ptr = fcx
+        .builder
+        .build_alloca(result_llvm_ty, "map_get.result")
+        .map_err(llvm_err)?;
+
+    let some_bb = fcx.context.append_basic_block(fcx.function, "map_get.some");
+    let none_bb = fcx.context.append_basic_block(fcx.function, "map_get.none");
+    let merge_bb = fcx
+        .context
+        .append_basic_block(fcx.function, "map_get.merge");
+    fcx.builder
+        .build_conditional_branch(is_none, none_bb, some_bb)
+        .map_err(llvm_err)?;
+
+    fcx.builder.position_at_end(some_bb);
+    let raw_val = unbox_value(fcx, boxed, value_ty)?;
+    let some_val = crate::nullable::emit_wrap_some(fcx, raw_val, value_ty, result_llvm_ty)?;
+    fcx.builder
+        .build_store(result_ptr, some_val)
+        .map_err(llvm_err)?;
+    fcx.builder
+        .build_unconditional_branch(merge_bb)
+        .map_err(llvm_err)?;
+
+    fcx.builder.position_at_end(none_bb);
+    let none_val = crate::nullable::emit_null_lit(fcx, ty)?;
+    fcx.builder
+        .build_store(result_ptr, none_val)
+        .map_err(llvm_err)?;
+    fcx.builder
+        .build_unconditional_branch(merge_bb)
+        .map_err(llvm_err)?;
+
+    fcx.builder.position_at_end(merge_bb);
+    fcx.builder
+        .build_load(result_llvm_ty, result_ptr, "map_get.load")
+        .map_err(llvm_err)
 }
 
 /// Calls `keel_list_len` directly (not through an `Expr::Call` — used by
@@ -179,7 +353,7 @@ pub(crate) fn unbox_value<'ctx>(
                 .map_err(llvm_err)?;
             Ok(b.into())
         }
-        KirType::Str | KirType::List(_) => Ok(boxed.into()),
+        KirType::Str | KirType::List(_) | KirType::Map(_) | KirType::Set(_) => Ok(boxed.into()),
         KirType::Unit | KirType::Struct(_) | KirType::Enum(_) | KirType::Nullable(_) => {
             Err(CodegenError::Unsupported(
                 "a list element type other than int/float/bool/str (struct/enum/nullable \

--- a/crates/keel-codegen/tests/maps.rs
+++ b/crates/keel-codegen/tests/maps.rs
@@ -1,0 +1,129 @@
+//! Exit criterion for issue #162 (map containers, construct+read subset):
+//! a program building a `map[str, V]`, reading it back through every
+//! lowered method (`get`, `contains`/`has`, `keys`, `values`, `len`,
+//! `is_empty`), and iterating it — compiles, links, and matches the
+//! interpreter byte-for-byte.
+//!
+//! Mutation (`map.insert`-style) isn't modeled yet — the interpreter itself
+//! has no map mutation method to match against — so there's no CoW-aliasing
+//! test here (unlike `lists.rs`); #151 already gets its "CoW case" from
+//! list (#163). See `KirType::Map`'s doc for the full scope note.
+//!
+//! `get`'s miss path is the highest-risk shape in this file: it exercises a
+//! genuinely different LLVM basic block (the `keel_is_none`-guarded none
+//! branch) than the hit path, and a `map[str, str]`'s `get` exercises the
+//! pointer-based nullable repr instead of `map[str, int]`'s scalar `{i1,T}`
+//! repr — both are covered explicitly below rather than only ever hitting.
+
+use std::process::Command;
+
+use keel_codegen::BuildOptions;
+
+#[path = "support/mod.rs"]
+mod support;
+
+fn compile_and_run(source: &str) -> std::process::Output {
+    let kir = support::parse_check_and_lower(source);
+
+    let out_dir = tempfile::tempdir().expect("create temp out dir");
+    let opts = BuildOptions {
+        out_dir: out_dir.path().to_path_buf(),
+        runtime_link_args: support::runtime_link_args().clone(),
+    };
+    let bin = keel_codegen::compile(&kir, &opts).expect("compile must succeed");
+    Command::new(&bin).output().expect("run compiled binary")
+}
+
+fn assert_matches_interpreter(source: &str, expected_stdout: &[u8]) {
+    let compiled = compile_and_run(source);
+    let interpreted = support::run_interpreter(source);
+
+    assert_eq!(
+        String::from_utf8_lossy(&compiled.stdout),
+        String::from_utf8_lossy(&interpreted.stdout),
+        "compiled stdout must match the interpreter's"
+    );
+    assert_eq!(
+        compiled.status.code(),
+        interpreted.status.code(),
+        "compiled exit code must match the interpreter's"
+    );
+    assert_eq!(compiled.stdout, expected_stdout);
+}
+
+#[test]
+fn get_hit_and_miss_match_the_interpreter_scalar_value() {
+    let source = r#"
+use std/io
+
+stock: map[str, int] = {apples: 1}
+found = stock.get("apples") ?? -1
+missing = stock.get("bananas") ?? -1
+io.show(found)
+io.show(missing)
+"#;
+    assert_matches_interpreter(source, b"  1\n  -1\n");
+}
+
+#[test]
+fn get_hit_and_miss_match_the_interpreter_str_value() {
+    // A `str`-valued map's `.get` returns `str?`, which uses the
+    // pointer-based nullable repr — a different codegen branch than the
+    // scalar `{i1,T}` repr the `int`-valued test above exercises.
+    let source = r#"
+use std/io
+
+labels: map[str, str] = {a: "excellent", b: "good"}
+io.show(labels.get("a") ?? "unknown")
+io.show(labels.get("z") ?? "unknown")
+"#;
+    assert_matches_interpreter(source, b"  excellent\n  unknown\n");
+}
+
+#[test]
+fn len_contains_and_is_empty_match_the_interpreter() {
+    let source = r#"
+use std/io
+
+stock: map[str, int] = {apples: 1, pears: 2}
+io.show(stock.len())
+io.show(stock.contains("apples"))
+io.show(stock.contains("bananas"))
+io.show(stock.has("pears"))
+io.show(stock.is_empty())
+"#;
+    assert_matches_interpreter(source, b"  2\n  true\n  false\n  true\n  false\n");
+}
+
+#[test]
+fn keys_and_values_match_the_interpreter() {
+    let source = r#"
+use std/io
+
+stock: map[str, int] = {apples: 1, pears: 2}
+io.show(stock.keys())
+io.show(stock.values())
+"#;
+    // Both are documented as sorted by key so codegen and the interpreter
+    // agree on order without relying on hash-map iteration order.
+    assert_matches_interpreter(source, b"  1. apples\n  2. pears\n  1. 1\n  2. 2\n");
+}
+
+#[test]
+fn iterating_keys_and_summing_looked_up_values_matches_the_interpreter() {
+    let source = r#"
+use std/io
+
+task total_stock(stock: map[str, int]) -> int {
+  sum = 0
+  for key in stock.keys() {
+    sum += (stock.get(key) ?? 0)
+  }
+  return sum
+}
+
+stock: map[str, int] = {apples: 1, pears: 2}
+io.show(total_stock(stock))
+"#;
+    assert_matches_interpreter(source, b"  3\n");
+}

--- a/crates/keel-codegen/tests/sets.rs
+++ b/crates/keel-codegen/tests/sets.rs
@@ -1,0 +1,69 @@
+//! Exit criterion for issue #162 (set containers, construct+pass-through
+//! subset): a `set[T]` literal built, bound, and passed/printed through —
+//! compiles, links, and matches the interpreter byte-for-byte.
+//!
+//! The interpreter has no `Value::Set` variant — a `set[...]` literal
+//! evaluates to a plain, non-deduplicating `Value::List` ("v0.1: sets share
+//! list repr", see `KirType::Set`'s doc) — so there's no dedup behavior to
+//! observe and no set methods lowered yet (`unknown_...` cases live in
+//! `keel-kir`'s `lower_errors.rs`, not here). This file only pins the
+//! construct+pass-through shape that #151's fixtures actually need.
+
+use std::process::Command;
+
+use keel_codegen::BuildOptions;
+
+#[path = "support/mod.rs"]
+mod support;
+
+fn compile_and_run(source: &str) -> std::process::Output {
+    let kir = support::parse_check_and_lower(source);
+
+    let out_dir = tempfile::tempdir().expect("create temp out dir");
+    let opts = BuildOptions {
+        out_dir: out_dir.path().to_path_buf(),
+        runtime_link_args: support::runtime_link_args().clone(),
+    };
+    let bin = keel_codegen::compile(&kir, &opts).expect("compile must succeed");
+    Command::new(&bin).output().expect("run compiled binary")
+}
+
+fn assert_matches_interpreter(source: &str, expected_stdout: &[u8]) {
+    let compiled = compile_and_run(source);
+    let interpreted = support::run_interpreter(source);
+
+    assert_eq!(
+        String::from_utf8_lossy(&compiled.stdout),
+        String::from_utf8_lossy(&interpreted.stdout),
+        "compiled stdout must match the interpreter's"
+    );
+    assert_eq!(
+        compiled.status.code(),
+        interpreted.status.code(),
+        "compiled exit code must match the interpreter's"
+    );
+    assert_eq!(compiled.stdout, expected_stdout);
+}
+
+#[test]
+fn set_literal_construction_and_pass_through_matches_the_interpreter() {
+    let source = r#"
+use std/io
+
+nums = set[1, 2, 3]
+other = nums
+io.show(other)
+"#;
+    assert_matches_interpreter(source, b"  1. 1\n  2. 2\n  3. 3\n");
+}
+
+#[test]
+fn set_of_str_elements_matches_the_interpreter() {
+    let source = r#"
+use std/io
+
+names = set["alice", "bob"]
+io.show(names)
+"#;
+    assert_matches_interpreter(source, b"  1. alice\n  2. bob\n");
+}

--- a/crates/keel-kir/src/dump.rs
+++ b/crates/keel-kir/src/dump.rs
@@ -47,6 +47,8 @@ fn fmt_ty(program: &KirProgram, ty: KirType) -> String {
         KirType::Struct(id) => program.structs[id].name.clone(),
         KirType::Enum(id) => program.enums[id].name.clone(),
         KirType::List(id) => format!("list[{}]", fmt_ty(program, program.lists[id])),
+        KirType::Map(id) => format!("map[str, {}]", fmt_ty(program, program.maps[id])),
+        KirType::Set(id) => format!("set[{}]", fmt_ty(program, program.sets[id])),
         KirType::Nullable(id) => format!("{}?", fmt_ty(program, program.nullables[id])),
         other => other.to_string(),
     }
@@ -324,6 +326,15 @@ fn rt_fn_name(rt_fn: crate::ir::RtFn) -> &'static str {
         crate::ir::RtFn::IntToStr => "int_to_str",
         crate::ir::RtFn::FloatToStr => "float_to_str",
         crate::ir::RtFn::BoolToStr => "bool_to_str",
+        crate::ir::RtFn::MapNew => "map_new",
+        crate::ir::RtFn::MapInsert => "map_insert",
+        crate::ir::RtFn::MapGet => "map_get",
+        crate::ir::RtFn::MapLen => "map_len",
+        crate::ir::RtFn::MapContains => "map_contains",
+        crate::ir::RtFn::MapKeys => "map_keys",
+        crate::ir::RtFn::MapValues => "map_values",
+        crate::ir::RtFn::SetNew => "set_new",
+        crate::ir::RtFn::SetInsert => "set_insert",
     }
 }
 

--- a/crates/keel-kir/src/ir.rs
+++ b/crates/keel-kir/src/ir.rs
@@ -39,6 +39,16 @@ pub type ListId = usize;
 /// `NullableId`.
 pub type NullableId = usize;
 
+/// Index into `KirProgram::maps` — a *structural* intern id over the
+/// *value* type only (the key is always `str` — see `KirType::Map`'s doc),
+/// same rationale as `ListId`: `map[str, int]` written anywhere in the
+/// program is the same `MapId`.
+pub type MapId = usize;
+
+/// Index into `KirProgram::sets` — a *structural* intern id over the
+/// element type, same rationale as `ListId`.
+pub type SetId = usize;
+
 /// A whole lowered program (currently: a single file's tasks + its
 /// top-level statements — multi-module lowering is deferred until the
 /// `keel-compiler` `ModuleGraph`/`CheckArtifacts` seam lands, see `lib.rs`).
@@ -67,6 +77,24 @@ pub struct KirProgram {
     /// marshaling that doesn't exist yet (deferred, see `lower/expr.rs`'s
     /// list-literal lowering doc).
     pub lists: Vec<KirType>,
+    /// Every distinct `map[str, V]` *value* type interned so far (structural,
+    /// not declaration order — see `MapId`'s doc). Only int/float/bool/str
+    /// values are modeled, same restriction as `lists`; the key is always
+    /// `str` (non-`str` keys are a later issue, see `KirType::Map`'s doc).
+    /// No mutation op is exposed yet — issue #162's construct/read scope
+    /// (the interpreter itself has no `map.insert`-style method to match).
+    pub maps: Vec<KirType>,
+    /// Every distinct `set[T]` element type interned so far (structural, not
+    /// declaration order — see `SetId`'s doc). Only int/float/bool/str
+    /// elements are modeled, same restriction as `lists`. `Set` is purely a
+    /// *static* type distinct from `List` — at runtime a set is the exact
+    /// same `Value::List` a list is (see `KirType::Set`'s doc), so no method
+    /// call lowers on it yet: the interpreter itself doesn't type-check any
+    /// set method or `for`-over-`set[T]` today (every set method call
+    /// resolves to `Ty::Unknown(InferenceLimitation)`, and `for` explicitly
+    /// requires `Ty::List`) — there is nothing for the compiled backend to
+    /// match yet.
+    pub sets: Vec<KirType>,
     /// Every distinct nullable inner type interned so far (structural, not
     /// declaration order — see `NullableId`'s doc). Only int/float/bool/str/
     /// list/struct inner types are modeled — see
@@ -396,6 +424,39 @@ pub enum RtFn {
     FloatToStr,
     /// `keel_bool_to_str(bool) -> str`. See [`RtFn::IntToStr`].
     BoolToStr,
+    /// `keel_map_new() -> map` — builds an empty `map[str, V]`.
+    MapNew,
+    /// `keel_map_insert(map, key, val) -> map'` — always clones, same
+    /// convention as [`RtFn::ListPush`]. `key` is always `str`-typed
+    /// (`map[str, V]` only — see `KirType::Map`'s doc).
+    MapInsert,
+    /// `keel_map_get(map, key) -> V?` — returns a boxed `none` on a missing
+    /// key rather than exiting (unlike `Expr::Index`'s list-indexing
+    /// out-of-bounds exit, `keel-rt-ffi`'s `keel_list_get`): a missing key is
+    /// an ordinary, checker-required-nullable outcome the interpreter's own
+    /// `map.get` also just returns `none` for.
+    MapGet,
+    /// `keel_map_len(map) -> int`.
+    MapLen,
+    /// `keel_map_contains(map, key) -> bool`.
+    MapContains,
+    /// `keel_map_keys(map) -> list[str]`, sorted (see `keel-rt-ffi`'s doc on
+    /// why: `HashMap` iteration order isn't deterministic).
+    MapKeys,
+    /// `keel_map_values(map) -> list[V]`, ordered by sorted key. See
+    /// [`RtFn::MapKeys`].
+    MapValues,
+    /// Builds an empty `set[T]` — codegen calls `keel_list_new` directly
+    /// (a distinct `RtFn` variant from [`RtFn::ListNew`] only so `keel-kir`'s
+    /// verify pass can require this call's result to be `KirType::Set`, not
+    /// `KirType::List` — see `KirType::Set`'s doc for why they share a
+    /// runtime representation but stay distinct static types).
+    SetNew,
+    /// `set[T]` literal's per-element fold — codegen calls `keel_list_push`
+    /// directly, no dedup (matches the interpreter's own `SetLit` evaluation
+    /// — see `KirType::Set`'s doc). See [`RtFn::SetNew`] for why this is a
+    /// distinct variant from [`RtFn::ListPush`].
+    SetInsert,
 }
 
 impl Expr {

--- a/crates/keel-kir/src/lower/decl.rs
+++ b/crates/keel-kir/src/lower/decl.rs
@@ -17,11 +17,14 @@ use crate::types::KirType;
 /// parameter values are allowed here (just their *type*, matching the
 /// declared param) — see [`lower_param_defaults`] for lowering the default
 /// *expressions* themselves.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn signature_of(
     task: &TaskDecl,
     structs_by_name: &HashMap<String, StructId>,
     enums_by_name: &HashMap<String, EnumId>,
     lists: &std::cell::RefCell<Vec<KirType>>,
+    maps: &std::cell::RefCell<Vec<KirType>>,
+    sets: &std::cell::RefCell<Vec<KirType>>,
     nullables: &std::cell::RefCell<Vec<KirType>>,
 ) -> Result<(Vec<KirType>, KirType), LowerError> {
     if !task.type_params.is_empty() {
@@ -57,11 +60,21 @@ pub(crate) fn signature_of(
             structs_by_name,
             enums_by_name,
             lists,
+            maps,
+            sets,
             nullables,
         )?);
     }
     let ret = match &task.return_type {
-        Some(ty) => ty_expr_to_kir(ty, structs_by_name, enums_by_name, lists, nullables)?,
+        Some(ty) => ty_expr_to_kir(
+            ty,
+            structs_by_name,
+            enums_by_name,
+            lists,
+            maps,
+            sets,
+            nullables,
+        )?,
         None => KirType::Unit,
     };
     Ok((params, ret))

--- a/crates/keel-kir/src/lower/expr.rs
+++ b/crates/keel-kir/src/lower/expr.rs
@@ -24,7 +24,7 @@ use keel_syntax::lexer::Span;
 use keel_catalog::builtins::BuiltinResult;
 
 use super::{FnCtx, LowerCtx, LowerError, describe_ty};
-use crate::ir::{self, CallTarget, Expr, StructId};
+use crate::ir::{self, CallTarget, Expr, MapId, StructId};
 use crate::span_table::SpanTable;
 use crate::types::KirType;
 
@@ -256,19 +256,37 @@ pub(crate) fn lower_expr(
         // No expected-type context here (that's `lower_expr_expecting`'s
         // job) — an anonymous struct literal with nothing pinning it to a
         // named struct isn't modeled yet (deferred until an M2 fixture
-        // needs one; see `ir.rs`'s `StructLayout` doc).
-        ast::Expr::StructLit(_) => Err(LowerError::unsupported(
-            "struct literal outside a known-struct-typed position (a `let` annotation, \
-             `return`, or call argument)",
-            expr.span.clone(),
-        )),
+        // needs one; see `ir.rs`'s `StructLayout` doc). An int/bool-keyed
+        // literal is unambiguously a map even without that context (the
+        // checker's own `classify_literal` treats it that way, `str`/bare
+        // keys need an expected `map[str, V]` type to disambiguate from a
+        // struct) — but non-`str` map keys aren't modeled yet either (see
+        // `KirType::Map`'s doc), so this names that specifically rather than
+        // reporting the generic struct-literal message for what's actually
+        // a map literal.
+        ast::Expr::StructLit(fields) => {
+            if let Some((ast::MapLitKey::Int(_) | ast::MapLitKey::Bool(_), value)) = fields.first()
+            {
+                return Err(LowerError::unsupported(
+                    "map literal with a non-str key (int/bool keys are a later M2/M3 concern)",
+                    value.span.clone(),
+                ));
+            }
+            Err(LowerError::unsupported(
+                "struct literal outside a known-struct-typed position (a `let` annotation, \
+                 `return`, or call argument) — the same restriction applies to a bareword/`str`-\
+                 keyed map literal, which needs an expected `map[str, V]` type to disambiguate \
+                 from a struct",
+                expr.span.clone(),
+            ))
+        }
         ast::Expr::StructSpreadUpdate { .. } => Err(LowerError::unsupported(
             "struct spread-update outside a known-struct-typed position (a `let` annotation, \
              `return`, or call argument)",
             expr.span.clone(),
         )),
         ast::Expr::ListLit(items) => lower_list_lit(items, &expr.span, ctx, lcx, table),
-        ast::Expr::SetLit(_) => Err(LowerError::unsupported("set literal", expr.span.clone())),
+        ast::Expr::SetLit(items) => lower_set_lit(items, &expr.span, ctx, lcx, table),
         ast::Expr::TupleLit(_) => Err(LowerError::unsupported("tuple literal", expr.span.clone())),
         ast::Expr::NullCoalesce(nullable, fallback) => {
             let nullable_e = lower_expr(nullable, ctx, lcx, table)?;
@@ -310,6 +328,9 @@ pub(crate) fn lower_expr(
             match object_e.ty() {
                 KirType::List(_) => {
                     lower_list_method_call(object_e, method, args, ctx, lcx, table, &expr.span)
+                }
+                KirType::Map(_) => {
+                    lower_map_method_call(object_e, method, args, ctx, lcx, table, &expr.span)
                 }
                 _ => Err(LowerError::unsupported("method call", expr.span.clone())),
             }
@@ -384,6 +405,17 @@ pub(crate) fn lower_expr_expecting(
             }
             _ => {}
         }
+    }
+    // `{key: value, ...}` is the same ambiguous `ast::Expr::StructLit` node
+    // a struct literal parses to (see `ast::MapLitKey`'s doc) — the checker
+    // itself only resolves a bareword/`str`-keyed one to a map when an
+    // expected `map[str, V]` type is already in scope; since that's exactly
+    // what `expected` already carries here, this needs no `CheckArtifacts`
+    // lookup, same as `lower_struct_lit` above never needing one.
+    if let KirType::Map(map_id) = expected
+        && let ast::Expr::StructLit(fields) = &expr.kind
+    {
+        return lower_map_lit(fields, map_id, &expr.span, ctx, lcx, table);
     }
     // `none` has no type of its own to infer bottom-up (`lower_expr` rejects
     // it outright) — the checker only accepts a bare `none` literal where an
@@ -483,6 +515,63 @@ fn lower_struct_lit(
     }
 
     Ok(Expr::MakeStruct { struct_id, fields })
+}
+
+/// Lowers a bareword/`str`-keyed `{key: value, ...}` literal against its
+/// expected `map[str, V]` type (the `map_methods.keel`-style shape,
+/// `stock: map[str, int] = {apples: 12, ...}`) — folds into a
+/// `MapNew`/`MapInsert` chain, same shape [`lower_list_lit`] builds for a
+/// list literal. Field order in the source doesn't matter (unlike a struct
+/// literal, a map has no declared field order to rebuild into) — each
+/// key/value pair just inserts in source order.
+fn lower_map_lit(
+    lit_fields: &[(ast::MapLitKey, SpannedExpr)],
+    map_id: MapId,
+    span: &Span,
+    ctx: &mut FnCtx,
+    lcx: &LowerCtx<'_>,
+    table: &mut SpanTable,
+) -> Result<Expr, LowerError> {
+    let value_ty = lcx.maps.borrow()[map_id];
+    let map_ty = KirType::Map(map_id);
+    let span_id = table.intern(span.clone());
+
+    let mut seen: HashMap<&str, ()> = HashMap::with_capacity(lit_fields.len());
+    let mut acc = Expr::Call {
+        target: CallTarget::Rt(ir::RtFn::MapNew),
+        args: Vec::new(),
+        ty: map_ty,
+        span: span_id,
+    };
+    for (key, value) in lit_fields {
+        let key_str = key.as_str().ok_or_else(|| {
+            LowerError::unsupported(
+                "map literal with a non-str key (int/bool keys are a later M2/M3 concern)",
+                value.span.clone(),
+            )
+        })?;
+        if seen.insert(key_str, ()).is_some() {
+            // The interpreter silently takes last-wins on a duplicate map
+            // key (no error); rejecting it here is a deliberate, stricter-
+            // than-interpreter divergence — this repo's namespace-
+            // implementation checklist treats a duplicate key as a
+            // structural-precondition violation that must error rather than
+            // silently drop data, and no conformance fixture should ever
+            // contain a duplicate-key map literal in the first place.
+            return Err(LowerError::new(
+                format!("duplicate key `{key_str}` in map literal"),
+                value.span.clone(),
+            ));
+        }
+        let value_e = lower_expr_expecting(value, value_ty, ctx, lcx, table)?;
+        acc = Expr::Call {
+            target: CallTarget::Rt(ir::RtFn::MapInsert),
+            args: vec![acc, Expr::ConstStr(key_str.to_string()), value_e],
+            ty: map_ty,
+            span: span_id,
+        };
+    }
+    Ok(acc)
 }
 
 /// Resolves the `(LocalId, KirType)` a spread-update's `base` already
@@ -891,6 +980,71 @@ fn lower_list_lit(
     Ok(acc)
 }
 
+/// Lowers `set[expr, ...]` — folds into a `SetNew`/`SetInsert` chain, same
+/// shape [`lower_list_lit`] builds, with no dedup (`RtFn::SetInsert`'s doc
+/// has the rationale: the interpreter's own `SetLit` doesn't dedup either,
+/// "v0.1: sets share list repr" — matching that, not a "more correct"
+/// deduplicating set the interpreter doesn't have, is the whole point).
+fn lower_set_lit(
+    items: &[SpannedExpr],
+    span: &Span,
+    ctx: &mut FnCtx,
+    lcx: &LowerCtx<'_>,
+    table: &mut SpanTable,
+) -> Result<Expr, LowerError> {
+    let [first, rest @ ..] = items else {
+        return Err(LowerError::unsupported(
+            "empty set literal (element type can't be inferred without an annotation)",
+            span.clone(),
+        ));
+    };
+    let first_e = lower_expr(first, ctx, lcx, table)?;
+    let elem_ty = first_e.ty();
+    if !super::is_list_element_ty(elem_ty) {
+        return Err(LowerError::unsupported(
+            "set element type other than int/float/bool/str (struct/enum elements need Value \
+             marshaling, a later M2/M3 concern)",
+            first.span.clone(),
+        ));
+    }
+
+    let mut elements = Vec::with_capacity(items.len());
+    elements.push(first_e);
+    for item in rest {
+        let item_e = lower_expr(item, ctx, lcx, table)?;
+        if item_e.ty() != elem_ty {
+            return Err(LowerError::new(
+                format!(
+                    "set literal has mixed element types: `{}` and `{}`",
+                    describe_ty(elem_ty, lcx),
+                    describe_ty(item_e.ty(), lcx)
+                ),
+                item.span.clone(),
+            ));
+        }
+        elements.push(item_e);
+    }
+
+    let set_id = super::intern_set(lcx.sets, elem_ty);
+    let set_ty = KirType::Set(set_id);
+    let span_id = table.intern(span.clone());
+    let mut acc = Expr::Call {
+        target: CallTarget::Rt(ir::RtFn::SetNew),
+        args: Vec::new(),
+        ty: set_ty,
+        span: span_id,
+    };
+    for element in elements {
+        acc = Expr::Call {
+            target: CallTarget::Rt(ir::RtFn::SetInsert),
+            args: vec![acc, element],
+            ty: set_ty,
+            span: span_id,
+        };
+    }
+    Ok(acc)
+}
+
 /// Lowers a value method call on a `list[T]`-typed receiver (`xs.push(v)`,
 /// `xs.len()`) — the only container value methods lowered so far.
 fn lower_list_method_call(
@@ -948,6 +1102,144 @@ fn lower_list_method_call(
         }
         other => Err(LowerError::unsupported(
             &format!("list method `{other}` (only `push`/`len`/`count` are lowered so far)"),
+            call_span.clone(),
+        )),
+    }
+}
+
+/// Lowers a value method call on a `map[str, V]`-typed receiver (`m.get(k)`,
+/// `m.keys()`, `m.values()`, `m.len()`/`.count()`/`.size()`,
+/// `m.is_empty()`, `m.contains(k)`/`.has(k)`) — the construct/read subset
+/// issue #162 scopes to (no mutation method exists in the interpreter to
+/// match yet — see `KirType::Map`'s doc). `is_empty` has no dedicated
+/// runtime op; it's synthesized as `len == 0` rather than adding a
+/// `keel_map_is_empty` FFI symbol whose only job would be exactly that.
+fn lower_map_method_call(
+    object_e: Expr,
+    method: &str,
+    args: &[ast::CallArg],
+    ctx: &mut FnCtx,
+    lcx: &LowerCtx<'_>,
+    table: &mut SpanTable,
+    call_span: &Span,
+) -> Result<Expr, LowerError> {
+    let KirType::Map(map_id) = object_e.ty() else {
+        unreachable!("caller only invokes lower_map_method_call on a KirType::Map receiver");
+    };
+    for arg in args {
+        if arg.name.is_some() || arg.spread {
+            return Err(LowerError::unsupported(
+                "named or spread arguments to a map method call",
+                arg.value.span.clone(),
+            ));
+        }
+    }
+
+    let value_ty = lcx.maps.borrow()[map_id];
+    let span_id = table.intern(call_span.clone());
+
+    let one_str_arg = |args: &[ast::CallArg],
+                       ctx: &mut FnCtx,
+                       table: &mut SpanTable|
+     -> Result<Expr, LowerError> {
+        let [arg] = args else {
+            return Err(LowerError::new(
+                format!("`{method}` takes 1 argument, got {}", args.len()),
+                call_span.clone(),
+            ));
+        };
+        lower_expr_expecting(&arg.value, KirType::Str, ctx, lcx, table)
+    };
+
+    match method {
+        "get" => {
+            let key_e = one_str_arg(args, ctx, table)?;
+            let nullable_id = super::intern_nullable(lcx.nullables, value_ty);
+            Ok(Expr::Call {
+                target: CallTarget::Rt(ir::RtFn::MapGet),
+                args: vec![object_e, key_e],
+                ty: KirType::Nullable(nullable_id),
+                span: span_id,
+            })
+        }
+        "contains" | "has" => {
+            let key_e = one_str_arg(args, ctx, table)?;
+            Ok(Expr::Call {
+                target: CallTarget::Rt(ir::RtFn::MapContains),
+                args: vec![object_e, key_e],
+                ty: KirType::Bool,
+                span: span_id,
+            })
+        }
+        "keys" => {
+            if !args.is_empty() {
+                return Err(LowerError::new(
+                    format!("`keys` takes 0 arguments, got {}", args.len()),
+                    call_span.clone(),
+                ));
+            }
+            let list_id = super::intern_list(lcx.lists, KirType::Str);
+            Ok(Expr::Call {
+                target: CallTarget::Rt(ir::RtFn::MapKeys),
+                args: vec![object_e],
+                ty: KirType::List(list_id),
+                span: span_id,
+            })
+        }
+        "values" => {
+            if !args.is_empty() {
+                return Err(LowerError::new(
+                    format!("`values` takes 0 arguments, got {}", args.len()),
+                    call_span.clone(),
+                ));
+            }
+            let list_id = super::intern_list(lcx.lists, value_ty);
+            Ok(Expr::Call {
+                target: CallTarget::Rt(ir::RtFn::MapValues),
+                args: vec![object_e],
+                ty: KirType::List(list_id),
+                span: span_id,
+            })
+        }
+        "len" | "count" | "size" => {
+            if !args.is_empty() {
+                return Err(LowerError::new(
+                    format!("`{method}` takes 0 arguments, got {}", args.len()),
+                    call_span.clone(),
+                ));
+            }
+            Ok(Expr::Call {
+                target: CallTarget::Rt(ir::RtFn::MapLen),
+                args: vec![object_e],
+                ty: KirType::I64,
+                span: span_id,
+            })
+        }
+        "is_empty" => {
+            if !args.is_empty() {
+                return Err(LowerError::new(
+                    format!("`is_empty` takes 0 arguments, got {}", args.len()),
+                    call_span.clone(),
+                ));
+            }
+            let len_e = Expr::Call {
+                target: CallTarget::Rt(ir::RtFn::MapLen),
+                args: vec![object_e],
+                ty: KirType::I64,
+                span: span_id,
+            };
+            Ok(Expr::BinOp {
+                op: ir::BinOp::Eq,
+                left: Box::new(len_e),
+                right: Box::new(Expr::ConstInt(0)),
+                ty: KirType::Bool,
+            })
+        }
+        other => Err(LowerError::unsupported(
+            &format!(
+                "map method `{other}` (only `get`/`keys`/`values`/`len`/`count`/`size`/\
+                 `is_empty`/`contains`/`has` are lowered so far)"
+            ),
             call_span.clone(),
         )),
     }

--- a/crates/keel-kir/src/lower/mod.rs
+++ b/crates/keel-kir/src/lower/mod.rs
@@ -51,8 +51,8 @@ use keel_syntax::ast::{Binding, Decl, Program, TypeDef, UseDecl, UseKind, UseSou
 use keel_syntax::lexer::Span;
 
 use crate::ir::{
-    Block, EnumId, EnumLayout, FuncId, KirFunction, KirProgram, ListId, LocalId, NullableId,
-    StructId, StructLayout,
+    Block, EnumId, EnumLayout, FuncId, KirFunction, KirProgram, ListId, LocalId, MapId, NullableId,
+    SetId, StructId, StructLayout,
 };
 use crate::span_table::SpanTable;
 use crate::types::KirType;
@@ -117,6 +117,12 @@ pub(crate) struct LowerCtx<'a> {
     /// See `lower_program`'s `lists` local for why this needs interior
     /// mutability (structurally discovered, not pre-declared).
     pub(crate) lists: &'a std::cell::RefCell<Vec<KirType>>,
+    /// Same interior-mutability rationale as `lists`, for `map[str, V]`
+    /// value types.
+    pub(crate) maps: &'a std::cell::RefCell<Vec<KirType>>,
+    /// Same interior-mutability rationale as `lists`, for `set[T]` element
+    /// types.
+    pub(crate) sets: &'a std::cell::RefCell<Vec<KirType>>,
     /// Same interior-mutability rationale as `lists`, for `T?` shapes.
     pub(crate) nullables: &'a std::cell::RefCell<Vec<KirType>>,
     /// Each task's per-parameter default-value expression (`None` for a
@@ -235,6 +241,12 @@ pub fn lower_program(
     // `LowerCtx` otherwise fully immutable/shared (see its doc) while still
     // letting every lowering function grow this table via `intern_list`.
     let lists: std::cell::RefCell<Vec<KirType>> = std::cell::RefCell::new(Vec::new());
+    // Same structural-interning rationale as `lists`, for `map[str, V]`
+    // value types.
+    let maps: std::cell::RefCell<Vec<KirType>> = std::cell::RefCell::new(Vec::new());
+    // Same structural-interning rationale as `lists`, for `set[T]` element
+    // types.
+    let sets: std::cell::RefCell<Vec<KirType>> = std::cell::RefCell::new(Vec::new());
     // Same structural-interning rationale as `lists`, for `T?` shapes.
     let nullables: std::cell::RefCell<Vec<KirType>> = std::cell::RefCell::new(Vec::new());
 
@@ -303,6 +315,8 @@ pub fn lower_program(
                     &structs_by_name,
                     &enums_by_name,
                     &lists,
+                    &maps,
+                    &sets,
                     &nullables,
                 )?,
             ));
@@ -339,8 +353,15 @@ pub fn lower_program(
     for decl in &program.declarations {
         match &decl.kind {
             Decl::Task(task) => {
-                let (params, ret) =
-                    decl::signature_of(task, &structs_by_name, &enums_by_name, &lists, &nullables)?;
+                let (params, ret) = decl::signature_of(
+                    task,
+                    &structs_by_name,
+                    &enums_by_name,
+                    &lists,
+                    &maps,
+                    &sets,
+                    &nullables,
+                )?;
                 let func_id = task_order.len();
                 task_order.push(task);
                 funcs.insert(
@@ -385,6 +406,8 @@ pub fn lower_program(
             enums_by_name: &enums_by_name,
             enum_layouts: &enum_layouts,
             lists: &lists,
+            maps: &maps,
+            sets: &sets,
             nullables: &nullables,
             param_defaults: &empty_param_defaults,
             artifacts,
@@ -406,6 +429,8 @@ pub fn lower_program(
         enums_by_name: &enums_by_name,
         enum_layouts: &enum_layouts,
         lists: &lists,
+        maps: &maps,
+        sets: &sets,
         nullables: &nullables,
         param_defaults: &param_defaults,
         artifacts,
@@ -469,6 +494,8 @@ pub fn lower_program(
         structs: struct_layouts,
         enums: enum_layouts,
         lists: lists.into_inner(),
+        maps: maps.into_inner(),
+        sets: sets.into_inner(),
         nullables: nullables.into_inner(),
         span_table,
     })
@@ -741,11 +768,14 @@ fn stmt_uses_raise_or_try(stmt: &keel_syntax::ast::Stmt) -> bool {
 /// `enums_by_name` resolve a bare `Named` type to a declared struct or enum
 /// — checked after the built-in scalar names, so neither can shadow a
 /// reserved type name.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn ty_expr_to_kir(
     ty: &keel_syntax::ast::Node<keel_syntax::ast::TypeExpr>,
     structs_by_name: &HashMap<String, StructId>,
     enums_by_name: &HashMap<String, EnumId>,
     lists: &std::cell::RefCell<Vec<KirType>>,
+    maps: &std::cell::RefCell<Vec<KirType>>,
+    sets: &std::cell::RefCell<Vec<KirType>>,
     nullables: &std::cell::RefCell<Vec<KirType>>,
 ) -> Result<KirType, LowerError> {
     use keel_syntax::ast::TypeExpr;
@@ -777,6 +807,8 @@ pub(crate) fn ty_expr_to_kir(
                 structs_by_name,
                 enums_by_name,
                 lists,
+                maps,
+                sets,
                 nullables,
             )?;
             if !is_nullable_inner_ty(inner_ty) {
@@ -799,6 +831,8 @@ pub(crate) fn ty_expr_to_kir(
                 structs_by_name,
                 enums_by_name,
                 lists,
+                maps,
+                sets,
                 nullables,
             )?;
             if !is_list_element_ty(elem_ty) {
@@ -810,8 +844,64 @@ pub(crate) fn ty_expr_to_kir(
             }
             Ok(KirType::List(intern_list(lists, elem_ty)))
         }
-        TypeExpr::Map(_, _) => Err(LowerError::unsupported("map type", ty.span.clone())),
-        TypeExpr::Set(_) => Err(LowerError::unsupported("set type", ty.span.clone())),
+        TypeExpr::Map(key, value) => {
+            // `TypeExpr::Map` boxes bare `TypeExpr`s, not `Node<TypeExpr>`s
+            // (no span of their own), same situation as `TypeExpr::List`.
+            let key_node = keel_syntax::ast::Node::new((**key).clone(), ty.span.clone());
+            let key_ty = ty_expr_to_kir(
+                &key_node,
+                structs_by_name,
+                enums_by_name,
+                lists,
+                maps,
+                sets,
+                nullables,
+            )?;
+            if key_ty != KirType::Str {
+                return Err(LowerError::unsupported(
+                    "map key type other than str (int/bool keys are a later M2/M3 concern)",
+                    ty.span.clone(),
+                ));
+            }
+            let value_node = keel_syntax::ast::Node::new((**value).clone(), ty.span.clone());
+            let value_ty = ty_expr_to_kir(
+                &value_node,
+                structs_by_name,
+                enums_by_name,
+                lists,
+                maps,
+                sets,
+                nullables,
+            )?;
+            if !is_list_element_ty(value_ty) {
+                return Err(LowerError::unsupported(
+                    "map value type other than int/float/bool/str (struct/enum values need \
+                     Value marshaling, a later M2/M3 concern)",
+                    ty.span.clone(),
+                ));
+            }
+            Ok(KirType::Map(intern_map(maps, value_ty)))
+        }
+        TypeExpr::Set(inner) => {
+            let inner_node = keel_syntax::ast::Node::new((**inner).clone(), ty.span.clone());
+            let elem_ty = ty_expr_to_kir(
+                &inner_node,
+                structs_by_name,
+                enums_by_name,
+                lists,
+                maps,
+                sets,
+                nullables,
+            )?;
+            if !is_list_element_ty(elem_ty) {
+                return Err(LowerError::unsupported(
+                    "set element type other than int/float/bool/str (struct/enum elements \
+                     need Value marshaling, a later M2/M3 concern)",
+                    ty.span.clone(),
+                ));
+            }
+            Ok(KirType::Set(intern_set(sets, elem_ty)))
+        }
         TypeExpr::Struct(_) => Err(LowerError::unsupported(
             "inline struct type",
             ty.span.clone(),
@@ -847,6 +937,29 @@ pub(crate) fn intern_list(lists: &std::cell::RefCell<Vec<KirType>>, elem: KirTyp
     }
     lists.push(elem);
     lists.len() - 1
+}
+
+/// Interns `value` into `maps`, returning its `MapId` — same structural-
+/// interning rationale as [`intern_list`] (the key is always `str`, so only
+/// the value type needs interning — see `ir.rs`'s `MapId` doc).
+pub(crate) fn intern_map(maps: &std::cell::RefCell<Vec<KirType>>, value: KirType) -> MapId {
+    let mut maps = maps.borrow_mut();
+    if let Some(id) = maps.iter().position(|t| *t == value) {
+        return id;
+    }
+    maps.push(value);
+    maps.len() - 1
+}
+
+/// Interns `elem` into `sets`, returning its `SetId` — same structural-
+/// interning rationale as [`intern_list`].
+pub(crate) fn intern_set(sets: &std::cell::RefCell<Vec<KirType>>, elem: KirType) -> SetId {
+    let mut sets = sets.borrow_mut();
+    if let Some(id) = sets.iter().position(|t| *t == elem) {
+        return id;
+    }
+    sets.push(elem);
+    sets.len() - 1
 }
 
 /// `true` for the inner types a nullable (`T?`) can wrap today —

--- a/crates/keel-kir/src/lower/stmt.rs
+++ b/crates/keel-kir/src/lower/stmt.rs
@@ -61,6 +61,8 @@ pub(crate) fn lower_stmt(
                     lcx.structs_by_name,
                     lcx.enums_by_name,
                     lcx.lists,
+                    lcx.maps,
+                    lcx.sets,
                     lcx.nullables,
                 )?;
                 lower_expr_expecting(value, expected, ctx, lcx, table)?

--- a/crates/keel-kir/src/passes/verify.rs
+++ b/crates/keel-kir/src/passes/verify.rs
@@ -134,6 +134,26 @@ fn check_list(program: &KirProgram, id: crate::ir::ListId) -> Result<(), String>
     Ok(())
 }
 
+fn check_map(program: &KirProgram, id: crate::ir::MapId) -> Result<(), String> {
+    if id >= program.maps.len() {
+        return Err(format!(
+            "MapId {id} out of range ({} maps)",
+            program.maps.len()
+        ));
+    }
+    Ok(())
+}
+
+fn check_set(program: &KirProgram, id: crate::ir::SetId) -> Result<(), String> {
+    if id >= program.sets.len() {
+        return Err(format!(
+            "SetId {id} out of range ({} sets)",
+            program.sets.len()
+        ));
+    }
+    Ok(())
+}
+
 fn check_nullable(program: &KirProgram, id: crate::ir::NullableId) -> Result<(), String> {
     if id >= program.nullables.len() {
         return Err(format!(
@@ -658,6 +678,188 @@ fn verify_rt_call(
             check_list(program, list_id)?;
             if ty != KirType::I64 {
                 return Err(format!("rt.list_len result is {ty}, expected int"));
+            }
+            Ok(())
+        }
+        RtFn::MapNew => {
+            if !args.is_empty() {
+                return Err(format!("rt.map_new takes 0 args, got {}", args.len()));
+            }
+            let KirType::Map(map_id) = ty else {
+                return Err(format!("rt.map_new result is {ty}, expected a map"));
+            };
+            check_map(program, map_id)
+        }
+        RtFn::MapInsert => {
+            let [map, key, val] = args else {
+                return Err(format!("rt.map_insert takes 3 args, got {}", args.len()));
+            };
+            let KirType::Map(map_id) = map.ty() else {
+                return Err(format!(
+                    "rt.map_insert base is {}, expected a map",
+                    map.ty()
+                ));
+            };
+            check_map(program, map_id)?;
+            if key.ty() != KirType::Str {
+                return Err(format!(
+                    "rt.map_insert key is {}, expected str (map[str, V] only)",
+                    key.ty()
+                ));
+            }
+            let value_ty = program.maps[map_id];
+            if val.ty() != value_ty {
+                return Err(format!(
+                    "rt.map_insert value is {} but the map holds {value_ty}",
+                    val.ty()
+                ));
+            }
+            if ty != map.ty() {
+                return Err(format!(
+                    "rt.map_insert result is {ty} but the base map is {}",
+                    map.ty()
+                ));
+            }
+            Ok(())
+        }
+        RtFn::MapGet => {
+            let [map, key] = args else {
+                return Err(format!("rt.map_get takes 2 args, got {}", args.len()));
+            };
+            let KirType::Map(map_id) = map.ty() else {
+                return Err(format!("rt.map_get base is {}, expected a map", map.ty()));
+            };
+            check_map(program, map_id)?;
+            if key.ty() != KirType::Str {
+                return Err(format!(
+                    "rt.map_get key is {}, expected str (map[str, V] only)",
+                    key.ty()
+                ));
+            }
+            let value_ty = program.maps[map_id];
+            let KirType::Nullable(nullable_id) = ty else {
+                return Err(format!("rt.map_get result is {ty}, expected a nullable"));
+            };
+            check_nullable(program, nullable_id)?;
+            if program.nullables[nullable_id] != value_ty {
+                return Err(format!(
+                    "rt.map_get result is {}? but the map holds {value_ty}",
+                    program.nullables[nullable_id]
+                ));
+            }
+            Ok(())
+        }
+        RtFn::MapLen => {
+            let [map] = args else {
+                return Err(format!("rt.map_len takes 1 arg, got {}", args.len()));
+            };
+            let KirType::Map(map_id) = map.ty() else {
+                return Err(format!("rt.map_len base is {}, expected a map", map.ty()));
+            };
+            check_map(program, map_id)?;
+            if ty != KirType::I64 {
+                return Err(format!("rt.map_len result is {ty}, expected int"));
+            }
+            Ok(())
+        }
+        RtFn::MapContains => {
+            let [map, key] = args else {
+                return Err(format!("rt.map_contains takes 2 args, got {}", args.len()));
+            };
+            let KirType::Map(map_id) = map.ty() else {
+                return Err(format!(
+                    "rt.map_contains base is {}, expected a map",
+                    map.ty()
+                ));
+            };
+            check_map(program, map_id)?;
+            if key.ty() != KirType::Str {
+                return Err(format!(
+                    "rt.map_contains key is {}, expected str (map[str, V] only)",
+                    key.ty()
+                ));
+            }
+            if ty != KirType::Bool {
+                return Err(format!("rt.map_contains result is {ty}, expected bool"));
+            }
+            Ok(())
+        }
+        RtFn::MapKeys => {
+            let [map] = args else {
+                return Err(format!("rt.map_keys takes 1 arg, got {}", args.len()));
+            };
+            let KirType::Map(map_id) = map.ty() else {
+                return Err(format!("rt.map_keys base is {}, expected a map", map.ty()));
+            };
+            check_map(program, map_id)?;
+            let KirType::List(list_id) = ty else {
+                return Err(format!("rt.map_keys result is {ty}, expected a list"));
+            };
+            check_list(program, list_id)?;
+            if program.lists[list_id] != KirType::Str {
+                return Err(format!(
+                    "rt.map_keys result is list[{}], expected list[str] (map[str, V] only)",
+                    program.lists[list_id]
+                ));
+            }
+            Ok(())
+        }
+        RtFn::MapValues => {
+            let [map] = args else {
+                return Err(format!("rt.map_values takes 1 arg, got {}", args.len()));
+            };
+            let KirType::Map(map_id) = map.ty() else {
+                return Err(format!(
+                    "rt.map_values base is {}, expected a map",
+                    map.ty()
+                ));
+            };
+            check_map(program, map_id)?;
+            let value_ty = program.maps[map_id];
+            let KirType::List(list_id) = ty else {
+                return Err(format!("rt.map_values result is {ty}, expected a list"));
+            };
+            check_list(program, list_id)?;
+            if program.lists[list_id] != value_ty {
+                return Err(format!(
+                    "rt.map_values result is list[{}] but the map holds {value_ty}",
+                    program.lists[list_id]
+                ));
+            }
+            Ok(())
+        }
+        RtFn::SetNew => {
+            if !args.is_empty() {
+                return Err(format!("rt.set_new takes 0 args, got {}", args.len()));
+            }
+            let KirType::Set(set_id) = ty else {
+                return Err(format!("rt.set_new result is {ty}, expected a set"));
+            };
+            check_set(program, set_id)
+        }
+        RtFn::SetInsert => {
+            let [set, elem] = args else {
+                return Err(format!("rt.set_insert takes 2 args, got {}", args.len()));
+            };
+            let KirType::Set(set_id) = set.ty() else {
+                return Err(format!(
+                    "rt.set_insert base is {}, expected a set",
+                    set.ty()
+                ));
+            };
+            check_set(program, set_id)?;
+            let elem_ty = program.sets[set_id];
+            if elem.ty() != elem_ty {
+                return Err(format!(
+                    "rt.set_insert element is {} but the set holds {elem_ty}",
+                    elem.ty()
+                ));
+            }
+            if ty != set.ty() {
+                return Err(format!(
+                    "rt.set_insert result is {ty} but the base set is {}",
+                    set.ty()
+                ));
             }
             Ok(())
         }

--- a/crates/keel-kir/src/types.rs
+++ b/crates/keel-kir/src/types.rs
@@ -1,14 +1,15 @@
 //! `KirType` — the lowered type vocabulary KIR expressions carry.
 //!
 //! M0/M1 lower the scalar subset only (see `designs/llvm-compilation.md`
-//! §4); M2 adds named structs, simple enums, and `list[T]` (int/float/bool/
-//! str elements only). The remaining variants sketched in the design doc's
-//! `KirType` (§2.3) — map/set, anonymous struct shapes, rich enum variants,
-//! nullable, func, boxed `dynamic`, opaque handles — are deliberately not
-//! modeled yet; adding them is later-M2+ work, done alongside the lowering
-//! support that produces them.
+//! §4); M2 adds named structs, simple enums, `list[T]`, `map[str, V]`,
+//! `set[T]` (all restricted to int/float/bool/str elements), and nullable.
+//! The remaining variants sketched in the design doc's `KirType` (§2.3) —
+//! anonymous struct shapes, rich enum variants, non-`str` map keys, func,
+//! boxed `dynamic`, opaque handles — are deliberately not modeled yet;
+//! adding them is later-M2+ work, done alongside the lowering support that
+//! produces them.
 
-use crate::ir::{EnumId, KirProgram, ListId, NullableId, StructId};
+use crate::ir::{EnumId, KirProgram, ListId, MapId, NullableId, SetId, StructId};
 
 /// A KIR-level type. Every KIR expression carries one.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -41,6 +42,22 @@ pub enum KirType {
     /// mutation `Value::List` (opaque to codegen; every operation is a
     /// `CallTarget::Rt` runtime call, `designs/llvm-compilation.md` §2.7).
     List(ListId),
+    /// `map[str, V]` (`V` restricted to int/float/bool/str, and the key is
+    /// always `str` — see `KirProgram::maps`'s doc; non-`str` keys are a
+    /// later issue) — a `ptr` to an RC'd, always-clone-on-mutation
+    /// `Value::Map` (opaque to codegen, same `CallTarget::Rt` treatment as
+    /// `List`). No mutation op is exposed yet (issue #162's construct/read
+    /// scope — see `KirProgram::maps`'s doc for why).
+    Map(MapId),
+    /// `set[T]` (`T` restricted to int/float/bool/str, same as `List`) — a
+    /// `ptr` to an RC'd `Value::List` under the hood: the interpreter itself
+    /// has no distinct `Value::Set` representation yet (`SetLit` evaluates
+    /// to a plain, non-deduplicating `Value::List` — "v0.1: sets share list
+    /// repr"), so the compiled backend deliberately matches that rather than
+    /// diverging with a "more correct" deduplicating set the interpreter
+    /// doesn't have. `Set` is purely a *static* type distinction from
+    /// `List` — see `KirProgram::sets`'s doc.
+    Set(SetId),
     /// `T?` (inner restricted to int/float/bool/str/list/struct — see
     /// `KirProgram::nullables`'s doc and `lower::is_nullable_inner_ty`). Per
     /// §1.1's representation split: a nullable *struct* is the same `ptr` as
@@ -72,6 +89,8 @@ impl KirType {
             KirType::Struct(_) => "struct",
             KirType::Enum(_) => "enum",
             KirType::List(_) => "list",
+            KirType::Map(_) => "map",
+            KirType::Set(_) => "set",
             KirType::Nullable(_) => "nullable",
         }
     }
@@ -91,7 +110,7 @@ impl KirType {
         match self {
             KirType::Str => true,
             KirType::Struct(id) => program.structs[id].is_heap(program),
-            KirType::List(_) => true,
+            KirType::List(_) | KirType::Map(_) | KirType::Set(_) => true,
             KirType::I64 | KirType::F64 | KirType::Bool | KirType::Unit | KirType::Enum(_) => false,
             // A nullable scalar is a by-value `{ i1, T }` pair, not a
             // pointer — everything else nullable wraps a `ptr` (see

--- a/crates/keel-kir/tests/fixtures/maps_sets.keel
+++ b/crates/keel-kir/tests/fixtures/maps_sets.keel
@@ -1,0 +1,18 @@
+task total_stock(stock: map[str, int]) -> int {
+  sum = 0
+  for key in stock.keys() {
+    sum += (stock.get(key) ?? 0)
+  }
+  return sum
+}
+
+stock: map[str, int] = {apples: 1, pears: 2}
+count = stock.len()
+has_apples = stock.contains("apples")
+missing = stock.get("bananas") ?? -1
+names = stock.keys()
+amounts = stock.values()
+sum = total_stock(stock)
+
+nums = set[1, 2, 3]
+other = nums

--- a/crates/keel-kir/tests/fixtures/maps_sets.kir
+++ b/crates/keel-kir/tests/fixtures/maps_sets.kir
@@ -1,0 +1,19 @@
+fn total_stock(stock: map[str, int]) -> int {
+  let sum: int = 0
+  for key in rt.map_keys(stock) {
+    sum = (sum + (rt.map_get(stock, key) ?? 0))
+  }
+  return sum
+}
+
+fn <toplevel>() -> none {
+  let stock: map[str, int] = rt.map_insert(rt.map_insert(rt.map_new(), "apples", 1), "pears", 2)
+  let count: int = rt.map_len(stock)
+  let has_apples: bool = rt.map_contains(stock, "apples")
+  let missing: int = (rt.map_get(stock, "bananas") ?? (-1))
+  let names: list[str] = rt.map_keys(stock)
+  let amounts: list[int] = rt.map_values(stock)
+  let sum: int = total_stock(stock)
+  let nums: set[int] = rt.set_insert(rt.set_insert(rt.set_insert(rt.set_new(), 1), 2), 3)
+  let other: set[int] = nums
+}

--- a/crates/keel-kir/tests/lower_errors.rs
+++ b/crates/keel-kir/tests/lower_errors.rs
@@ -563,6 +563,81 @@ task f() -> int {
 }
 
 #[test]
+fn map_literal_with_a_non_str_key_is_rejected() {
+    let msg = lower_err(
+        r#"
+task f() -> int {
+  stock: map[str, int] = {1: 2}
+  return 0
+}
+"#,
+    );
+    assert!(msg.contains("non-str key"), "unexpected message: {msg}");
+}
+
+#[test]
+fn duplicate_key_in_map_literal_is_rejected() {
+    let msg = lower_err(
+        r#"
+task f() -> int {
+  stock: map[str, int] = {apples: 1, apples: 2}
+  return 0
+}
+"#,
+    );
+    assert!(
+        msg.contains("duplicate key `apples`"),
+        "unexpected message: {msg}"
+    );
+}
+
+#[test]
+fn unknown_map_method_is_rejected() {
+    let msg = lower_err(
+        r#"
+task f() -> int {
+  stock: map[str, int] = {apples: 1}
+  ys = stock.pop()
+  return 0
+}
+"#,
+    );
+    assert!(msg.contains("map method"), "unexpected message: {msg}");
+}
+
+#[test]
+fn map_get_wrong_arg_count_is_rejected() {
+    let msg = lower_err(
+        r#"
+task f() -> int {
+  stock: map[str, int] = {apples: 1}
+  ys = stock.get()
+  return 0
+}
+"#,
+    );
+    assert!(msg.contains("`get`"), "unexpected message: {msg}");
+}
+
+#[test]
+fn set_value_method_call_is_rejected() {
+    // Issue #162 scopes construct/pass-through only for `set[T]` (the
+    // interpreter has no `Value::Set` variant and no set methods to match
+    // against yet — see `KirType::Set`'s doc) — a method call on a set
+    // falls through to the generic "method call" rejection, same as any
+    // other unsupported receiver type.
+    let msg = lower_err(
+        r#"
+task f() -> int {
+  nums = set[1, 2, 3]
+  return nums.len()
+}
+"#,
+    );
+    assert!(msg.contains("method call"), "unexpected message: {msg}");
+}
+
+#[test]
 fn index_access_on_a_non_list_value_is_rejected() {
     let msg = lower_err(
         r#"

--- a/crates/keel-rt-ffi/src/abi/mod.rs
+++ b/crates/keel-rt-ffi/src/abi/mod.rs
@@ -19,10 +19,11 @@
 
 pub mod rc;
 
+use std::collections::HashMap;
 use std::slice;
 use std::sync::Arc;
 
-use keel_runtime::interpreter::value::Value;
+use keel_runtime::interpreter::value::{MapKey, Value};
 
 /// Boxes an `int` constant. Returns a strong (+1) reference the caller owns
 /// and must eventually pass to [`rc::keel_box_release`].
@@ -270,6 +271,136 @@ pub unsafe extern "C" fn keel_list_get(list: *const Value, index: i64) -> *const
         std::process::exit(1);
     };
     boxed(item.clone())
+}
+
+/// Builds an empty `map[str, V]`. See [`keel_box_int`] for ownership.
+#[unsafe(no_mangle)]
+pub extern "C" fn keel_map_new() -> *const Value {
+    Arc::into_raw(Arc::new(Value::Map(HashMap::new())))
+}
+
+/// Returns a **fresh** map with `key`/`val` inserted (overwriting `key`'s
+/// existing entry, if any), leaving `map` untouched — the same deliberate
+/// always-clone convention as [`keel_list_push`] (see its doc for why: real
+/// copy-on-write needs the RC pass this codebase doesn't implement yet).
+///
+/// # Safety
+///
+/// `map` must be a live `KeelBox` whose `Value` is `Value::Map`; `key` must
+/// be a live `KeelBox` whose `Value` is `Value::String` (`map[str, V]` only
+/// — non-`str` keys are a later issue); `val` must be a live `KeelBox` (any
+/// variant).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn keel_map_insert(
+    map: *const Value,
+    key: *const Value,
+    val: *const Value,
+) -> *const Value {
+    let Value::Map(entries) = (unsafe { &*map }) else {
+        unreachable!("keel-codegen only calls keel_map_insert on a KirType::Map value");
+    };
+    let Value::String(key) = (unsafe { &*key }) else {
+        unreachable!("keel-codegen only calls keel_map_insert with a str key (map[str, V])");
+    };
+    let mut entries = entries.clone();
+    entries.insert(MapKey::Str(key.clone()), unsafe { borrow(val) });
+    boxed(Value::Map(entries))
+}
+
+/// Returns the value for `key`, or a boxed `Value::None` if absent — mirrors
+/// the interpreter's `map.get` (`interpreter/methods.rs`), which returns
+/// `none` rather than raising on a missing key (unlike [`keel_list_get`]'s
+/// out-of-bounds exit: a missing map key is an ordinary, checker-required-
+/// nullable outcome, not a programming error).
+///
+/// # Safety
+///
+/// `map` must be a live `KeelBox` whose `Value` is `Value::Map`; `key` must
+/// be a live `KeelBox` whose `Value` is `Value::String`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn keel_map_get(map: *const Value, key: *const Value) -> *const Value {
+    let Value::Map(entries) = (unsafe { &*map }) else {
+        unreachable!("keel-codegen only calls keel_map_get on a KirType::Map value");
+    };
+    let Value::String(key) = (unsafe { &*key }) else {
+        unreachable!("keel-codegen only calls keel_map_get with a str key (map[str, V])");
+    };
+    boxed(
+        entries
+            .get(&MapKey::Str(key.clone()))
+            .cloned()
+            .unwrap_or(Value::None),
+    )
+}
+
+/// Returns a map's entry count.
+///
+/// # Safety
+///
+/// `map` must be a live `KeelBox` whose `Value` is `Value::Map`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn keel_map_len(map: *const Value) -> i64 {
+    let Value::Map(entries) = (unsafe { &*map }) else {
+        unreachable!("keel-codegen only calls keel_map_len on a KirType::Map value");
+    };
+    entries.len() as i64
+}
+
+/// Reports whether `key` is present. Returns `1`/`0`, matching
+/// [`keel_str_eq`]'s convention.
+///
+/// # Safety
+///
+/// `map` must be a live `KeelBox` whose `Value` is `Value::Map`; `key` must
+/// be a live `KeelBox` whose `Value` is `Value::String`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn keel_map_contains(map: *const Value, key: *const Value) -> u8 {
+    let Value::Map(entries) = (unsafe { &*map }) else {
+        unreachable!("keel-codegen only calls keel_map_contains on a KirType::Map value");
+    };
+    let Value::String(key) = (unsafe { &*key }) else {
+        unreachable!("keel-codegen only calls keel_map_contains with a str key (map[str, V])");
+    };
+    u8::from(entries.contains_key(&MapKey::Str(key.clone())))
+}
+
+/// Returns this map's keys as a `list[str]`, **sorted** — `HashMap`
+/// iteration order isn't deterministic, so this matches the interpreter's
+/// own `map.keys` (`interpreter/methods.rs`), which sorts for exactly that
+/// reason (byte-identical output is the whole point of this ABI).
+///
+/// # Safety
+///
+/// `map` must be a live `KeelBox` whose `Value` is `Value::Map`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn keel_map_keys(map: *const Value) -> *const Value {
+    let Value::Map(entries) = (unsafe { &*map }) else {
+        unreachable!("keel-codegen only calls keel_map_keys on a KirType::Map value");
+    };
+    let mut keys: Vec<&MapKey> = entries.keys().collect();
+    keys.sort();
+    boxed(Value::List(
+        keys.into_iter().map(MapKey::to_value).collect(),
+    ))
+}
+
+/// Returns this map's values as a `list[V]`, ordered by **sorted key** —
+/// same determinism rationale as [`keel_map_keys`], matching the
+/// interpreter's `map.values`.
+///
+/// # Safety
+///
+/// `map` must be a live `KeelBox` whose `Value` is `Value::Map`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn keel_map_values(map: *const Value) -> *const Value {
+    let Value::Map(entries) = (unsafe { &*map }) else {
+        unreachable!("keel-codegen only calls keel_map_values on a KirType::Map value");
+    };
+    let mut keys: Vec<&MapKey> = entries.keys().collect();
+    keys.sort();
+    boxed(Value::List(
+        keys.into_iter().map(|k| entries[k].clone()).collect(),
+    ))
 }
 
 /// Reads a `KeelBox`'s value without consuming the caller's reference —

--- a/crates/keel-syntax/src/parser/types.rs
+++ b/crates/keel-syntax/src/parser/types.rs
@@ -10,7 +10,7 @@ use super::common::KeelExt;
 use crate::ast::{Field, Node, TypeExpr};
 use crate::lexer::Token;
 
-use super::common::{P, field_name, field_sep, ident, newlines};
+use super::common::{P, field_name, field_sep, newlines};
 
 /// Wrap a [`type_expr`] production with its source span.
 ///
@@ -23,7 +23,19 @@ pub(super) fn spanned_type_expr() -> P<Node<TypeExpr>> {
 
 pub(super) fn type_expr() -> P<TypeExpr> {
     recursive(|ty| {
-        let named = ident().map(TypeExpr::Named);
+        // `set` is a reserved keyword (its own `Token::Set`, used by the
+        // `set[1, 2, 3]` literal-expression grammar) rather than a plain
+        // `Token::Ident` — so plain `ident()` can never produce
+        // `TypeExpr::Named("set")`, and `set[T]` as a *type annotation*
+        // (as opposed to a set literal) could never parse without this,
+        // even though the generic-args resolution below already has a
+        // `n == "set"` branch waiting for it. Same "keyword usable as a
+        // name in this one grammar position" pattern as `field_name()`.
+        let named = select! {
+            Token::Ident(s) => s,
+            Token::Set => "set".to_string(),
+        }
+        .map(TypeExpr::Named);
 
         let dynamic_ty = just(Token::Ident("dynamic".to_string())).to(TypeExpr::Dynamic);
 


### PR DESCRIPTION
## What's in scope here

- `keel-rt-ffi`: 7 new FFI symbols — `keel_map_new/insert/get/len/contains/keys/values` — following the same always-clone-on-mutate convention as `keel_list_push`. `keel_map_get` returns a boxed `Value::None` on a miss (never exits), matching the interpreter's `map.get`.
- `keel-kir`: `KirType::Map`/`KirType::Set`, structural interning (`intern_map`/`intern_set`), map/set literal lowering (map literals are disambiguated from struct literals via the already-parsed `MapLitKey` keys plus the expected-type channel, same move used for list-literal element inference), and map read methods: `get`/`contains`/`has`/`keys`/`values`/`len`/`count`/`size`/`is_empty`. Set literals lower to construction + pass-through only — no set methods, since the interpreter has none to match against yet.
- `keel-codegen`: codegen for all of the above, including `.get()`'s `Nullable` result — verified against both the scalar `{i1, i64}` nullable repr (`map[str, int]`) and the pointer-based repr (`map[str, str]`), since those are genuinely different LLVM basic blocks.
- **Unplanned parser fix**, outside "keel-kir + keel-codegen" but blocking: `set[T]` as a *type annotation* (`nums: set[int] = ...`) could never parse — only the `set[1, 2, 3]` literal-expression grammar accepted the `set` keyword token; the type-expr grammar's generic-args resolution already had a dead `n == "set"` branch waiting for input it could never receive. Fixed in `crates/keel-syntax/src/parser/types.rs` by letting `Token::Set` resolve to `TypeExpr::Named("set")` in that one grammar position (same pattern as `field_name()`).

## Tests

- Golden-dump fixture: `maps_sets.keel`/`.kir`.
- `lower_errors.rs`: 5 new cases — non-str map key, duplicate key, unknown map method, `get` wrong arg count, set method call rejection.
- `keel-codegen` integration tests: `maps.rs` (5 tests: scalar and str-valued `.get()` hit+miss, `len`/`contains`/`has`/`is_empty`, `keys`/`values`, an end-to-end iterate-and-sum-lookups task) and `sets.rs` (2 tests: construction/pass-through, str elements). Every test diffs stdout **and exit code** against the interpreter.

Full workspace `cargo fmt` / `cargo clippy --all-targets -- -D warnings` / `cargo test --workspace` all clean, zero regressions.

## Deferred

Map/set *mutation* plus a differential CoW-aliasing test (mirroring list's `#163` `aliased_bindings_do_not_observe_each_others_push`) aren't satisfiable yet: `keel-runtime` has no map mutation method and no `Value::Set` variant at all (a `set[...]` literal today evaluates to a plain, non-deduplicating `Value::List`) — there's nothing on the interpreter side to differentially match the compiled backend against yet. Split out to #172, which tracks adding those to the interpreter first — same "split deferred scope into its own tracked issue" shape as #147 → #162.

One intentional, documented divergence: a duplicate key in a map literal is a hard lowering error here, while the interpreter silently takes last-wins. No conformance fixture would ever exercise this; flagged in a comment at the rejection site.

Closes #162