### PR TITLE
type checker: allow bare none wherever a nullable type is expected (#174)

### DIFF
--- a/crates/keel-compiler/src/types/checker.rs
+++ b/crates/keel-compiler/src/types/checker.rs
@@ -995,6 +995,9 @@ impl<'hir, 'ast> Checker<'hir, 'ast> {
             | (Ty::Bool, Ty::Bool)
             | (Ty::None_, Ty::None_)
             | (Ty::Uuid, Ty::Uuid) => true,
+            // A bare `none` matches any nullable type — same rationale as
+            // `expect_at`'s equivalent case (#174).
+            (Ty::None_, Ty::Nullable(_)) | (Ty::Nullable(_), Ty::None_) => true,
             (Ty::List(a), Ty::List(b)) | (Ty::Set(a), Ty::Set(b)) => {
                 self.types_match(a.as_ref(), b.as_ref())
             }
@@ -1049,6 +1052,21 @@ impl<'hir, 'ast> Checker<'hir, 'ast> {
             return;
         }
         if expected.is_opaque() {
+            return;
+        }
+
+        // A bare `none` literal is assignable to any nullable type — it never
+        // carries a concrete inner type of its own to compare structurally,
+        // so this must short-circuit before the struct/list/map/tuple
+        // recursion below (which would otherwise compare `None_` against
+        // whatever `expected`'s inner type is and fail the raw `!=`
+        // fallback). Without this, `alias: str? = none` (SPEC.md §2.7's own
+        // example), a nullable struct-literal field, a `return none`, and a
+        // `none` call argument are all rejected even though a nullable
+        // *default parameter value* (`n: int? = none`) has always worked —
+        // that path just never validates its default's type at all, it
+        // isn't a more permissive coercion (see #174).
+        if matches!(actual, Ty::None_) && matches!(expected, Ty::Nullable(_)) {
             return;
         }
 
@@ -1890,6 +1908,87 @@ task t() {
   x: str? = "hello"
 }
 "#,
+        );
+    }
+
+    // ─── #174: bare `none` assignable wherever a nullable type is expected ───────
+
+    #[test]
+    fn valid_none_assigned_to_annotated_nullable_let() {
+        // SPEC.md §2.7's own canonical example.
+        type_ok(
+            r#"
+name: str   = "Keel"
+alias: str? = none
+"#,
+        );
+    }
+
+    #[test]
+    fn valid_none_in_nullable_struct_literal_field() {
+        type_ok(
+            r#"
+type Email { subject: str? }
+
+e: Email = { subject: none }
+"#,
+        );
+    }
+
+    #[test]
+    fn valid_none_returned_from_nullable_returning_task() {
+        type_ok(
+            r#"
+task pick() -> int? {
+  return none
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn valid_none_passed_as_nullable_call_argument() {
+        type_ok(
+            r#"
+task f(n: int?) -> int {
+  return n ?? 0
+}
+
+x = f(none)
+"#,
+        );
+    }
+
+    #[test]
+    fn valid_none_overriding_a_nullable_struct_field_in_spread_update() {
+        type_ok(
+            r#"
+type Email { subject: str? }
+
+task run_test() {
+  e: Email = { subject: "hi" }
+  e2 = { ...e, subject: none }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn error_spread_update_field_override_wrong_type_is_still_rejected() {
+        // The struct-literal branch of spread-update never validated override
+        // values against the base field's declared type at all (a `none` was
+        // never the only thing that slipped through) — this pins that a
+        // genuinely wrong type is still caught now that it does.
+        expect_error(
+            r#"
+type Point { x: int, y: int }
+
+task run_test() {
+  p: Point = { x: 1, y: 2 }
+  q = { ...p, x: "oops" }
+}
+"#,
+            "expected",
         );
     }
 

--- a/crates/keel-compiler/src/types/checker/expr.rs
+++ b/crates/keel-compiler/src/types/checker/expr.rs
@@ -318,7 +318,7 @@ impl Checker<'_, '_> {
                         return Ty::Error;
                     }
                 };
-                let mut result_fields = base_fields.clone();
+                let result_fields = base_fields.clone();
                 let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
                 for (k, v) in overrides {
                     let val_ty = self.infer_expr(v, scope);
@@ -331,7 +331,17 @@ impl Checker<'_, '_> {
                         continue;
                     }
                     if let Some(pos) = result_fields.iter().position(|(f, _)| f == k) {
-                        result_fields[pos] = (k.clone(), val_ty);
+                        // Validate the override against the field's declared
+                        // type (previously unchecked — any type silently
+                        // replaced the field's static type here, mirroring
+                        // the map branch above's existing `self.expect` call
+                        // for the same purpose, #174). The result keeps the
+                        // struct's *declared* field type, not the override
+                        // expression's raw inferred type — e.g. overriding a
+                        // `str?` field with a bare `none` must not narrow the
+                        // result field's static type to `None_`.
+                        let field_ty = result_fields[pos].1.clone();
+                        self.expect(&val_ty, &field_ty, &format!("spread-update field `{k}`"));
                     } else {
                         self.err(format!(
                             "unknown field `{}` in spread-update — not present in base struct",

--- a/tests/conformance/main.rs
+++ b/tests/conformance/main.rs
@@ -309,6 +309,35 @@ fn skip_reason(stem: &str) -> Option<&'static str> {
 
 #[tokio::test]
 async fn interpreter_is_deterministic_across_the_corpus() {
+    // Pure, synchronous assertions on `strip_slow_test_watchdog_noise` — run
+    // here, inline, rather than as separate `#[test]` functions in this
+    // file: this binary's own module doc is explicit that a *second* test
+    // of any kind (sync or async) sharing this binary is enough to corrupt
+    // the fd-1 capture below, since libtest prints every sibling test's own
+    // `test <name> ... ok` status line to real stdout — exactly the class
+    // of bug this filter exists to work around in the first place. Adding
+    // these as sibling `#[test]`s previously did exactly that (observed:
+    // their own status lines leaked into the `agent_delegation` fixture's
+    // captured stdout).
+    assert_eq!(
+        strip_slow_test_watchdog_noise("  1. 1\n  2. 2\n".to_string()),
+        "  1. 1\n  2. 2\n",
+        "clean output must be returned byte-identical"
+    );
+    assert_eq!(
+        strip_slow_test_watchdog_noise("no trailing newline".to_string()),
+        "no trailing newline",
+        "output with no trailing newline must be untouched"
+    );
+    assert_eq!(
+        strip_slow_test_watchdog_noise(
+            "  hello\ntest interpreter_is_deterministic_across_the_corpus has been running for over 60 seconds\n  world\n"
+                .to_string()
+        ),
+        "  hello\n  world\n",
+        "a watchdog line spliced mid-output must be removed"
+    );
+
     // KEEL_LLM=mock keeps `ai.*` deterministic and offline; KEEL_ONESHOT=1
     // makes agent programs exit after one idle window instead of serving
     // forever. Set once, process-wide — safe because this whole corpus runs
@@ -477,30 +506,4 @@ async fn interpreter_is_deterministic_across_the_corpus() {
         failures.len(),
         failures.join("\n")
     );
-}
-
-#[cfg(test)]
-mod noise_filter_tests {
-    use super::strip_slow_test_watchdog_noise;
-
-    #[test]
-    fn clean_output_is_returned_byte_identical() {
-        let clean = "  1. 1\n  2. 2\n".to_string();
-        assert_eq!(strip_slow_test_watchdog_noise(clean.clone()), clean);
-    }
-
-    #[test]
-    fn output_with_no_trailing_newline_is_untouched() {
-        let clean = "no trailing newline".to_string();
-        assert_eq!(strip_slow_test_watchdog_noise(clean.clone()), clean);
-    }
-
-    #[test]
-    fn watchdog_line_spliced_mid_output_is_removed() {
-        let polluted = "  hello\ntest interpreter_is_deterministic_across_the_corpus has been running for over 60 seconds\n  world\n".to_string();
-        assert_eq!(
-            strip_slow_test_watchdog_noise(polluted),
-            "  hello\n  world\n"
-        );
-    }
 }

--- a/tests/conformance/main.rs
+++ b/tests/conformance/main.rs
@@ -127,7 +127,45 @@ where
     let mut captured = String::new();
     tmp.read_to_string(&mut captured)
         .expect("capture tempfile must be valid UTF-8");
-    (result, captured)
+    (result, strip_slow_test_watchdog_noise(captured))
+}
+
+/// Strips libtest's own "slow test" watchdog line from captured output.
+///
+/// This is not a sibling test writing to fd 1 (the risk the module doc
+/// already calls out) — it's the test harness's *own* built-in monitor
+/// thread, which unconditionally prints `test <name> has been running for
+/// over N seconds` to the process's real stdout if this single
+/// `#[tokio::test]` (which now runs the entire corpus, plus the M1/M2
+/// subprocess comparisons, sequentially) takes longer than the harness's
+/// slow-test threshold — observed in CI once the M2 fixture set (#151)
+/// pushed total runtime close to it, even though it stays comfortably under
+/// locally. There is no stable flag to disable that monitor thread, and the
+/// alternative (redirecting the *interpreter's* own output through an
+/// injectable writer instead of OS-level fd 1) is the "no injectable writer
+/// exists in the runtime today" gap the module doc already defers. Whichever
+/// corpus entry happens to be mid-capture when the monitor fires gets this
+/// line spliced into its otherwise-deterministic output — filtering the
+/// exact, recognizable line here is the narrow fix for that, not a general
+/// license to scrub arbitrary "unexpected" output.
+fn strip_slow_test_watchdog_noise(captured: String) -> String {
+    const MARKER: &str = "has been running for over";
+    // Fast path: the overwhelming majority of captures never see the
+    // watchdog fire at all — return byte-identical in that case rather than
+    // risk altering a program's output that doesn't end in a trailing
+    // newline via a lines()-based rebuild.
+    if !captured.contains(MARKER) {
+        return captured;
+    }
+    // `split('\n')` (not `.lines()`) preserves the exact segment structure
+    // — including a trailing empty segment when `captured` ends in `\n` —
+    // so rejoining with `\n` reconstructs byte-identically except for the
+    // one filtered-out line.
+    captured
+        .split('\n')
+        .filter(|line| !(line.starts_with("test ") && line.contains(MARKER)))
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 /// Runs one program under `engine`, in an isolated temp working directory
@@ -439,4 +477,30 @@ async fn interpreter_is_deterministic_across_the_corpus() {
         failures.len(),
         failures.join("\n")
     );
+}
+
+#[cfg(test)]
+mod noise_filter_tests {
+    use super::strip_slow_test_watchdog_noise;
+
+    #[test]
+    fn clean_output_is_returned_byte_identical() {
+        let clean = "  1. 1\n  2. 2\n".to_string();
+        assert_eq!(strip_slow_test_watchdog_noise(clean.clone()), clean);
+    }
+
+    #[test]
+    fn output_with_no_trailing_newline_is_untouched() {
+        let clean = "no trailing newline".to_string();
+        assert_eq!(strip_slow_test_watchdog_noise(clean.clone()), clean);
+    }
+
+    #[test]
+    fn watchdog_line_spliced_mid_output_is_removed() {
+        let polluted = "  hello\ntest interpreter_is_deterministic_across_the_corpus has been running for over 60 seconds\n  world\n".to_string();
+        assert_eq!(
+            strip_slow_test_watchdog_noise(polluted),
+            "  hello\n  world\n"
+        );
+    }
 }


### PR DESCRIPTION
## Problem

`Checker::expect_at` (`crates/keel-compiler/src/types/checker.rs`) never special-cased `Ty::None_` (the type a bare `none` literal infers to) against `Ty::Nullable(_)`. This rejected `none` in every position that routes through `expect`/`expect_at`:

- An annotated `let` — including SPEC.md §2.7's own canonical example, `alias: str? = none`
- A nullable struct-literal field (`e: Email = { subject: none }`)
- A nullable `return none`
- A nullable call argument (`f(none)`)

A nullable *default parameter value* (`n: int? = none`) always worked, but not because of a smarter coercion path — default values simply aren't validated against their declared type at all (see #176, filed separately; that's a distinct, more severe gap this PR doesn't touch).

## Fix

- `expect_at`: short-circuits `(Ty::None_, Ty::Nullable(_))` before the struct/list/map/tuple recursion, so it applies uniformly to every position listed above.
- `types_match`: added the same case (and its symmetric reverse) for consistency, since it's used for structural equality elsewhere (list/set element checks, variadic spread homogeneity).

## A closely-related gap fixed along the way

While tracing every call site of `expect`/`expect_at`, struct spread-update (`{ ...base, field: value }`) turned out to never validate override values against the base struct's declared field type at all — any type silently replaced the field's static type (the map-literal branch of spread-update already had this check; the struct branch didn't). Fixed the same way, and the result now keeps the struct's *declared* field type rather than the override's raw inferred type — important so overriding a `str?` field with `none` doesn't narrow the result's field type to bare `None_`.

## Two more severe gaps found, filed separately (not fixed here — different root causes)

- **#176**: default parameter/field values (task/method/interface/extern params, agent state fields) aren't type-checked against their declared type *at all* — `n: int = "oops"` passes `keel check` cleanly today.
- **#177**: top-level (module-scope) statements are each checked against a brand-new, empty `Scope` (`Checker::check_body`'s `Decl::Stmt` arm) — a later top-level statement referencing an earlier top-level binding gets no type info for it, so structural checks (nonexistent fields, wrong-type spread-update overrides) silently no-op at top level even though the identical code inside a task body is correctly rejected. Caught only by the interpreter's runtime guards, not `keel check`.

## Unrelated CI flakiness fixed on the same branch

CI on this branch surfaced a conformance-harness flakiness introduced by #151 (unrelated to the type-checker fix above, but found while this PR's own CI was running): the M2 fixture set pushed `interpreter_is_deterministic_across_the_corpus`'s total runtime close enough to libtest's unconditional 60-second slow-test warning that a slower CI runner triggers it mid-run. That warning prints straight to the process's real stdout, landing inside whichever corpus entry's `capture_stdout` window happens to be open and producing a spurious non-determinism failure (observed on `showcase`). `capture_stdout` now strips that exact line before comparing, with a fast path that returns captured output byte-identical when the watchdog never fires. 3 new unit tests pin this (clean output untouched, no-trailing-newline output untouched, polluted output correctly cleaned).

## Test plan

- [x] 6 new regression tests in `checker.rs`: annotated let (SPEC.md's example), nullable struct-literal field, nullable return, nullable call argument, spread-update override with `none`, and a negative test confirming a genuinely wrong-typed spread-update override is still rejected
- [x] 3 new unit tests for the watchdog-noise filter in `tests/conformance/main.rs`
- [x] `cargo test -p keel-compiler` — 216 passed (up from 210), 0 failed
- [x] `cargo test --test integration spread` — all 17 spread-related integration tests still pass, no regressions from the new spread-update validation
- [x] `cargo test --workspace --features build-backend --test conformance` — green, including the full M1+M2+corpus comparison
- [x] `cargo test --workspace` (default) — green
- [x] `cargo test --workspace --features build-backend` — green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo clippy --workspace --all-targets --features build-backend -- -D warnings` — clean
- [x] `cargo fmt --all` — clean

Close #174