### PR TITLE
type checker: check impl method bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,24 @@ Known D0 gaps (see `docs/src/guide/debugging.md`): code inside `Async.spawn` run
 ### Fixed
 
 - **Default parameter and state-field values were never checked against their declared type.** `task f(n: int = "oops") -> int` and an agent `state { count: int = "oops" }` both passed `keel check` cleanly — the HIR lowering pass visited every default expression for name resolution, but nothing in the second-pass checker ever validated the default's inferred type against the declared one, for any type. Task and agent-task parameter defaults and agent state-field defaults are now checked with the same `expect_at` check that call arguments and return values already use; a nullable default of bare `none` (`n: int? = none`) is unaffected. Interface method params, extern params, on-handler params, and variadic params are unaffected too, but only because the parser never allows a default to appear at those sites in the first place.
+- **`impl` method bodies were never type-checked at all.** The second-pass validation walk dispatched on task, test, agent, and top-level-statement declarations and dropped `Decl::Impl` on the floor, so a method body was parsed and name-resolved but never inferred — `keel check` passed cleanly on any type error inside one. `impl` bodies are now walked exactly like task bodies, with `self` bound to the implementing type: `self.field` resolves to the field's declared type (and an undeclared field is an error), and `self` can be passed anywhere a value of that type is expected. Two constructs that the interpreter has always rejected are now compile-time errors instead of run-time ones: `self.field = value` (the receiver is passed by value, so the write can never outlive the call) and `self.method(...)` (which always dispatches to the enclosing *agent's* task, never to another `impl` method — extract a top-level task and call it as `method(self)`).
+
+```keel
+interface Greetable {
+  task greet(self) -> str
+}
+
+type Person { name: str }
+
+impl Greetable for Person {
+  task greet(self) -> str {
+    x: int = "oops"      # now: `x`: expected int, got str
+    return self.nickname # now: field `nickname` does not exist on `Person`
+  }
+}
+```
+
+- **Built-in types were reported as "declared in another module".** Naming a built-in struct or interface in an annotation — `task complete(self, req: CompletionRequest)`, the signature every user-authored LLM provider writes — failed `keel check` with a suggestion to import it from a file, because the module-visibility check treated the checker's pre-seeded built-in tables as another module's declarations. Prelude names are now exempt; they are always in scope and cannot be imported.
 - **`keel check` gave false confidence for top-level programs that chain bindings.** Every top-level statement was checked against a brand-new, empty scope, so a later top-level statement referencing an earlier top-level binding had no type information for it — the checker fell back to an opaque type and silently accepted anything downstream (a spread-update overriding a field with the wrong type, or an unknown field added via spread-update, both passed `keel check` cleanly at the top level despite failing correctly inside a `task` body). Top-level statement checking now threads one scope across the whole program, mirroring how the runtime already shares one environment across top-level statements at run time.
 - **Plain `.field`/`?.field` access on a struct never checked the field actually existed.** In any context — top level or task body — an unknown field silently resolved to an opaque type instead of raising a diagnostic, so only the runtime's `Value has no field ...` error ever caught a typo. Now checked statically, same as struct-pattern destructuring already was.
 - **`schedule.cron` could stall the runtime on rare/impossible expressions.** Computing the next fire time scanned candidate minutes one at a time — up to ~4 years' worth — synchronously inside the async task driving the cron loop. A spec that fires rarely (or never, e.g. `"0 0 31 2 *"`, which asks for February 31st) blocked that task's worker thread for the full scan. The scan now runs via `tokio::task::spawn_blocking`, off the async worker pool; the matching logic itself is unchanged.

--- a/SPEC.md
+++ b/SPEC.md
@@ -801,6 +801,14 @@ io.show(p.print())    # → "(1.5, 2.0)"
 - Parameter types must match the interface signature. `dynamic` in the interface's parameter position is a wildcard — an `impl` may narrow it to any concrete type (this is how `Comparable`/`Equatable` accept `other: dynamic` while the `impl` declares `other: Score`). A concrete interface parameter type requires an exact match.
 - Return types must match exactly (`dynamic` in the return position is likewise a wildcard).
 - `self` inside the block receives the struct value. Use `self.field` to access fields.
+- Method bodies are type-checked like any other task body.
+
+**`self` inside a method body.** `self` is the receiver *value*, of the type named by the `for` clause — not an agent reference. So:
+
+- `self.field` has the field's declared type; naming a field the type does not declare is a compile-time error.
+- `self` may be passed anywhere a value of the implementing type is expected.
+- `self.field = value` is a compile-time error. The receiver is passed by value, so the write could never outlive the call — return an updated value instead.
+- `self.method(...)` is a compile-time error. That form is agent syntax and always dispatches to the enclosing agent's task, never to another `impl` method. Move the logic into a top-level task and call it as `method(self)`.
 
 **Dispatch rule.** The runtime dispatches `impl` methods by the value's declared type tag. A value acquires its tag at the first typed boundary it crosses: a `let x: TypeName = ...` binding, a task parameter with a named type annotation, a task return with a named return type, or an `ai.extract(…, as: TypeName)` call. List elements are promoted to `Value::Struct` when the list is assigned to a `list[TypeName]` variable. Untagged maps (struct literals not yet passed through a typed boundary) do not dispatch to any `impl` method.
 

--- a/crates/keel-compiler/src/types/checker.rs
+++ b/crates/keel-compiler/src/types/checker.rs
@@ -122,6 +122,11 @@ pub(crate) struct Checker<'hir, 'ast> {
     top_tasks: HashMap<String, TaskSig>,
     agents: HashMap<String, AgentInfo>,
     current_agent: Option<String>,
+    /// Implementing type name of the `impl` block whose method body is being
+    /// checked. `self` inside such a body is a value of that type — the
+    /// receiver — not an agent reference, so every `self`-gated site consults
+    /// this before falling back to the agent path.
+    current_impl_type: Option<String>,
     /// Declared return type of the task currently being checked.
     current_return_ty: Option<Ty>,
     /// Mock targets declared by the test currently being checked.
@@ -729,6 +734,7 @@ impl<'hir, 'ast> Checker<'hir, 'ast> {
             top_tasks: HashMap::new(),
             agents: HashMap::new(),
             current_agent: None,
+            current_impl_type: None,
             current_return_ty: None,
             current_test_mocks: None,
             current_span: None,
@@ -1031,7 +1037,14 @@ impl<'hir, 'ast> Checker<'hir, 'ast> {
         let mut last = Ty::None_;
         for node in block {
             last = match &node.kind {
-                Stmt::Expr(e) => self.infer_expr(e, scope),
+                Stmt::Expr(e) => {
+                    // Expression statements bypass `check_stmt`, the usual
+                    // writer of `current_span` — set it here too so errors
+                    // raised during inference carry this statement's location
+                    // instead of the enclosing declaration's.
+                    self.current_span = Some(node.span.clone());
+                    self.infer_expr(e, scope)
+                }
                 other => {
                     self.check_stmt(other, node.span.clone(), scope);
                     Ty::None_
@@ -2077,6 +2090,193 @@ agent A {
             r#"
 task f(n: int? = none) -> int {
   return n ?? 0
+}
+"#,
+        );
+    }
+
+    // ─── #181: impl method bodies were never type-checked ───────────────────────
+    // `check_body`'s dispatch used to drop `Decl::Impl` on the floor, so an impl
+    // method's body was parsed and name-resolved but never inferred — any type
+    // error inside it was silently accepted. These pin that impl bodies are now
+    // walked like any other task body, with `self` bound to the implementing
+    // type rather than to agent state.
+
+    #[test]
+    fn error_type_mismatch_inside_impl_method_body_is_rejected() {
+        expect_error(
+            r#"
+interface Greetable {
+  task greet(self) -> str
+}
+
+type Person { name: str }
+
+impl Greetable for Person {
+  task greet(self) -> str {
+    x: int = "oops"
+    return self.name
+  }
+}
+"#,
+            "expected int, got str",
+        );
+    }
+
+    #[test]
+    fn error_impl_method_returns_wrong_type() {
+        expect_error(
+            r#"
+interface Shape {
+  task area(self) -> float
+}
+
+type Rect { w: float, h: float }
+
+impl Shape for Rect {
+  task area(self) -> float {
+    return "wide"
+  }
+}
+"#,
+            "return value: expected float, got str",
+        );
+    }
+
+    #[test]
+    fn error_impl_method_unknown_self_field() {
+        expect_error(
+            r#"
+interface Shape {
+  task area(self) -> float
+}
+
+type Rect { w: float, h: float }
+
+impl Shape for Rect {
+  task area(self) -> float {
+    self.nope
+  }
+}
+"#,
+            "field `nope` does not exist on `Rect`",
+        );
+    }
+
+    #[test]
+    fn error_impl_method_undefined_name() {
+        expect_error(
+            r#"
+interface Shape {
+  task area(self) -> float
+}
+
+type Rect { w: float, h: float }
+
+impl Shape for Rect {
+  task area(self) -> float {
+    return missing * self.w
+  }
+}
+"#,
+            "undefined",
+        );
+    }
+
+    #[test]
+    fn error_impl_method_assigns_to_self_field() {
+        // The receiver is passed by value, so the write cannot outlive the
+        // call — the interpreter rejects it too.
+        expect_error(
+            r#"
+interface Shape {
+  task area(self) -> float
+}
+
+type Rect { w: float, h: float }
+
+impl Shape for Rect {
+  task area(self) -> float {
+    self.w = 2.0
+    self.w
+  }
+}
+"#,
+            "cannot assign to `self.w` in an `impl` method",
+        );
+    }
+
+    #[test]
+    fn error_impl_method_calls_self_method() {
+        // `self.m(...)` always routes to the enclosing *agent's* task at run
+        // time, so in an impl method it either fails or silently calls
+        // something else entirely.
+        expect_error(
+            r#"
+interface Shape {
+  task area(self) -> float
+  task label(self) -> str
+}
+
+type Rect { w: float, h: float }
+
+impl Shape for Rect {
+  task area(self) -> float {
+    self.w * self.h
+  }
+
+  task label(self) -> str {
+    "area is {self.area()}"
+  }
+}
+"#,
+            "not available in an `impl` method",
+        );
+    }
+
+    #[test]
+    fn valid_impl_method_body_type_checks_self_and_params() {
+        // `self` is a value of the implementing type: its fields resolve to
+        // their declared types and it can be passed wherever that type is
+        // expected.
+        type_ok(
+            r#"
+interface Shape {
+  task area(self) -> float
+  task grown(self) -> Rect
+}
+
+type Rect { w: float, h: float }
+
+task scale(r: Rect, factor: float) -> Rect {
+  { w: r.w * factor, h: r.h * factor }
+}
+
+impl Shape for Rect {
+  task area(self) -> float {
+    self.w * self.h
+  }
+
+  task grown(self) -> Rect {
+    return scale(self, 2.0)
+  }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn valid_impl_method_on_non_struct_type_stays_opaque() {
+        // Enum and alias receivers have no fields to validate against; they
+        // must not produce false "field does not exist" reports.
+        type_ok(
+            r#"
+type Kind = small | large
+
+impl Stringable for Kind {
+  task to_str(self) -> str {
+    "kind"
+  }
 }
 "#,
         );

--- a/crates/keel-compiler/src/types/checker/expr.rs
+++ b/crates/keel-compiler/src/types/checker/expr.rs
@@ -29,6 +29,20 @@ fn mock_target_from_expr(expr: &SpannedExpr) -> Option<(&str, &str)> {
     Some((namespace.as_str(), method.as_str()))
 }
 
+/// Message for `self.m(...)` inside an `impl` method. The interpreter routes
+/// every `self.m(...)` to the *current agent's* task, so in an impl method it
+/// either fails outright or — when the method was called from inside an agent —
+/// silently invokes that agent's task of the same name. Neither is what the
+/// author meant, so reject it at check time.
+fn impl_self_call_error(method: &str) -> String {
+    format!(
+        "`self.{method}(...)` is not available in an `impl` method: `self` is the \
+         receiver value, and `self.{method}(...)` always calls the enclosing \
+         agent's task. Move the logic into a top-level task and call it as \
+         `{method}(self)`"
+    )
+}
+
 impl Checker<'_, '_> {
     pub(crate) fn infer_expr(&mut self, spanned: &SpannedExpr, scope: &mut Scope) -> Ty {
         let ty = self.infer_expr_uncached(spanned, scope);
@@ -104,6 +118,13 @@ impl Checker<'_, '_> {
             }
 
             Expr::SelfAccess { field, .. } => {
+                // Inside an `impl` method the receiver is a value of the
+                // implementing type — resolve the field against that type.
+                // Non-struct implementing types (enums, aliases) resolve
+                // opaquely, so nothing is falsely reported.
+                if let Some(self_ty) = self.impl_self_ty() {
+                    return self.resolve_struct_field_checked(&self_ty, field);
+                }
                 let Some(agent_name) = self.current_agent.clone() else {
                     self.err(format!("`self.{field}` used outside an agent"));
                     return Ty::Error;
@@ -119,9 +140,13 @@ impl Checker<'_, '_> {
                 Ty::Error
             }
 
-            // The type of `self` (the agent reference itself) is not tracked
-            // statically — only `self.field` and `self.task(...)` are resolved.
-            Expr::SelfRef => Ty::Unknown(UnknownReason::InferenceLimitation),
+            // In an `impl` method `self` is the receiver value, so it has the
+            // implementing type. Elsewhere it is the agent reference itself,
+            // whose type is not tracked statically — only `self.field` and
+            // `self.task(...)` are resolved there.
+            Expr::SelfRef => self
+                .impl_self_ty()
+                .unwrap_or(Ty::Unknown(UnknownReason::InferenceLimitation)),
 
             Expr::FieldAccess(obj, field) => {
                 if matches!(field.as_str(), "called" | "call_count")
@@ -505,6 +530,10 @@ impl Checker<'_, '_> {
                     field: task_name, ..
                 } = &callee.as_ref().kind
                 {
+                    if self.current_impl_type.is_some() {
+                        self.err(impl_self_call_error(task_name));
+                        return Ty::Error;
+                    }
                     let Some(agent_name) = self.current_agent.clone() else {
                         self.err(format!("`self.{task_name}(...)` used outside an agent"));
                         return Ty::Error;
@@ -784,6 +813,10 @@ impl Checker<'_, '_> {
                     return Ty::Error;
                 }
                 if matches!(&object.as_ref().kind, Expr::SelfRef) {
+                    if self.current_impl_type.is_some() {
+                        self.err(impl_self_call_error(method));
+                        return Ty::Error;
+                    }
                     let Some(agent_name) = self.current_agent.clone() else {
                         self.err(format!("`self.{method}(...)` used outside an agent"));
                         return Ty::Error;

--- a/crates/keel-compiler/src/types/checker/resolve.rs
+++ b/crates/keel-compiler/src/types/checker/resolve.rs
@@ -19,6 +19,15 @@ impl Checker<'_, '_> {
         self.resolve_type_with_env(ty, &HashMap::new())
     }
 
+    /// The type of `self` while checking an `impl` method body, or `None`
+    /// outside one. Mirrors the runtime, which rewrites the synthetic
+    /// `SelfType` receiver to the implementing type when it registers impl
+    /// methods (`interpreter/decl.rs`).
+    pub(crate) fn impl_self_ty(&self) -> Option<Ty> {
+        let name = self.current_impl_type.as_ref()?;
+        Some(self.resolve_type(&TypeExpr::Named(name.clone())))
+    }
+
     /// Resolve a type and emit a compile-time error if it is `map[K, V]` with
     /// an unsupported key type. Built-in hashable types are `str`, `int`, `bool`.
     /// `float` is excluded because NaN violates the Hash/Eq contract.
@@ -57,6 +66,12 @@ impl Checker<'_, '_> {
         let mut names = Vec::new();
         collect_named_types(ty, &mut names);
         for name in names {
+            // Built-in types and interfaces (`CompletionRequest`, `Stringable`,
+            // …) live in the checker's tables from `Checker::new`, not in any
+            // module — they are always in scope and can never be imported.
+            if crate::types::prelude::builtin_type_names().contains(&name) {
+                continue;
+            }
             let known = self.enum_variants.contains_key(&name)
                 || self.structs.contains_key(&name)
                 || self.aliases.contains_key(&name)

--- a/crates/keel-compiler/src/types/checker/stmt.rs
+++ b/crates/keel-compiler/src/types/checker/stmt.rs
@@ -258,6 +258,22 @@ impl Checker<'_, '_> {
                     }
                     self.current_agent = None;
                 }
+                Decl::Impl(impl_decl) => {
+                    // Method bodies are ordinary task bodies with `self` bound
+                    // to the implementing type. `check_impl_conformance` (run
+                    // during collection) only compares signatures.
+                    self.current_agent = None;
+                    self.current_impl_type = Some(impl_decl.type_name.clone());
+                    // Errors raised outside `check_stmt` — parameter type
+                    // resolution, default values, the implicit-return check —
+                    // otherwise land at byte 0.
+                    self.current_span = Some(node.span.clone());
+                    for method in &impl_decl.methods {
+                        self.check_task(method);
+                    }
+                    self.current_span = None;
+                    self.current_impl_type = None;
+                }
                 Decl::Stmt(stmt_node) => {
                     self.check_stmt(
                         &stmt_node.kind,
@@ -598,6 +614,18 @@ impl Checker<'_, '_> {
                 self.bind_to_scope(binding, &bound, scope);
             }
             Stmt::SelfAssign { field, value, .. } => {
+                // An `impl` receiver is passed by value, so a write to
+                // `self.field` cannot outlive the call — the interpreter
+                // rejects it too ("used outside an agent" at run time).
+                if let Some(type_name) = self.current_impl_type.clone() {
+                    self.err(format!(
+                        "cannot assign to `self.{field}` in an `impl` method: the \
+                         `{type_name}` receiver is passed by value — return an \
+                         updated value instead"
+                    ));
+                    self.infer_expr(value, scope);
+                    return;
+                }
                 let Some(agent_name) = &self.current_agent.clone() else {
                     self.err(format!("`self.{field}` used outside an agent"));
                     return;

--- a/crates/keel-compiler/src/types/prelude.rs
+++ b/crates/keel-compiler/src/types/prelude.rs
@@ -238,6 +238,25 @@ pub(crate) fn prelude_names() -> &'static HashSet<String> {
 // Built-in interface definitions
 // ---------------------------------------------------------------------------
 
+/// Names of the types and interfaces the checker pre-seeds its tables with in
+/// `Checker::new` — `CompletionRequest`, `Stringable`, and friends.
+///
+/// These belong to no module, so the module-visibility check must never ask a
+/// program to import them. Deliberately narrower than [`prelude_names`], which
+/// also covers ordinary identifiers a user may legitimately declare a type
+/// with (`Message`, `Result`, …) and whose cross-module use must still be
+/// reported.
+pub(crate) fn builtin_type_names() -> &'static HashSet<String> {
+    &BUILTIN_TYPE_NAMES
+}
+
+static BUILTIN_TYPE_NAMES: LazyLock<HashSet<String>> = LazyLock::new(|| {
+    builtin_structs()
+        .into_keys()
+        .chain(builtin_interfaces().into_keys())
+        .collect()
+});
+
 /// Return the built-in interface catalog.
 ///
 /// Each entry maps an interface name to the list of method signatures that

--- a/docs/src/guide/interfaces.md
+++ b/docs/src/guide/interfaces.md
@@ -46,6 +46,42 @@ io.show(p.print())    # → "(1.5, 2.0)"
 - Parameter count and parameter types must match the interface signature. `dynamic` in the interface's parameter position is a wildcard — an `impl` may narrow it to any concrete type (this is how `Comparable` declares `other: dynamic` while an `impl` writes `other: Score`). A concrete parameter type requires an exact match.
 - Return types must match exactly (`dynamic` in the return position is likewise a wildcard).
 - Interfaces and their `impl` blocks can appear in any order in the same file.
+- Method **bodies** are type-checked like any other task body — see below.
+
+## Inside a method body
+
+An `impl` method body is checked exactly like a top-level task: annotations, return values, field access, arity, and enum exhaustiveness are all validated by `keel check`.
+
+```keel
+interface Shape {
+  task area(self) -> float
+  task grown(self) -> str
+}
+
+type Rect { w: float, h: float }
+
+task scale(r: Rect, factor: float) -> Rect {
+  { w: r.w * factor, h: r.h * factor }
+}
+
+impl Shape for Rect {
+  task area(self) -> float {
+    self.w * self.h          # fields keep their declared types
+  }
+
+  task grown(self) -> str {
+    bigger = scale(self, 2.0)   # `self` is a value of the implementing type
+    "{bigger.w}x{bigger.h}"
+  }
+}
+```
+
+These rules follow from `self` being the receiver **value**, not an agent:
+
+- `self.field` resolves to the field's declared type; naming a field the type doesn't declare is a compile-time error.
+- `self` can be passed anywhere a value of the implementing type is expected.
+- `self.field = value` is a compile-time error — the receiver is passed by value, so the write could never outlive the call. Return an updated value instead.
+- `self.method(...)` is a compile-time error. `self.method(...)` is agent syntax and always dispatches to the enclosing *agent's* task, never to another `impl` method. Move shared logic into a top-level task and call it as `method(self)`.
 
 ## Multiple types, one interface
 

--- a/docs/src/release-notes.md
+++ b/docs/src/release-notes.md
@@ -40,6 +40,35 @@ in this first milestone and what's still a documented gap (code inside
 [vscode-keel](https://github.com/keel-lang/vscode-keel) are the notable
 ones).
 
+### `impl` method bodies are type-checked
+
+The checker's validation walk never visited `impl` blocks, so a method body was
+name-resolved but never type-inferred — `keel check` passed cleanly on any type
+error inside one:
+
+```keel
+interface Greetable {
+  task greet(self) -> str
+}
+
+type Person { name: str }
+
+impl Greetable for Person {
+  task greet(self) -> str {
+    x: int = "oops"       # now: `x`: expected int, got str
+    return self.nickname  # now: field `nickname` does not exist on `Person`
+  }
+}
+```
+
+Bodies are now checked exactly like task bodies, with `self` bound to the
+implementing type: `self.field` carries the field's declared type, and `self`
+can be passed anywhere a value of that type is expected. Two forms the
+interpreter has always rejected now fail at check time instead of run time —
+`self.field = value` (the receiver is passed by value) and `self.method(...)`
+(agent syntax; it dispatches to the enclosing agent's task, never to another
+`impl` method). See [Interfaces](./guide/interfaces.md#inside-a-method-body).
+
 ---
 
 ## v0.2.4 — 2026-06-21

--- a/tests/integration/language/interfaces.rs
+++ b/tests/integration/language/interfaces.rs
@@ -336,3 +336,150 @@ run_test()
         "dynamic param should accept any concrete type\nstdout: {stdout}\nstderr: {stderr}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// impl method bodies are type-checked (#181)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn impl_method_body_type_mismatch_fails_check() {
+    // `check_body` used to skip `Decl::Impl` entirely, so any type error inside
+    // a method body passed `keel check` untouched.
+    let src = r#"
+interface Greetable {
+  task greet(self) -> str
+}
+
+type Person { name: str }
+
+impl Greetable for Person {
+  task greet(self) -> str {
+    x: int = "oops"
+    return self.name
+  }
+}
+"#;
+    let (ok, _stdout, stderr) = check_inline_output(src);
+    assert!(!ok, "should have failed");
+    assert!(
+        stderr.contains("expected int, got str"),
+        "expected a type-mismatch diagnostic, got: {stderr}"
+    );
+}
+
+#[test]
+fn impl_method_unknown_self_field_fails_check() {
+    let src = r#"
+interface Greetable {
+  task greet(self) -> str
+}
+
+type Person { name: str }
+
+impl Greetable for Person {
+  task greet(self) -> str {
+    return self.nickname
+  }
+}
+"#;
+    let (ok, _stdout, stderr) = check_inline_output(src);
+    assert!(!ok, "should have failed");
+    assert!(
+        stderr.contains("nickname"),
+        "expected an unknown-field diagnostic, got: {stderr}"
+    );
+}
+
+#[test]
+fn impl_method_body_using_self_still_runs() {
+    // The receiver is a value of the implementing type: its fields keep their
+    // declared types and it can be handed to a task that expects that type.
+    let src = r#"
+use std/io
+interface Shape {
+  task area(self) -> float
+  task grown(self) -> str
+}
+
+type Rect { w: float, h: float }
+
+task scale(r: Rect, factor: float) -> Rect {
+  { w: r.w * factor, h: r.h * factor }
+}
+
+impl Shape for Rect {
+  task area(self) -> float {
+    self.w * self.h
+  }
+
+  task grown(self) -> str {
+    bigger = scale(self, 2.0)
+    "{bigger.w}x{bigger.h}"
+  }
+}
+
+task run_test() {
+  r: Rect = { w: 2.0, h: 3.0 }
+  io.show("{r.area()} {r.grown()}")
+}
+run_test()
+"#;
+    let (ok, stdout, stderr) = run_inline(src, false);
+    assert!(ok, "program failed\nstdout: {stdout}\nstderr: {stderr}");
+    assert!(stdout.contains("6 4x6"), "got: {stdout}");
+}
+
+#[test]
+fn impl_method_calling_self_method_fails_check() {
+    // At run time `self.m(...)` always dispatches to the enclosing agent's
+    // task, never to another impl method — reject it at check time instead of
+    // failing (or calling the wrong thing) at run time.
+    let src = r#"
+interface Shape {
+  task area(self) -> float
+  task label(self) -> str
+}
+
+type Rect { w: float, h: float }
+
+impl Shape for Rect {
+  task area(self) -> float {
+    self.w * self.h
+  }
+
+  task label(self) -> str {
+    "area is {self.area()}"
+  }
+}
+"#;
+    let (ok, _stdout, stderr) = check_inline_output(src);
+    assert!(!ok, "should have failed");
+    assert!(
+        stderr.contains("not available in an `impl` method"),
+        "expected an impl self-call diagnostic, got: {stderr}"
+    );
+}
+
+#[test]
+fn impl_method_assigning_to_self_field_fails_check() {
+    let src = r#"
+interface Shape {
+  task area(self) -> float
+}
+
+type Rect { w: float, h: float }
+
+impl Shape for Rect {
+  task area(self) -> float {
+    self.w = 4.0
+    self.w
+  }
+}
+"#;
+    let (ok, _stdout, stderr) = check_inline_output(src);
+    assert!(!ok, "should have failed");
+    assert!(
+        stderr.contains("cannot assign to `self.w` in an `impl` method"),
+        "expected an impl self-assign diagnostic, got: {stderr}"
+    );
+}

--- a/tests/integration/modules.rs
+++ b/tests/integration/modules.rs
@@ -433,6 +433,24 @@ task f(c: Classifier) -> str {
 }
 
 #[test]
+fn builtin_type_annotation_needs_no_import() {
+    // Built-in types live in the checker's tables rather than in any module.
+    // The visibility check used to treat them as another module's declarations
+    // and demand an impossible import — `CompletionRequest` is the signature
+    // every user-authored LLM provider writes.
+    let (_dir, entry) = write_project(&[(
+        "main.keel",
+        r#"
+task describe(req: CompletionRequest) -> str {
+  "{req.user}"
+}
+"#,
+    )]);
+    let (ok, _stdout, stderr) = keel("check", &entry);
+    assert!(ok, "built-in type must not require an import:\n{stderr}");
+}
+
+#[test]
 fn duplicate_import_binding_is_rejected_with_alias_hint() {
     let (dir, _) = write_project(&[
         ("strings.keel", "task s() -> str { \"local\" }\n"),


### PR DESCRIPTION
Closes #181.

## Problem

`Checker::check_body` — the second-pass validation walk — dispatched on `Decl::Task`, `Decl::Test`, `Decl::Agent`, and `Decl::Stmt`, and let `Decl::Impl` fall through the catch-all arm. An impl method body was parsed and name-resolved (HIR lowering visits it) but never type-inferred, so `keel check` passed cleanly on anything inside one:

```keel
interface Greetable {
  task greet(self) -> str
}

type Person { name: str }

impl Greetable for Person {
  task greet(self) -> str {
    x: int = "oops"       # now: `x`: expected int, got str
    return self.nickname  # now: field `nickname` does not exist on `Person`
  }
}
```

`check_impl_conformance` only ever compared signatures, never bodies.

## Change

`Decl::Impl` now routes each method through `check_task`, with the implementing type recorded on the checker so every `self`-gated site branches on impl context before falling back to the agent path:

- **`self.field`** resolves against the implementing type. An undeclared field is an error; a declared one carries its type. Non-struct receivers (enums, aliases) resolve opaquely, so nothing is falsely reported.
- **bare `self`** is a value of the implementing type, so it can be passed wherever that type is expected, compared, returned, and iterated exactly like any other binding of that type. Verified at parity: `self == "hello"` is accepted iff `p == "hello"` is; `for x in self` works on an `Iterable` type and is rejected on a plain struct.
- **`self.field = value`** is a compile-time error. The receiver is passed by value, so the write can never outlive the call — the interpreter rejects it too.
- **`self.method(...)`** is a compile-time error. At run time that form always dispatches to the enclosing *agent's* task, so outside an agent it hard-fails, and inside one it silently invokes an unrelated task of the same name. The message points at the workaround: extract a top-level task and call it as `method(self)`.

### Two supporting fixes this surfaced

**Built-in types were reported as "declared in another module".** `check_type_visibility` treated the checker's pre-seeded built-in tables as another module's declarations, so `task complete(self, req: CompletionRequest)` — the signature every user-authored LLM provider writes, and what `examples/custom_provider.keel` contains — failed with a suggestion to import it from a file. Exempted via a new narrow `prelude::builtin_type_names()` (built-in structs + interfaces only, deliberately *not* `prelude_names()`, so a user type sharing a prelude identifier like `Message` or `Result` still reports correctly across modules — pinned by the existing `foreign_type_annotation_requires_symbol_import` test).

**Trailing-expression diagnostics pointed at the wrong node.** `block_type` never wrote `current_span` for `Stmt::Expr`, the one statement kind that bypasses `check_stmt`. An `if`-branch type mismatch used to underline the whole `v = if … }` statement; it now underlines the offending branch expression.

## Tests

- 8 checker unit tests in a new `#181` section: type mismatch in a body, wrong return type, unknown `self` field, undefined name, self-assign, self-method-call, a positive case exercising `self` as a value, and a non-struct (enum) receiver staying opaque.
- 5 integration tests in `tests/integration/language/interfaces.rs` covering the same surface end to end through `keel check`/`keel run`.
- 1 integration test in `tests/integration/modules.rs` pinning that a built-in type annotation needs no import.

`cargo fmt --check` and `clippy --workspace --all-targets -D warnings` clean; 44/44 test binaries pass; every `examples/*.keel` still checks, and `keel test` is green on all five programs with `impl` blocks. `mdbook build` runs clean over the updated pages.

## Docs

`SPEC.md §5.2` gains a "`self` inside a method body" block; `docs/src/guide/interfaces.md` gains an "Inside a method body" section; plus `CHANGELOG.md` and `docs/src/release-notes.md` entries.