### PR TITLE
Parse and type-check tuple positional access (pair.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,30 @@ All notable changes to Keel.
 
 ### Added
 
+- **Tuple positional access (`pair.0`).** `SPEC.md` §2.8 has always documented reading a tuple element by position, but the parser never accepted it — the postfix `.` parser took identifiers and a few contextual keywords, never an integer, so `SPEC`'s own example failed `keel check` with `found '0' expected something else`. Positional reads now parse, resolve to the element's declared type, and are bounds-checked at compile time against the tuple's arity. `?.` works too. Numeric names remain a syntax error in declarations (`type X { 0: int }`), because the postfix parser is deliberately separate from the one used for struct fields and map keys.
+
+```keel
+use std/io
+
+pair: (str, int) = ("hello", 42)
+(name, count) = pair              # destructuring already worked
+x = pair.0                        # str  — new
+io.show("{x} {pair.1} {name} {count}")   # hello 42 hello 42
+
+maybe: (str, int)? = ("hi", 7)
+io.show("{maybe?.0}")             # hi
+
+nested: ((int, int), int) = ((1, 2), 3)
+io.show("{(nested.0).1}")         # 2 — parentheses required, see #185
+```
+
+  Because tuples and lists share one runtime representation in v0.1, `.N` on a
+  non-tuple is rejected by the type checker rather than the interpreter:
+  `xs.0` on a `list[int]` reports *positional access `.0` is only valid on
+  tuples; index `list[int]` with `[0]`*. Nested access without parentheses
+  (`t.0.1`) still fails to parse — `0.1` matches the float-literal pattern and
+  is claimed as one token — tracked in #185.
+
 - **`keel dap` — an interpreter-backed step debugger over the Debug Adapter Protocol.** Any DAP-speaking editor (VS Code, `lldb-dap`-style clients) can now set source breakpoints, step over/in/out, inspect the call stack, and view locals and live agent `state` in a running Keel program — the same tree-walking interpreter every `keel run`/`keel test` already uses, paused in place rather than a separate execution path. `keel test --debug --filter <name>` debugs a single test the same way. Evaluating an expression while paused (`watch`/`hover`) reuses the program's own expression evaluator, so it sees the same values, types, and errors the paused statement would.
 
 ```keel

--- a/SPEC.md
+++ b/SPEC.md
@@ -303,6 +303,18 @@ x = pair.0                        # positional access
 
 Tuples are structural, immutable. Single-element tuples are not a thing (`(str)` is `str`). `()` is `none`.
 
+Positional access is bounds-checked at compile time — `pair.2` on a 2-tuple is a type error, not a runtime one — and `.N` is valid only on tuples. Lists and maps use subscripts (`xs[0]`), which is why `xs.0` is rejected. `?.` works too: `maybe_pair?.0`.
+
+Nested positional access currently needs parentheses:
+
+```keel
+t: ((int, int), int) = ((1, 2), 3)
+b = (t.0).1                       # ok
+# b = t.0.1                       # parse error — see below
+```
+
+This is a lexer limitation rather than a language rule: `0.1` matches the float-literal pattern and is claimed as a single token before the grammar sees two indices. Tracked in [#185](https://github.com/keel-lang/keel/issues/185); the parenthesized form is not going away.
+
 ### 2.9 The `dynamic` type (FFI/interop only)
 
 `dynamic` exists for untyped boundaries: `extern` returns, `prompt as dynamic`, raw SQL rows, and JSON/cache interop. It must always be explicitly written — there is no implicit path to `dynamic`.

--- a/crates/keel-compiler/src/types/checker/resolve.rs
+++ b/crates/keel-compiler/src/types/checker/resolve.rs
@@ -354,6 +354,13 @@ impl Checker<'_, '_> {
             Ty::Struct { fields, .. } => Self::find_struct_field(fields, field)
                 .cloned()
                 .unwrap_or(Ty::Unknown(UnknownReason::InferenceLimitation)),
+            // Positional tuple access (`pair.0`, `SPEC.md` §2.8). Silent
+            // variant: an out-of-range or non-numeric field yields the same
+            // inference gap as an unknown struct field.
+            Ty::Tuple(items) => tuple_index(field)
+                .and_then(|i| items.get(i))
+                .cloned()
+                .unwrap_or(Ty::Unknown(UnknownReason::InferenceLimitation)),
             _ => Ty::Unknown(UnknownReason::InferenceLimitation),
         }
     }
@@ -366,6 +373,57 @@ impl Checker<'_, '_> {
     /// already validates unknown fields itself, so routing it through here
     /// too would double-report.
     pub(crate) fn resolve_struct_field_checked(&mut self, subject_ty: &Ty, field: &str) -> Ty {
+        let subject = subject_ty.strip_nullable();
+
+        // Positional access (`SPEC.md` §2.8). Handled before struct fields
+        // and keyed off the *field* shape, not the subject: an all-digit
+        // field name is only ever a tuple index, so `.0` on a non-tuple has
+        // to be rejected here. The interpreter cannot make that call —
+        // tuples share the list repr in v0.1, so `xs.0` on a `list` would
+        // silently succeed at runtime if this arm let it through.
+        if let Some(idx) = tuple_index(field) {
+            return match subject {
+                Ty::Tuple(items) if idx < items.len() => items[idx].clone(),
+                Ty::Tuple(items) => {
+                    self.err(format!(
+                        "tuple index {idx} is out of bounds for `{}` (arity {})",
+                        describe_ty(subject_ty),
+                        items.len()
+                    ));
+                    Ty::Error
+                }
+                // Opaque subjects have no known shape to validate against —
+                // same silence as an unknown struct field.
+                _ if subject.is_opaque() => Ty::Unknown(UnknownReason::InferenceLimitation),
+                Ty::List(_) | Ty::Set(_) | Ty::Map(_, _) => {
+                    self.err(format!(
+                        "positional access `.{idx}` is only valid on tuples; \
+                         index `{}` with `[{idx}]`",
+                        describe_ty(subject_ty)
+                    ));
+                    Ty::Error
+                }
+                _ => {
+                    self.err(format!(
+                        "positional access `.{idx}` is only valid on tuples, not `{}`",
+                        describe_ty(subject_ty)
+                    ));
+                    Ty::Error
+                }
+            };
+        }
+
+        // A non-numeric field on a tuple can never resolve — tuples have no
+        // named fields.
+        if let Ty::Tuple(items) = subject {
+            self.err(format!(
+                "`{}` has no field `{field}` — tuple elements are read by \
+                 position (`.0` … `.{}`)",
+                describe_ty(subject_ty),
+                items.len().saturating_sub(1)
+            ));
+            return Ty::Error;
+        }
         let Ty::Struct { fields, .. } = subject_ty.strip_nullable() else {
             return Ty::Unknown(UnknownReason::InferenceLimitation);
         };

--- a/crates/keel-runtime/src/interpreter/expr.rs
+++ b/crates/keel-runtime/src/interpreter/expr.rs
@@ -4,7 +4,7 @@ use std::pin::Pin;
 
 use miette::Result;
 
-use crate::ast::{CallArg, Expr, Node, SpannedExpr, StringPart, TypeExpr, UnOp};
+use crate::ast::{CallArg, Expr, Node, SpannedExpr, StringPart, TypeExpr, UnOp, tuple_index};
 
 use super::environment::Environment;
 use super::runtime_error;
@@ -397,6 +397,24 @@ impl Interpreter {
                                 .await
                                 .map(ExprFlow::Value)
                                 .map_err(|_| runtime_error(format!("Value has no field `{field}`")))
+                        }
+                        // Positional tuple access (`pair.0`, `SPEC.md` §2.8).
+                        // Tuples share the list repr in v0.1 (see
+                        // `cast_tuple` below), so this arm cannot tell a
+                        // tuple from a list — the type checker is the gate
+                        // that rejects `[1, 2].0`, since `Ty::Tuple` is
+                        // distinct from `Ty::List` there. Compiled tuples
+                        // are by-value LLVM structs, so the two engines
+                        // only diverge on input the checker already
+                        // rejects; do not "fix" that asymmetry here.
+                        Value::List(items) if tuple_index(field).is_some() => {
+                            let idx = tuple_index(field).expect("guarded above");
+                            items.get(idx).cloned().map(ExprFlow::Value).ok_or_else(|| {
+                                runtime_error(format!(
+                                    "tuple index {idx} is out of bounds (arity {})",
+                                    items.len()
+                                ))
+                            })
                         }
                         _ => {
                             // Zero-arg method fallback for properties

--- a/crates/keel-syntax/src/ast/expr.rs
+++ b/crates/keel-syntax/src/ast/expr.rs
@@ -233,6 +233,21 @@ pub enum DurationUnit {
     Weeks,
 }
 
+/// Reads a [`Expr::FieldAccess`] / [`Expr::NullFieldAccess`] field name as a
+/// tuple position: `"0"` → `Some(0)`, `"name"` → `None`.
+///
+/// The inverse of `parser::common::postfix_field_name`, which is the only
+/// parser that can produce an all-digit field name — so an all-digit name is
+/// unambiguously a tuple index and never a struct field (`SPEC.md` §2.8).
+/// Shared by the type checker and the interpreter, which both have to
+/// distinguish the two readings of the same `String`.
+pub fn tuple_index(field: &str) -> Option<usize> {
+    if field.is_empty() || !field.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    field.parse().ok()
+}
+
 impl DurationUnit {
     /// Canonical lower-case unit name for error messages and the formatter.
     pub fn canonical_name(self) -> &'static str {

--- a/crates/keel-syntax/src/parser/common.rs
+++ b/crates/keel-syntax/src/parser/common.rs
@@ -112,6 +112,23 @@ pub(super) fn field_name() -> P<String> {
     .boxed()
 }
 
+/// Field name in *postfix* position (after `.` or `?.`) — a [`field_name`]
+/// plus a bare integer, so tuple positional access (`pair.0`, `SPEC.md`
+/// §2.8) parses. Deliberately separate from [`field_name`]: that parser is
+/// also used for `type X { field: T }` declarations, map-literal keys, and
+/// struct-literal fields, where a numeric name must stay a syntax error.
+///
+/// The index is carried as a `String` so `Expr::FieldAccess` needs no new
+/// AST variant — `field_name` can never yield an all-digit name, so there
+/// is no ambiguity with a real field.
+///
+/// Only *flat* indexing parses: `t.0.1` lexes `0.1` as a single
+/// `Token::Float` (logos picks the longest match — see `lexer.rs`'s `Float`
+/// regex), so nested tuple access needs `(t.0).1`. Tracked separately.
+pub(super) fn postfix_field_name() -> P<String> {
+    field_name().or(select! { Token::Integer(n) => n }).boxed()
+}
+
 /// Map / struct-literal key: a field_name or a string literal (strings
 /// are raw-decoded into the key).  Used for `StructSpreadUpdate` overrides,
 /// which are always identifier-shaped.

--- a/crates/keel-syntax/src/parser/expr.rs
+++ b/crates/keel-syntax/src/parser/expr.rs
@@ -13,7 +13,7 @@ use crate::lexer::Token;
 
 use super::common::{
     P, block_with, field_name, field_sep, ident, if_body, map_key, map_lit_key, newlines,
-    string_lit, when_arm, when_body,
+    postfix_field_name, string_lit, when_arm, when_body,
 };
 use super::types::spanned_type_expr;
 
@@ -422,11 +422,11 @@ pub(super) fn expr_parser() -> P<SpannedExpr> {
         // not stored in the AST.
         let postfix_op = choice((
             just(Token::Dot)
-                .ignore_then(field_name())
+                .ignore_then(postfix_field_name())
                 .then(call_args.clone().or_not())
                 .map(|(field, args)| PostfixOp::DotAccess { field, args }),
             just(Token::NullDot)
-                .ignore_then(field_name())
+                .ignore_then(postfix_field_name())
                 .map(PostfixOp::NullDotAccess),
             just(Token::Bang).to(PostfixOp::NullAssert),
             call_args.clone().map(PostfixOp::Call),

--- a/docs/src/guide/types.md
+++ b/docs/src/guide/types.md
@@ -315,6 +315,67 @@ String subscript (`str[i]`) returns a single-character `str` by the same rules.
 | `.last` | `T?` | Last element or none |
 | `.is_empty` | `bool` | True if count == 0 |
 
+## Tuples
+
+A tuple is a fixed-length, ordered group of values whose types can differ. Write the type as parenthesised element types:
+
+```keel
+pair: (str, int) = ("hello", 42)
+```
+
+Tuples are structural and immutable — two tuples with the same element types are the same type, and you build a new one rather than modifying an existing one. There is no single-element tuple: `(str)` is just `str`. The empty tuple `()` is `none`.
+
+Read elements either by destructuring or by position:
+
+```keel
+use std/io
+
+pair: (str, int) = ("hello", 42)
+
+(name, count) = pair          # destructure into two bindings
+io.show(name)                 # hello
+
+x = pair.0                    # positional access — str
+io.show("{x} {pair.1}")       # hello 42
+```
+
+Positional access is checked at compile time. The index must be within the tuple's arity, and `.N` is only valid on tuples:
+
+```keel
+pair: (str, int) = ("hello", 42)
+
+# pair.5      # error: tuple index 5 is out of bounds for `(str, int)` (arity 2)
+# pair.name   # error: `(str, int)` has no field `name` — read by position
+```
+
+Lists and maps use subscripts instead, so `.0` on a list is an error that points you at the right syntax:
+
+```keel
+xs: list[int] = [1, 2, 3]
+
+y = xs[0]     # 1 — correct
+# y = xs.0    # error: positional access `.0` is only valid on tuples;
+              #        index `list[int]` with `[0]`
+```
+
+`?.` works on a nullable tuple, yielding a nullable element:
+
+```keel
+maybe: (str, int)? = ("hi", 7)
+io.show("{maybe?.0}")         # hi
+```
+
+Nested positional access needs parentheses:
+
+```keel
+t: ((int, int), int) = ((1, 2), 3)
+
+b = (t.0).1                   # 2
+# b = t.0.1                   # parse error
+```
+
+This is a lexer limitation, not a language rule — `0.1` matches the float-literal pattern and is claimed as a single token before the grammar sees two separate indices. Tracked in [issue #185](https://github.com/keel-lang/keel/issues/185). The parenthesised form works and will keep working.
+
 ## Function types
 
 Function types describe callable values. Write the parameter types in parentheses followed by `->` and the return type:

--- a/docs/src/release-notes.md
+++ b/docs/src/release-notes.md
@@ -4,6 +4,37 @@
 
 ## Unreleased
 
+### Tuple positional access — `pair.0`
+
+Reading a tuple element by position is documented in the spec but never
+parsed, so the spec's own example failed `keel check`. It works now:
+
+```keel
+use std/io
+
+pair: (str, int) = ("hello", 42)
+(name, count) = pair              # destructuring already worked
+x = pair.0                        # str
+io.show("{x} {pair.1} {name} {count}")   # hello 42 hello 42
+
+maybe: (str, int)? = ("hi", 7)
+io.show("{maybe?.0}")             # hi
+```
+
+Indices are bounds-checked when you compile, not when you run —
+`pair.5` on a 2-tuple is a type error. And because `.N` means *tuple
+position*, using it on a list or map tells you what to write instead:
+
+```keel
+xs: list[int] = [1, 2, 3]
+# xs.0   # error: positional access `.0` is only valid on tuples;
+         #        index `list[int]` with `[0]`
+```
+
+Nested access needs parentheses — `(t.0).1` rather than `t.0.1` — because
+`0.1` lexes as a float literal. See [issue #185](https://github.com/keel-lang/keel/issues/185)
+and the [Tuples guide](guide/types.md#tuples).
+
 ### `keel dap` — a step debugger over the Debug Adapter Protocol
 
 Any DAP-speaking editor can now set breakpoints, step, and inspect variables

--- a/tests/integration/language/mod.rs
+++ b/tests/integration/language/mod.rs
@@ -12,4 +12,5 @@ mod strings;
 mod structs;
 mod subscripts;
 mod testing;
+mod tuples;
 mod types;

--- a/tests/integration/language/tuples.rs
+++ b/tests/integration/language/tuples.rs
@@ -1,0 +1,153 @@
+use crate::common::*;
+
+// ---------------------------------------------------------------------------
+// Tuple positional access (issue #157) — `SPEC.md` §2.8
+// ---------------------------------------------------------------------------
+
+#[test]
+fn spec_2_8_example_runs() {
+    // The exact example from SPEC.md §2.8. Before #157 this failed to parse:
+    // `field_name()` never accepted `Token::Integer` in postfix position.
+    let src = r#"
+use std/io
+pair: (str, int) = ("hello", 42)
+(name, count) = pair
+x = pair.0
+io.show("{x} {pair.1} {name} {count}")
+"#;
+    let (ok, stdout, stderr) = run_inline(src, false);
+    assert!(ok, "SPEC §2.8's own example must run: {stderr}");
+    assert!(
+        stdout.contains("hello 42 hello 42"),
+        "expected positional and destructured reads to agree: {stdout}"
+    );
+}
+
+#[test]
+fn positional_access_resolves_element_type_not_unknown() {
+    // Regression guard for the checker arm: if `pair.0` fell through to
+    // `Ty::Unknown` the annotation mismatch below would go unreported.
+    let src = r#"
+pair: (str, int) = ("hello", 42)
+bad: int = pair.0
+"#;
+    let (ok, _stdout, stderr) = run_inline(src, false);
+    assert!(!ok, "pair.0 is str, not int — must be rejected");
+    assert!(
+        stderr.contains("expected int") && stderr.contains("str"),
+        "expected an int/str mismatch proving .0 resolved to str: {stderr}"
+    );
+}
+
+#[test]
+fn out_of_bounds_index_is_a_static_error() {
+    let src = r#"
+pair: (str, int) = ("hello", 42)
+y = pair.5
+"#;
+    let (ok, _stdout, stderr) = run_inline(src, false);
+    assert!(!ok, "index past the tuple's arity must fail the checker");
+    assert!(
+        stderr.contains("out of bounds") && stderr.contains("arity 2"),
+        "expected a bounds error naming the arity: {stderr}"
+    );
+}
+
+#[test]
+fn named_field_on_a_tuple_is_rejected() {
+    let src = r#"
+pair: (str, int) = ("hello", 42)
+y = pair.nope
+"#;
+    let (ok, _stdout, stderr) = run_inline(src, false);
+    assert!(!ok, "tuples have no named fields");
+    assert!(
+        stderr.contains("has no field") && stderr.contains("position"),
+        "error should point the user at positional access: {stderr}"
+    );
+}
+
+#[test]
+fn positional_access_on_a_list_is_rejected() {
+    // The load-bearing test for the shared repr: tuples and lists are both
+    // `Value::List` at runtime (v0.1), so `xs.0` would silently *succeed* in
+    // the interpreter. Only the checker can reject it.
+    let src = r#"
+xs: list[int] = [1, 2, 3]
+y = xs.0
+"#;
+    let (ok, _stdout, stderr) = run_inline(src, false);
+    assert!(!ok, "`.0` on a list must not typecheck — lists use `[0]`");
+    assert!(
+        stderr.contains("only valid on tuples"),
+        "expected a tuples-only error suggesting subscript syntax: {stderr}"
+    );
+}
+
+#[test]
+fn positional_access_on_a_map_is_rejected() {
+    let src = r#"
+m: map[str, int] = {"a": 1}
+y = m.0
+"#;
+    let (ok, _stdout, stderr) = run_inline(src, false);
+    assert!(!ok, "`.0` on a map must not typecheck");
+    assert!(
+        stderr.contains("only valid on tuples"),
+        "expected a tuples-only error: {stderr}"
+    );
+}
+
+#[test]
+fn null_safe_positional_access_on_a_nullable_tuple() {
+    let src = r#"
+use std/io
+maybe: (str, int)? = ("hi", 7)
+io.show("{maybe?.0}")
+"#;
+    let (ok, stdout, stderr) = run_inline(src, false);
+    assert!(ok, "`?.0` on a nullable tuple must work: {stderr}");
+    assert!(stdout.contains("hi"), "expected `hi`: {stdout}");
+}
+
+#[test]
+fn nested_tuple_access_requires_parentheses() {
+    // `t.0.1` cannot parse: the lexer's Float regex (`[0-9]+\.[0-9]+`) claims
+    // `0.1` as one token, and logos picks the longest match. Parenthesizing
+    // is the documented workaround; lifting the restriction is tracked
+    // separately. This test pins both halves so the follow-up has a target.
+    let parenthesized = r#"
+use std/io
+t: ((int, int), int) = ((1, 2), 3)
+io.show("{(t.0).1}")
+"#;
+    let (ok, stdout, stderr) = run_inline(parenthesized, false);
+    assert!(ok, "`(t.0).1` must work: {stderr}");
+    assert!(stdout.contains('2'), "expected `2`: {stdout}");
+
+    let unparenthesized = r#"
+t: ((int, int), int) = ((1, 2), 3)
+b = t.0.1
+"#;
+    let (ok, _stdout, stderr) = run_inline(unparenthesized, false);
+    assert!(!ok, "`t.0.1` is a known parse limitation, not valid today");
+    assert!(
+        stderr.contains("0.1"),
+        "error should show the Float token that swallowed the indices: {stderr}"
+    );
+}
+
+#[test]
+fn numeric_field_names_stay_invalid_in_declarations() {
+    // `postfix_field_name()` is deliberately separate from `field_name()`.
+    // If the numeric case leaked into the shared parser, this would parse.
+    let src = r#"
+type X { 0: int }
+"#;
+    let (ok, _stdout, stderr) = run_inline(src, false);
+    assert!(!ok, "a numeric struct field must stay a syntax error");
+    assert!(
+        stderr.contains("Parse error"),
+        "expected a parse error, not a type error: {stderr}"
+    );
+}


### PR DESCRIPTION
Part of #157. `SPEC.md` §2.8 documents reading a tuple element by position, but the postfix `.` parser never accepted an integer, so the spec's own example failed `keel check`:

```
$ keel check t.keel
Error:   × Parse error: found '0' expected something else
 3 │ x = pair.0
   ·          ┬
   ·          ╰── found '0' expected something else
```

## What this does

`pair.0` now parses, resolves to the element's declared type, and is bounds-checked at compile time. `?.0` works on nullable tuples.

```keel
use std/io

pair: (str, int) = ("hello", 42)
(name, count) = pair              # destructuring already worked
x = pair.0                        # str
io.show("{x} {pair.1} {name} {count}")   # hello 42 hello 42

maybe: (str, int)? = ("hi", 7)
io.show("{maybe?.0}")             # hi
```

## Design notes for review

**No new AST variant.** The index rides in the existing `Expr::FieldAccess(_, String)` payload. `field_name()` can never yield an all-digit name, so the two readings are unambiguous — and this avoids touching every exhaustive match over `Expr` in visit/checker/interpreter/formatter/LSP.

**`field_name()` is deliberately untouched.** It is shared by `type X { field: T }`, map-literal keys, and struct literals. The numeric case lives in a new `postfix_field_name()` used only after `.`/`?.`, so `type X { 0: int }` stays a syntax error. There is a test pinning that.

**The checker has to be the gate, not the interpreter.** Tuples and lists share one runtime representation in v0.1 (see `cast_tuple`), so the interpreter physically cannot distinguish `xs.0` on a `list` from `pair.0` on a tuple — it would silently succeed. Positional access therefore keys off the *field* shape rather than the subject type, and rejects non-tuples statically:

```
positional access `.0` is only valid on tuples; index `list[int]` with `[0]`
```

Opaque subjects (`dynamic`, `Json.parse` results) stay silent, matching existing unknown-field behaviour. `tuple_index()` lives in `keel-syntax` next to the parser that produces these names, shared by checker and interpreter rather than duplicated.

## Known limitation

Nested access `t.0.1` does not parse — the lexer's `Float` rule (`[0-9]+\.[0-9]+`) claims `0.1` as a single token and logos picks the longest match. `(t.0).1` works and is documented as the form to use. Filed as #185, with a test asserting both halves so the follow-up has a target.

## Scope

Front-end and interpreter only. **#157 stays open** — KIR lowering and codegen are not here. Adding a `KirType` variant touches 14 files with 35 exhaustive match sites on `KirType`, each needing the enumerate-all-variants audit `AGENTS.md` requires; that belongs in its own reviewable PR rather than bolted onto this one. This half fixes the user-visible `keel check` bug and stands alone.

## Verification

- 506 integration tests pass (was 497; 9 new in `tests/integration/language/tuples.rs`)
- `cargo fmt --check` clean, `cargo clippy --all-targets -- -D warnings` clean
- `mdbook build` clean over the updated guide and release-notes pages