### PR TITLE
Compile tuples: KIR lowering and by-value LLVM codegen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to Keel.
 
 ## [Unreleased]
 
-%%TAGLINE%% A stdio Debug Adapter Protocol server lets editors like VS Code set breakpoints, step, and inspect variables — including live agent state — in a running Keel program, alongside the native LLVM backend now compiling, linking, and running the full M2 feature set (structs, enums, containers, nullable, string interpolation, raise/try/catch) byte-for-byte identical to the interpreter.
+%%TAGLINE%% A stdio Debug Adapter Protocol server lets editors like VS Code set breakpoints, step, and inspect variables — including live agent state — in a running Keel program, alongside the native LLVM backend now compiling, linking, and running the full M2 feature set (structs, enums, containers, tuples, nullable, string interpolation, raise/try/catch) byte-for-byte identical to the interpreter.
 
 ### Added
 
@@ -35,6 +35,18 @@ io.show("{(nested.0).1}")         # 2 — parentheses required, see #185
   tuples; index `list[int]` with `[0]`*. Nested access without parentheses
   (`t.0.1`) still fails to parse — `0.1` matches the float-literal pattern and
   is claimed as one token — tracked in #185.
+
+  The native backend compiles tuples too: construction, positional reads, and
+  positional destructuring (`(a, b) = pair`) lower through KIR and codegen, and
+  the conformance harness runs them byte-identical under both engines. Tuples
+  are the first **by-value aggregate** in the compiled backend — an unnamed
+  LLVM struct built with `insertvalue` and read with `extractvalue`, with no
+  heap allocation, no pointer indirection, and no refcounting, unlike heap
+  structs and containers. Nested tuples are allowed as elements (a by-value
+  aggregate nests for free); containers, structs, enums, and nullables inside a
+  tuple are not, since those would need the `Value` marshaling the by-value
+  representation exists to avoid. Passing a whole tuple to a stdlib namespace
+  method is a compile error naming the construct — read an element instead.
 
 - **`keel dap` — an interpreter-backed step debugger over the Debug Adapter Protocol.** Any DAP-speaking editor (VS Code, `lldb-dap`-style clients) can now set source breakpoints, step over/in/out, inspect the call stack, and view locals and live agent `state` in a running Keel program — the same tree-walking interpreter every `keel run`/`keel test` already uses, paused in place rather than a separate execution path. `keel test --debug --filter <name>` debugs a single test the same way. Evaluating an expression while paused (`watch`/`hover`) reuses the program's own expression evaluator, so it sees the same values, types, and errors the paused statement would.
 

--- a/crates/keel-codegen/src/expr.rs
+++ b/crates/keel-codegen/src/expr.rs
@@ -64,6 +64,8 @@ pub(crate) fn emit_expr<'ctx>(
             field_index,
             ty,
         } => emit_field_get(fcx, base, *field_index, *ty),
+        Expr::MakeTuple { tuple_id, elems } => emit_make_tuple(fcx, *tuple_id, elems),
+        Expr::TupleGet { base, index, ty } => emit_tuple_get(fcx, base, *index, *ty),
         Expr::MakeEnum { variant_index, .. } => Ok(fcx
             .context
             .i32_type()
@@ -83,6 +85,63 @@ pub(crate) fn emit_expr<'ctx>(
             ty,
         } => crate::nullable::emit_null_field_get(fcx, base, *field_index, *ty),
     }
+}
+
+/// Builds a tuple as a by-value LLVM aggregate: start from `undef` of the
+/// tuple's struct type and `insertvalue` each element in positional order.
+/// No `malloc` and no `GEP`, unlike [`emit_make_struct`] — the aggregate
+/// lives in registers (or an `alloca` when a local binds it) rather than on
+/// the heap.
+fn emit_make_tuple<'ctx>(
+    fcx: &FuncCtx<'ctx, '_>,
+    tuple_id: keel_kir::ir::TupleId,
+    elems: &[Expr],
+) -> Result<BasicValueEnum<'ctx>, CodegenError> {
+    let aggregate_ty =
+        layout::llvm_type(fcx.context, fcx.program, KirType::Tuple(tuple_id))?.into_struct_type();
+    let mut aggregate = aggregate_ty.get_undef();
+    for (index, elem) in elems.iter().enumerate() {
+        let value = emit_expr(fcx, elem)?;
+        aggregate = fcx
+            .builder
+            .build_insert_value(
+                aggregate,
+                value,
+                u32::try_from(index).map_err(|_| {
+                    CodegenError::Unsupported(format!("tuple arity {index} exceeds u32"))
+                })?,
+                "tuple.insert",
+            )
+            .map_err(llvm_err)?
+            .into_struct_value();
+    }
+    Ok(aggregate.into())
+}
+
+/// Reads one element out of a by-value tuple aggregate with `extractvalue`.
+/// The index is already bounds-checked — by the type checker for user code
+/// (`SPEC.md` §2.8) and again by `passes::verify` — so there is no runtime
+/// check here, unlike list indexing's `keel_list_get`.
+fn emit_tuple_get<'ctx>(
+    fcx: &FuncCtx<'ctx, '_>,
+    base: &Expr,
+    index: usize,
+    ty: KirType,
+) -> Result<BasicValueEnum<'ctx>, CodegenError> {
+    let aggregate = emit_expr(fcx, base)?.into_struct_value();
+    let index = u32::try_from(index)
+        .map_err(|_| CodegenError::Unsupported(format!("tuple index {index} exceeds u32")))?;
+    fcx.builder
+        .build_extract_value(aggregate, index, "tuple.get")
+        .map_err(llvm_err)
+        .and_then(|value| {
+            debug_assert_eq!(
+                value.get_type(),
+                layout::llvm_type(fcx.context, fcx.program, ty)?,
+                "verified KIR: TupleGet's ty matches the layout element"
+            );
+            Ok(value)
+        })
 }
 
 /// Allocates a fresh heap struct (via `malloc`, leaked for process lifetime
@@ -374,12 +433,17 @@ fn emit_binop<'ctx>(
             };
             Ok(result)
         }
+        // A tuple joins these as an unsupported operand: element-wise `==`
+        // on an aggregate would need a generated comparison loop, which the
+        // checker does not offer today either. Listed explicitly so a future
+        // tuple-equality feature has to come here deliberately.
         KirType::Unit
         | KirType::Struct(_)
         | KirType::List(_)
         | KirType::Map(_)
         | KirType::Set(_)
-        | KirType::Nullable(_) => Err(unreachable_combo(op, operand_ty)),
+        | KirType::Nullable(_)
+        | KirType::Tuple(_) => Err(unreachable_combo(op, operand_ty)),
     }
 }
 

--- a/crates/keel-codegen/src/layout.rs
+++ b/crates/keel-codegen/src/layout.rs
@@ -45,6 +45,19 @@ pub(crate) fn llvm_type<'ctx>(
             }
         }
         KirType::Enum(_) => Ok(context.i32_type().into()),
+        // A tuple is the one genuinely by-value *aggregate* in the backend:
+        // an unnamed LLVM struct passed and stored directly, no `ptr`
+        // indirection and no heap allocation (§1.1). A `str` element is
+        // still an element-level boxed `Value*`, which does not change the
+        // aggregate's own representation.
+        KirType::Tuple(id) => {
+            let elem_types = program.tuples[id]
+                .elems
+                .iter()
+                .map(|elem| llvm_type(context, program, *elem))
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(context.struct_type(&elem_types, false).into())
+        }
         KirType::List(_) | KirType::Map(_) | KirType::Set(_) => {
             Ok(context.ptr_type(AddressSpace::default()).into())
         }

--- a/crates/keel-codegen/src/ns_call.rs
+++ b/crates/keel-codegen/src/ns_call.rs
@@ -122,6 +122,17 @@ pub(crate) fn emit_box_arg<'ctx>(
              nullable into a boxed Value is a later-M2/M3 concern)"
                 .to_string(),
         )),
+        // A tuple is a by-value LLVM aggregate, not a boxed `Value` — there
+        // is no `keel_box_tuple`, so passing a whole tuple across the
+        // namespace boundary has no representation. Reading an element first
+        // (`io.show("{pair.0}")`) works, since that yields a scalar. An
+        // explicit arm rather than a fallthrough: silently treating the
+        // aggregate as a pointer would miscompile.
+        KirType::Tuple(_) => Err(CodegenError::Unsupported(
+            "tuple-typed argument to a namespace call (pass an element — `pair.0` — instead; \
+             marshaling a whole tuple into a boxed Value::List is a later-M2/M3 concern)"
+                .to_string(),
+        )),
     }
 }
 

--- a/crates/keel-codegen/src/rt_call.rs
+++ b/crates/keel-codegen/src/rt_call.rs
@@ -354,13 +354,21 @@ pub(crate) fn unbox_value<'ctx>(
             Ok(b.into())
         }
         KirType::Str | KirType::List(_) | KirType::Map(_) | KirType::Set(_) => Ok(boxed.into()),
-        KirType::Unit | KirType::Struct(_) | KirType::Enum(_) | KirType::Nullable(_) => {
-            Err(CodegenError::Unsupported(
-                "a list element type other than int/float/bool/str (struct/enum/nullable \
-                 elements need Value marshaling, a later M2/M3 concern)"
-                    .to_string(),
-            ))
-        }
+        // `Tuple` is unreachable here in practice — `is_list_element_ty`
+        // rejects a tuple element at lowering time, so no boxed tuple can
+        // exist to unbox — but it is listed explicitly rather than folded
+        // into a fallthrough: there is no `keel_unbox_tuple`, and returning
+        // `boxed` like the pass-through arm above would hand codegen a
+        // pointer where it expects a by-value aggregate.
+        KirType::Unit
+        | KirType::Struct(_)
+        | KirType::Enum(_)
+        | KirType::Nullable(_)
+        | KirType::Tuple(_) => Err(CodegenError::Unsupported(
+            "a list element type other than int/float/bool/str (struct/enum/nullable/tuple \
+             elements need Value marshaling, a later M2/M3 concern)"
+                .to_string(),
+        )),
     }
 }
 

--- a/crates/keel-codegen/tests/tuples.rs
+++ b/crates/keel-codegen/tests/tuples.rs
@@ -1,0 +1,211 @@
+//! Exit criterion for issue #157: a program declaring a tuple type,
+//! constructing a literal, and reading elements by position compiles, links,
+//! and matches the interpreter byte-for-byte.
+//!
+//! Tuples are the first genuinely **by-value aggregate** in the backend —
+//! an unnamed LLVM struct built with `insertvalue` and read with
+//! `extractvalue`, with no heap allocation, no `ptr` indirection, and no RC
+//! (`designs/llvm-compilation.md` §1.1). That makes them a different path
+//! from `structs.rs`, which exercises heap allocation and field `GEP`s;
+//! `layout.rs` still rejects an all-scalar *struct* for exactly the
+//! by-value-codegen reason these tests cover for tuples.
+
+use std::process::Command;
+
+use keel_codegen::BuildOptions;
+
+#[path = "support/mod.rs"]
+mod support;
+
+fn compile_and_run(source: &str) -> std::process::Output {
+    let kir = support::parse_check_and_lower(source);
+
+    let out_dir = tempfile::tempdir().expect("create temp out dir");
+    let opts = BuildOptions {
+        out_dir: out_dir.path().to_path_buf(),
+        runtime_link_args: support::runtime_link_args().clone(),
+    };
+    let bin = keel_codegen::compile(&kir, &opts).expect("compile must succeed");
+    Command::new(&bin).output().expect("run compiled binary")
+}
+
+const SCALAR_SOURCE: &str = r#"
+use std/io
+
+task sum_pair(p: (int, int)) -> int {
+  return p.0 + p.1
+}
+
+pair: (int, int) = (7, 35)
+io.show(pair.0)
+io.show(pair.1)
+io.show(sum_pair(pair))
+"#;
+
+#[test]
+fn scalar_tuple_construct_and_positional_read_match_the_interpreter() {
+    let compiled = compile_and_run(SCALAR_SOURCE);
+    let interpreted = support::run_interpreter(SCALAR_SOURCE);
+
+    assert_eq!(
+        String::from_utf8_lossy(&compiled.stdout),
+        String::from_utf8_lossy(&interpreted.stdout),
+        "compiled stdout must match the interpreter's"
+    );
+    assert_eq!(compiled.stdout, b"  7\n  35\n  42\n");
+}
+
+#[test]
+fn tuple_crosses_a_call_boundary_by_value() {
+    // The aggregate is passed as an LLVM struct argument and returned as an
+    // LLVM struct return — the two paths most likely to need aggregate-
+    // specific handling beyond insertvalue/extractvalue.
+    let source = r#"
+use std/io
+
+task swap(p: (int, float)) -> (float, int) {
+  return (p.1, p.0)
+}
+
+original: (int, float) = (3, 2.5)
+swapped = swap(original)
+io.show(swapped.0)
+io.show(swapped.1)
+"#;
+    let compiled = compile_and_run(source);
+    let interpreted = support::run_interpreter(source);
+
+    assert_eq!(
+        String::from_utf8_lossy(&compiled.stdout),
+        String::from_utf8_lossy(&interpreted.stdout),
+        "compiled stdout must match the interpreter's"
+    );
+    assert_eq!(compiled.stdout, b"  2.5\n  3\n");
+}
+
+#[test]
+fn str_element_rides_as_a_boxed_pointer_inside_the_aggregate() {
+    // A `str` element is a boxed `Value*`, so the aggregate mixes a pointer
+    // with a scalar. Copying the tuple duplicates that pointer without a
+    // retain, which is consistent with the rest of the backend today
+    // (`passes::rc::insert_rc` is a no-op, so nothing releases either) —
+    // see `TupleLayout`'s doc.
+    let source = r#"
+use std/io
+
+pair: (str, int) = ("hello", 42)
+io.show(pair.0)
+io.show(pair.1)
+"#;
+    let compiled = compile_and_run(source);
+    let interpreted = support::run_interpreter(source);
+
+    assert_eq!(
+        String::from_utf8_lossy(&compiled.stdout),
+        String::from_utf8_lossy(&interpreted.stdout),
+        "compiled stdout must match the interpreter's"
+    );
+    assert_eq!(compiled.stdout, b"  hello\n  42\n");
+}
+
+#[test]
+fn nested_tuple_nests_as_a_nested_aggregate() {
+    // Nested tuples are allowed where nested containers are not: a by-value
+    // aggregate nests for free, with no `Value` marshaling
+    // (`is_tuple_element_ty`). Parenthesised read per SPEC §2.8 / #185.
+    let source = r#"
+use std/io
+
+t: ((int, int), int) = ((1, 2), 3)
+io.show((t.0).1)
+io.show(t.1)
+"#;
+    let compiled = compile_and_run(source);
+    let interpreted = support::run_interpreter(source);
+
+    assert_eq!(
+        String::from_utf8_lossy(&compiled.stdout),
+        String::from_utf8_lossy(&interpreted.stdout),
+        "compiled stdout must match the interpreter's"
+    );
+    assert_eq!(compiled.stdout, b"  2\n  3\n");
+}
+
+#[test]
+fn positional_destructuring_binds_every_element() {
+    // `(a, b) = pair` lowers to a subject local plus one `TupleGet` per
+    // name, so the right-hand side is evaluated once regardless of arity.
+    let source = r#"
+use std/io
+
+pair: (str, int) = ("hello", 42)
+(name, count) = pair
+io.show(name)
+io.show(count)
+"#;
+    let compiled = compile_and_run(source);
+    let interpreted = support::run_interpreter(source);
+
+    assert_eq!(
+        String::from_utf8_lossy(&compiled.stdout),
+        String::from_utf8_lossy(&interpreted.stdout),
+        "compiled stdout must match the interpreter's"
+    );
+    assert_eq!(compiled.stdout, b"  hello\n  42\n");
+}
+
+#[test]
+fn destructuring_evaluates_the_subject_once() {
+    // If the subject were re-lowered per name, `bump` would run twice and
+    // the counter would read 2 instead of 1.
+    let source = r#"
+use std/io
+
+state_holder: (int, int) = (0, 0)
+
+task make_pair(seed: int) -> (int, int) {
+  io.show("building")
+  return (seed, seed + 1)
+}
+
+(low, high) = make_pair(10)
+io.show(low)
+io.show(high)
+"#;
+    let compiled = compile_and_run(source);
+    let interpreted = support::run_interpreter(source);
+
+    assert_eq!(
+        String::from_utf8_lossy(&compiled.stdout),
+        String::from_utf8_lossy(&interpreted.stdout),
+        "compiled stdout must match the interpreter's"
+    );
+    assert_eq!(compiled.stdout, b"  building\n  10\n  11\n");
+}
+
+#[test]
+fn whole_tuple_as_a_namespace_argument_is_a_clean_error() {
+    // There is no `keel_box_tuple`, so passing an entire aggregate across
+    // the namespace boundary must be a diagnostic, not a miscompile. Pins
+    // the explicit `emit_box_arg` arm against being folded into a
+    // fallthrough that would treat the aggregate as a pointer.
+    let source = r#"
+use std/io
+
+pair: (int, int) = (1, 2)
+io.show(pair)
+"#;
+    let kir = support::parse_check_and_lower(source);
+    let out_dir = tempfile::tempdir().expect("create temp out dir");
+    let opts = BuildOptions {
+        out_dir: out_dir.path().to_path_buf(),
+        runtime_link_args: support::runtime_link_args().clone(),
+    };
+    let err = keel_codegen::compile(&kir, &opts)
+        .expect_err("passing a whole tuple to a namespace call has no representation");
+    let message = err.to_string();
+    assert!(
+        message.contains("tuple-typed argument"),
+        "expected a tuple-specific diagnostic, got: {message}"
+    );
+}

--- a/crates/keel-kir/src/dump.rs
+++ b/crates/keel-kir/src/dump.rs
@@ -50,6 +50,15 @@ fn fmt_ty(program: &KirProgram, ty: KirType) -> String {
         KirType::Map(id) => format!("map[str, {}]", fmt_ty(program, program.maps[id])),
         KirType::Set(id) => format!("set[{}]", fmt_ty(program, program.sets[id])),
         KirType::Nullable(id) => format!("{}?", fmt_ty(program, program.nullables[id])),
+        KirType::Tuple(id) => format!(
+            "({})",
+            program.tuples[id]
+                .elems
+                .iter()
+                .map(|elem| fmt_ty(program, *elem))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
         other => other.to_string(),
     }
 }
@@ -251,6 +260,17 @@ fn fmt_expr(program: &KirProgram, func: &KirFunction, expr: &Expr) -> String {
                 .collect::<Vec<_>>()
                 .join(", ");
             format!("{} {{ {fields} }}", layout.name)
+        }
+        Expr::MakeTuple { elems, .. } => format!(
+            "({})",
+            elems
+                .iter()
+                .map(|e| fmt_expr(program, func, e))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        Expr::TupleGet { base, index, .. } => {
+            format!("{}.{index}", fmt_expr(program, func, base))
         }
         Expr::FieldGet {
             base, field_index, ..

--- a/crates/keel-kir/src/ir.rs
+++ b/crates/keel-kir/src/ir.rs
@@ -28,6 +28,11 @@ pub type StructId = usize;
 /// Index into `KirProgram::enums`.
 pub type EnumId = usize;
 
+/// Index into `KirProgram::tuples` — a *structural* intern id, like `ListId`
+/// rather than `StructId`: `(str, int)` written anywhere in the program is
+/// the same `TupleId`, since `SPEC.md` §2.8 makes tuples structural.
+pub type TupleId = usize;
+
 /// Index into `KirProgram::lists` — a *structural* intern id (unlike
 /// `StructId`/`EnumId`, which are nominal: two declarations with identical
 /// shape are still distinct types). `list[int]` written anywhere in the
@@ -100,7 +105,44 @@ pub struct KirProgram {
     /// list/struct inner types are modeled — see
     /// `lower::is_nullable_inner_ty`.
     pub nullables: Vec<KirType>,
+    /// Every distinct tuple *shape* interned so far (structural, not
+    /// declaration order — see `TupleId`'s doc). Element types are restricted
+    /// to int/float/bool/str and nested tuples (`lower::is_tuple_element_ty`);
+    /// containers, structs, enums, and nullables inside a tuple need `Value`
+    /// marshaling the by-value representation deliberately avoids.
+    pub tuples: Vec<TupleLayout>,
     pub span_table: SpanTable,
+}
+
+/// A tuple shape's compiled layout: element types in positional order,
+/// fixed at KIR-lowering time. Unlike [`StructLayout`] this is *structural*
+/// and unnamed — `(str, int)` written anywhere in the program is one
+/// `TupleId` (`SPEC.md` §2.8 makes tuples structural), so there is no
+/// declaration to carry a name from.
+///
+/// A tuple is a **by-value** LLVM aggregate: no heap allocation, no `ptr`
+/// indirection, and no RC — deliberately not the container ABI
+/// (`designs/llvm-compilation.md` §1.1). A `str` element is still a boxed
+/// `Value*`, so copying a tuple duplicates that pointer without a retain.
+/// That is consistent with the rest of the backend today — `passes::rc`'s
+/// `insert_rc` is a no-op, so nothing releases either and there is no
+/// double-free — and becomes real RC bookkeeping when that pass does.
+#[derive(Debug, Clone)]
+pub struct TupleLayout {
+    pub id: TupleId,
+    /// Positional order — `pair.0` indexes this directly.
+    pub elems: Vec<KirType>,
+}
+
+impl TupleLayout {
+    /// `true` when any element is heap-shaped, mirroring
+    /// [`StructLayout::is_heap`]. Note this does *not* make the tuple itself
+    /// a `ptr` the way a heap struct is — the aggregate stays by value; it
+    /// only reports that it *contains* RC'd data.
+    #[must_use]
+    pub fn is_heap(&self, program: &KirProgram) -> bool {
+        self.elems.iter().any(|ty| ty.is_heap(program))
+    }
 }
 
 /// A named struct type's compiled layout: field order + `KirType` per
@@ -336,6 +378,22 @@ pub enum Expr {
         field_index: usize,
         ty: KirType,
     },
+    /// Builds a tuple value (`("hello", 42)`) as a by-value aggregate — one
+    /// element expression per position in `TupleLayout::elems`, same order.
+    /// Unlike `MakeStruct` there is no heap allocation and no field-name
+    /// matching: tuple positions *are* the layout.
+    MakeTuple {
+        tuple_id: TupleId,
+        elems: Vec<Expr>,
+    },
+    /// `pair.0` on a tuple-typed `base` — `index` is the positional index,
+    /// bounds-checked by the type checker before lowering ever sees it
+    /// (`SPEC.md` §2.8), so codegen can `extractvalue` unconditionally.
+    TupleGet {
+        base: Box<Expr>,
+        index: usize,
+        ty: KirType,
+    },
     /// Builds a simple-enum value (`Priority.low`) — just its runtime tag,
     /// resolved at lowering time via `EnumLayout::variant_index`. No payload
     /// (rich variants aren't modeled yet).
@@ -479,6 +537,8 @@ impl Expr {
             | Expr::Call { ty, .. }
             | Expr::FieldGet { ty, .. } => *ty,
             Expr::MakeStruct { struct_id, .. } => KirType::Struct(*struct_id),
+            Expr::MakeTuple { tuple_id, .. } => KirType::Tuple(*tuple_id),
+            Expr::TupleGet { ty, .. } => *ty,
             Expr::MakeEnum { enum_id, .. } => KirType::Enum(*enum_id),
             Expr::Index { ty, .. }
             | Expr::NullLit { ty }

--- a/crates/keel-kir/src/lower/decl.rs
+++ b/crates/keel-kir/src/lower/decl.rs
@@ -8,7 +8,7 @@ use keel_syntax::ast::TaskDecl;
 
 use super::stmt::TailSink;
 use super::{FnCtx, FuncSig, LowerCtx, LowerError, binding_ident, ty_expr_to_kir};
-use crate::ir::{EnumId, Expr, KirFunction, Param, StructId};
+use crate::ir::{EnumId, Expr, KirFunction, Param, StructId, TupleLayout};
 use crate::span_table::SpanTable;
 use crate::types::KirType;
 
@@ -27,6 +27,7 @@ pub(crate) fn signature_of(
     maps: &std::cell::RefCell<Vec<KirType>>,
     sets: &std::cell::RefCell<Vec<KirType>>,
     nullables: &std::cell::RefCell<Vec<KirType>>,
+    tuples: &std::cell::RefCell<Vec<TupleLayout>>,
 ) -> Result<(Vec<KirType>, KirType), LowerError> {
     if !task.type_params.is_empty() {
         return Err(LowerError::unsupported(
@@ -64,6 +65,7 @@ pub(crate) fn signature_of(
             maps,
             sets,
             nullables,
+            tuples,
         )?);
     }
     let ret = match &task.return_type {
@@ -75,6 +77,7 @@ pub(crate) fn signature_of(
             maps,
             sets,
             nullables,
+            tuples,
         )?,
         None => KirType::Unit,
     };

--- a/crates/keel-kir/src/lower/expr.rs
+++ b/crates/keel-kir/src/lower/expr.rs
@@ -196,6 +196,42 @@ pub(crate) fn lower_expr(
             }
 
             let base_e = lower_expr(base, ctx, lcx, table)?;
+
+            // Positional tuple read (`pair.0`, `SPEC.md` §2.8). An all-digit
+            // field name can only come from `postfix_field_name()`, so it is
+            // unambiguously an index rather than a struct field. The checker
+            // has already bounds-checked it and rejected `.N` on non-tuples,
+            // so the arity check here is a lowering invariant, not a
+            // user-facing diagnostic.
+            if let Some(index) = keel_syntax::ast::tuple_index(field) {
+                let KirType::Tuple(tuple_id) = base_e.ty() else {
+                    return Err(LowerError::new(
+                        format!(
+                            "positional read `.{index}` on a {} value — the checker should \
+                             have rejected this",
+                            describe_ty(base_e.ty(), lcx)
+                        ),
+                        expr.span.clone(),
+                    ));
+                };
+                let elems = &lcx.tuples.borrow()[tuple_id].elems;
+                let ty = *elems.get(index).ok_or_else(|| {
+                    LowerError::new(
+                        format!(
+                            "tuple index {index} is out of bounds for a {}-element shape — \
+                             the checker should have rejected this",
+                            elems.len()
+                        ),
+                        expr.span.clone(),
+                    )
+                })?;
+                return Ok(Expr::TupleGet {
+                    base: Box::new(base_e),
+                    index,
+                    ty,
+                });
+            }
+
             let KirType::Struct(struct_id) = base_e.ty() else {
                 return Err(LowerError::unsupported(
                     "field access on a non-struct value (containers/dynamic land in a later \
@@ -287,7 +323,27 @@ pub(crate) fn lower_expr(
         )),
         ast::Expr::ListLit(items) => lower_list_lit(items, &expr.span, ctx, lcx, table),
         ast::Expr::SetLit(items) => lower_set_lit(items, &expr.span, ctx, lcx, table),
-        ast::Expr::TupleLit(_) => Err(LowerError::unsupported("tuple literal", expr.span.clone())),
+        ast::Expr::TupleLit(items) => {
+            // Tuples are structural, so the shape is inferred bottom-up from
+            // the element expressions — no expected-type context needed, in
+            // contrast to struct literals (see `lower_expr_expecting`).
+            let mut elems = Vec::with_capacity(items.len());
+            for item in items {
+                let elem_e = lower_expr(item, ctx, lcx, table)?;
+                if !super::is_tuple_element_ty(elem_e.ty()) {
+                    return Err(LowerError::unsupported(
+                        "tuple element type other than int/float/bool/str or a nested tuple \
+                         (container/struct/enum/nullable elements need the `Value` marshaling a \
+                         by-value tuple deliberately avoids)",
+                        item.span.clone(),
+                    ));
+                }
+                elems.push(elem_e);
+            }
+            let shape = elems.iter().map(Expr::ty).collect::<Vec<_>>();
+            let tuple_id = super::intern_tuple(lcx.tuples, shape);
+            Ok(Expr::MakeTuple { tuple_id, elems })
+        }
         ast::Expr::NullCoalesce(nullable, fallback) => {
             let nullable_e = lower_expr(nullable, ctx, lcx, table)?;
             let KirType::Nullable(nullable_id) = nullable_e.ty() else {

--- a/crates/keel-kir/src/lower/mod.rs
+++ b/crates/keel-kir/src/lower/mod.rs
@@ -52,7 +52,7 @@ use keel_syntax::lexer::Span;
 
 use crate::ir::{
     Block, EnumId, EnumLayout, FuncId, KirFunction, KirProgram, ListId, LocalId, MapId, NullableId,
-    SetId, StructId, StructLayout,
+    SetId, StructId, StructLayout, TupleId, TupleLayout,
 };
 use crate::span_table::SpanTable;
 use crate::types::KirType;
@@ -125,6 +125,8 @@ pub(crate) struct LowerCtx<'a> {
     pub(crate) sets: &'a std::cell::RefCell<Vec<KirType>>,
     /// Same interior-mutability rationale as `lists`, for `T?` shapes.
     pub(crate) nullables: &'a std::cell::RefCell<Vec<KirType>>,
+    /// Same interior-mutability rationale as `lists`, for tuple shapes.
+    pub(crate) tuples: &'a std::cell::RefCell<Vec<TupleLayout>>,
     /// Each task's per-parameter default-value expression (`None` for a
     /// parameter with no default), indexed by `FuncId`, parallel to that
     /// task's own param list. Lowered once per declaration in a separate,
@@ -249,6 +251,8 @@ pub fn lower_program(
     let sets: std::cell::RefCell<Vec<KirType>> = std::cell::RefCell::new(Vec::new());
     // Same structural-interning rationale as `lists`, for `T?` shapes.
     let nullables: std::cell::RefCell<Vec<KirType>> = std::cell::RefCell::new(Vec::new());
+    // Same structural-interning rationale as `lists`, for tuple shapes.
+    let tuples: std::cell::RefCell<Vec<TupleLayout>> = std::cell::RefCell::new(Vec::new());
 
     // Pass 1a: reserve a `StructId` for every named struct declaration
     // before resolving any field types, so a field can reference another
@@ -318,6 +322,7 @@ pub fn lower_program(
                     &maps,
                     &sets,
                     &nullables,
+                    &tuples,
                 )?,
             ));
         }
@@ -361,6 +366,7 @@ pub fn lower_program(
                     &maps,
                     &sets,
                     &nullables,
+                    &tuples,
                 )?;
                 let func_id = task_order.len();
                 task_order.push(task);
@@ -409,6 +415,7 @@ pub fn lower_program(
             maps: &maps,
             sets: &sets,
             nullables: &nullables,
+            tuples: &tuples,
             param_defaults: &empty_param_defaults,
             artifacts,
             user_raised_struct_id,
@@ -432,6 +439,7 @@ pub fn lower_program(
         maps: &maps,
         sets: &sets,
         nullables: &nullables,
+        tuples: &tuples,
         param_defaults: &param_defaults,
         artifacts,
         user_raised_struct_id,
@@ -498,6 +506,7 @@ pub fn lower_program(
         maps: maps.into_inner(),
         sets: sets.into_inner(),
         nullables: nullables.into_inner(),
+        tuples: tuples.into_inner(),
         span_table,
     })
 }
@@ -648,12 +657,15 @@ fn expr_escapes_uncaught(expr: &crate::ir::Expr, try_depth: usize, can_raise: &[
             expr_escapes_uncaught(list, try_depth, can_raise)
                 || expr_escapes_uncaught(index, try_depth, can_raise)
         }
-        Expr::FieldGet { base, .. } | Expr::NullFieldGet { base, .. } => {
-            expr_escapes_uncaught(base, try_depth, can_raise)
-        }
+        Expr::FieldGet { base, .. }
+        | Expr::NullFieldGet { base, .. }
+        | Expr::TupleGet { base, .. } => expr_escapes_uncaught(base, try_depth, can_raise),
         Expr::MakeStruct { fields, .. } => fields
             .iter()
             .any(|f| expr_escapes_uncaught(f, try_depth, can_raise)),
+        Expr::MakeTuple { elems, .. } => elems
+            .iter()
+            .any(|e| expr_escapes_uncaught(e, try_depth, can_raise)),
         Expr::Call { target, args, .. } => {
             let self_escapes =
                 try_depth == 0 && matches!(target, crate::ir::CallTarget::Fn(id) if can_raise[*id]);
@@ -780,6 +792,7 @@ pub(crate) fn ty_expr_to_kir(
     maps: &std::cell::RefCell<Vec<KirType>>,
     sets: &std::cell::RefCell<Vec<KirType>>,
     nullables: &std::cell::RefCell<Vec<KirType>>,
+    tuples: &std::cell::RefCell<Vec<TupleLayout>>,
 ) -> Result<KirType, LowerError> {
     use keel_syntax::ast::TypeExpr;
     match &ty.kind {
@@ -813,6 +826,7 @@ pub(crate) fn ty_expr_to_kir(
                 maps,
                 sets,
                 nullables,
+                tuples,
             )?;
             if !is_nullable_inner_ty(inner_ty) {
                 return Err(LowerError::unsupported(
@@ -837,6 +851,7 @@ pub(crate) fn ty_expr_to_kir(
                 maps,
                 sets,
                 nullables,
+                tuples,
             )?;
             if !is_list_element_ty(elem_ty) {
                 return Err(LowerError::unsupported(
@@ -859,6 +874,7 @@ pub(crate) fn ty_expr_to_kir(
                 maps,
                 sets,
                 nullables,
+                tuples,
             )?;
             if key_ty != KirType::Str {
                 return Err(LowerError::unsupported(
@@ -875,6 +891,7 @@ pub(crate) fn ty_expr_to_kir(
                 maps,
                 sets,
                 nullables,
+                tuples,
             )?;
             if !is_list_element_ty(value_ty) {
                 return Err(LowerError::unsupported(
@@ -895,6 +912,7 @@ pub(crate) fn ty_expr_to_kir(
                 maps,
                 sets,
                 nullables,
+                tuples,
             )?;
             if !is_list_element_ty(elem_ty) {
                 return Err(LowerError::unsupported(
@@ -909,7 +927,34 @@ pub(crate) fn ty_expr_to_kir(
             "inline struct type",
             ty.span.clone(),
         )),
-        TypeExpr::Tuple(_) => Err(LowerError::unsupported("tuple type", ty.span.clone())),
+        TypeExpr::Tuple(items) => {
+            // `TypeExpr::Tuple` holds bare `TypeExpr`s with no spans of their
+            // own, same situation as `TypeExpr::List` above.
+            let mut elems = Vec::with_capacity(items.len());
+            for item in items {
+                let item_node = keel_syntax::ast::Node::new(item.clone(), ty.span.clone());
+                let elem_ty = ty_expr_to_kir(
+                    &item_node,
+                    structs_by_name,
+                    enums_by_name,
+                    lists,
+                    maps,
+                    sets,
+                    nullables,
+                    tuples,
+                )?;
+                if !is_tuple_element_ty(elem_ty) {
+                    return Err(LowerError::unsupported(
+                        "tuple element type other than int/float/bool/str or a nested tuple \
+                         (container/struct/enum/nullable elements need the `Value` marshaling a \
+                         by-value tuple deliberately avoids)",
+                        ty.span.clone(),
+                    ));
+                }
+                elems.push(elem_ty);
+            }
+            Ok(KirType::Tuple(intern_tuple(tuples, elems)))
+        }
         TypeExpr::Func(_, _) => Err(LowerError::unsupported("function type", ty.span.clone())),
         TypeExpr::Generic(_, _) => Err(LowerError::unsupported("generic type", ty.span.clone())),
         TypeExpr::Dynamic => Err(LowerError::unsupported("dynamic type", ty.span.clone())),
@@ -963,6 +1008,35 @@ pub(crate) fn intern_set(sets: &std::cell::RefCell<Vec<KirType>>, elem: KirType)
     }
     sets.push(elem);
     sets.len() - 1
+}
+
+/// `true` for the element types a tuple can hold today. Wider than
+/// [`is_list_element_ty`] in one direction — nested tuples are allowed, since
+/// a by-value aggregate nests for free with no `Value` marshaling — and
+/// deliberately excludes containers, structs, enums, and nullables, which
+/// would need exactly that marshaling. See `ir.rs`'s `TupleLayout` doc.
+pub(crate) fn is_tuple_element_ty(ty: KirType) -> bool {
+    matches!(
+        ty,
+        KirType::I64 | KirType::F64 | KirType::Bool | KirType::Str | KirType::Tuple(_)
+    )
+}
+
+/// Interns `elems` into `tuples`, returning its `TupleId` — same structural-
+/// interning rationale as [`intern_list`]: `(str, int)` written twice in a
+/// program is one `TupleId` (`SPEC.md` §2.8 makes tuples structural), unlike
+/// `StructId`'s nominal, declaration-order interning.
+pub(crate) fn intern_tuple(
+    tuples: &std::cell::RefCell<Vec<TupleLayout>>,
+    elems: Vec<KirType>,
+) -> TupleId {
+    let mut tuples = tuples.borrow_mut();
+    if let Some(id) = tuples.iter().position(|t| t.elems == elems) {
+        return id;
+    }
+    let id = tuples.len();
+    tuples.push(TupleLayout { id, elems });
+    id
 }
 
 /// `true` for the inner types a nullable (`T?`) can wrap today —

--- a/crates/keel-kir/src/lower/stmt.rs
+++ b/crates/keel-kir/src/lower/stmt.rs
@@ -96,6 +96,11 @@ pub(crate) fn lower_stmt(
 ) -> Result<Vec<ir::Stmt>, LowerError> {
     match &stmt.kind {
         ast::Stmt::Let { binding, ty, value } => {
+            // `(a, b) = pair` binds N names from one subject, which
+            // `binding_ident` cannot express (it returns a single name).
+            if let ast::Binding::Destruct(pat) = binding {
+                return lower_destructure_let(pat, ty, value, ctx, lcx, table, &stmt.span);
+            }
             let name = binding_ident(binding, &stmt.span)?;
             if let ast::Expr::WhenExpr { subject, arms } = &value.kind {
                 return lower_when_expr_let(
@@ -116,6 +121,7 @@ pub(crate) fn lower_stmt(
                     lcx.maps,
                     lcx.sets,
                     lcx.nullables,
+                    lcx.tuples,
                 )?;
                 lower_expr_expecting(value, expected, ctx, lcx, table)?
             } else if let ast::Expr::StructSpreadUpdate { base, .. } = &value.kind {
@@ -511,6 +517,7 @@ fn lower_when_expr_let(
             lcx.maps,
             lcx.sets,
             lcx.nullables,
+            lcx.tuples,
         )?,
         None => {
             let probe = lower_block(&arms[0].body, ctx, lcx, table, ret_ty, TailSink::Discard)?;
@@ -787,4 +794,92 @@ pub(crate) fn block_terminates(block: &Block) -> bool {
         }
         _ => false,
     }
+}
+
+/// Lowers `(a, b) = pair` — a positional tuple destructure — into a subject
+/// local plus one `TupleGet` binding per name.
+///
+/// The subject is bound to its own synthetic local first so the right-hand
+/// side is evaluated exactly once, however many names it feeds; reading
+/// `pair.0` and `pair.1` off a re-lowered RHS would duplicate any work (or
+/// any `raise`) inside it.
+///
+/// Struct destructuring (`{a, b} = value`) stays unsupported: it needs field-
+/// name resolution against a `StructLayout` and has no tuple fixture driving
+/// it, so it keeps the pre-existing "destructuring binding" error rather than
+/// a half-built path.
+fn lower_destructure_let(
+    pat: &ast::DestructPat,
+    annotation: &Option<Node<ast::TypeExpr>>,
+    value: &ast::SpannedExpr,
+    ctx: &mut FnCtx,
+    lcx: &LowerCtx<'_>,
+    table: &mut SpanTable,
+    span: &Span,
+) -> Result<Vec<ir::Stmt>, LowerError> {
+    let ast::DestructPat::Tuple(names) = pat else {
+        return Err(LowerError::unsupported(
+            "struct destructuring binding",
+            span.clone(),
+        ));
+    };
+
+    let init = if let Some(annotation) = annotation {
+        let expected = ty_expr_to_kir(
+            annotation,
+            lcx.structs_by_name,
+            lcx.enums_by_name,
+            lcx.lists,
+            lcx.maps,
+            lcx.sets,
+            lcx.nullables,
+            lcx.tuples,
+        )?;
+        lower_expr_expecting(value, expected, ctx, lcx, table)?
+    } else {
+        lower_expr(value, ctx, lcx, table)?
+    };
+
+    let subject_ty = init.ty();
+    let KirType::Tuple(tuple_id) = subject_ty else {
+        return Err(LowerError::unsupported(
+            "positional destructuring of a non-tuple value (list/struct destructuring is a \
+             later-M2/M3 concern)",
+            span.clone(),
+        ));
+    };
+    let elems = lcx.tuples.borrow()[tuple_id].elems.clone();
+    if elems.len() != names.len() {
+        return Err(LowerError::new(
+            format!(
+                "destructuring binds {} name(s) but the tuple has {} element(s) — the checker \
+                 should have rejected this",
+                names.len(),
+                elems.len()
+            ),
+            span.clone(),
+        ));
+    }
+
+    // Declared before the element locals so each `TupleGet` can reference it.
+    let subject_local = ctx.declare("<destructure.subject>", subject_ty);
+    let mut stmts = vec![ir::Stmt::Let {
+        local: subject_local,
+        init: Some(init),
+    }];
+    for (index, (name, elem_ty)) in names.iter().zip(&elems).enumerate() {
+        let local = ctx.declare(name, *elem_ty);
+        stmts.push(ir::Stmt::Let {
+            local,
+            init: Some(ir::Expr::TupleGet {
+                base: Box::new(ir::Expr::Local {
+                    id: subject_local,
+                    ty: subject_ty,
+                }),
+                index,
+                ty: *elem_ty,
+            }),
+        });
+    }
+    Ok(stmts)
 }

--- a/crates/keel-kir/src/passes/verify.rs
+++ b/crates/keel-kir/src/passes/verify.rs
@@ -14,6 +14,7 @@ use std::fmt;
 
 use crate::ir::{
     Block, CallTarget, EnumId, Expr, FuncId, KirFunction, KirProgram, LocalId, Stmt, StructId,
+    TupleId, TupleLayout,
 };
 use crate::types::KirType;
 
@@ -112,6 +113,18 @@ fn check_struct(program: &KirProgram, id: StructId) -> Result<(), String> {
         ));
     }
     Ok(())
+}
+
+/// Bounds-checks a `TupleId` and hands back the layout, since every tuple
+/// check needs the element list immediately afterwards (unlike
+/// [`check_struct`], whose callers already hold the layout).
+fn check_tuple(program: &KirProgram, id: TupleId) -> Result<&TupleLayout, String> {
+    program.tuples.get(id).ok_or_else(|| {
+        format!(
+            "TupleId {id} out of range ({} tuple shapes)",
+            program.tuples.len()
+        )
+    })
 }
 
 fn check_enum(program: &KirProgram, id: EnumId) -> Result<(), String> {
@@ -394,6 +407,49 @@ fn verify_expr(program: &KirProgram, func: &KirFunction, expr: &Expr) -> Result<
                         field.ty()
                     ));
                 }
+            }
+            Ok(())
+        }
+        Expr::MakeTuple { tuple_id, elems } => {
+            let layout = check_tuple(program, *tuple_id)?;
+            if layout.elems.len() != elems.len() {
+                return Err(format!(
+                    "tuple literal has {} element(s), shape declares {}",
+                    elems.len(),
+                    layout.elems.len()
+                ));
+            }
+            for (position, (elem, declared_ty)) in elems.iter().zip(&layout.elems).enumerate() {
+                verify_expr(program, func, elem)?;
+                if elem.ty() != *declared_ty {
+                    return Err(format!(
+                        "tuple element {position} is declared {declared_ty} but the literal \
+                         supplies {}",
+                        elem.ty()
+                    ));
+                }
+            }
+            Ok(())
+        }
+        Expr::TupleGet { base, index, ty } => {
+            verify_expr(program, func, base)?;
+            let KirType::Tuple(tuple_id) = base.ty() else {
+                return Err(format!(
+                    "tuple positional read `.{index}` on a {} base",
+                    base.ty()
+                ));
+            };
+            let layout = check_tuple(program, tuple_id)?;
+            let Some(declared_ty) = layout.elems.get(*index) else {
+                return Err(format!(
+                    "tuple index {index} is out of bounds for a {}-element shape",
+                    layout.elems.len()
+                ));
+            };
+            if *declared_ty != *ty {
+                return Err(format!(
+                    "tuple element {index} is {declared_ty} but the read claims {ty}"
+                ));
             }
             Ok(())
         }

--- a/crates/keel-kir/src/types.rs
+++ b/crates/keel-kir/src/types.rs
@@ -9,7 +9,7 @@
 //! adding them is later-M2+ work, done alongside the lowering support that
 //! produces them.
 
-use crate::ir::{EnumId, KirProgram, ListId, MapId, NullableId, SetId, StructId};
+use crate::ir::{EnumId, KirProgram, ListId, MapId, NullableId, SetId, StructId, TupleId};
 
 /// A KIR-level type. Every KIR expression carries one.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -70,6 +70,13 @@ pub enum KirType {
     /// has no pointer to repurpose at all, so it's an explicit
     /// `{ i1 has_value, T }` pair, by value.
     Nullable(NullableId),
+    /// A tuple shape (`(str, int)`) — see `KirProgram::tuples` for the
+    /// positional element types this id indexes. A **by-value** LLVM
+    /// aggregate: no heap allocation, no `ptr`, no RC, deliberately not the
+    /// container ABI (`designs/llvm-compilation.md` §1.1). Element types are
+    /// restricted to int/float/bool/str and nested tuples — see
+    /// `TupleLayout`'s doc for the `str`-element RC caveat.
+    Tuple(TupleId),
 }
 
 impl KirType {
@@ -92,6 +99,7 @@ impl KirType {
             KirType::Map(_) => "map",
             KirType::Set(_) => "set",
             KirType::Nullable(_) => "nullable",
+            KirType::Tuple(_) => "tuple",
         }
     }
 
@@ -112,6 +120,9 @@ impl KirType {
             KirType::Struct(id) => program.structs[id].is_heap(program),
             KirType::List(_) | KirType::Map(_) | KirType::Set(_) => true,
             KirType::I64 | KirType::F64 | KirType::Bool | KirType::Unit | KirType::Enum(_) => false,
+            // The aggregate itself is by value, but it *contains* RC'd data
+            // when any element does (a `str` element is a boxed `Value*`).
+            KirType::Tuple(id) => program.tuples[id].is_heap(program),
             // A nullable scalar is a by-value `{ i1, T }` pair, not a
             // pointer — everything else nullable wraps a `ptr` (see
             // `KirType::Nullable`'s doc). `is_nullable_inner_ty` guarantees

--- a/designs/llvm-compilation.md
+++ b/designs/llvm-compilation.md
@@ -280,6 +280,11 @@ pub struct KirProgram {
     pub functions: Vec<KirFunction>,          // includes lambdas + monomorphized stamps
     pub structs: Vec<StructLayout>,           // nominal + interned anonymous shapes
     pub enums: Vec<EnumLayout>,               // tag values fixed here, not in codegen
+    pub lists: Vec<KirType>,                  // ─┐ side tables every composite `KirType`
+    pub maps: Vec<KirType>,                   //  │ indexes into — see the interning note
+    pub sets: Vec<KirType>,                   //  │ below
+    pub nullables: Vec<KirType>,              //  │
+    pub tuples: Vec<TupleLayout>,             // ─┘
     pub agents: Vec<AgentDescriptor>,         // state layout, handler FuncIds, @tools,
                                               //   @schedule specs (feeds descriptor.rs)
     pub toplevel: FuncId,                     // compiled top-level statements
@@ -288,9 +293,9 @@ pub struct KirProgram {
 
 pub enum KirType {
     I64, F64, Bool, Unit, Duration,           // unboxed scalars
-    Str, List(Box<KirType>), Map(..), Set(..),// opaque RC pointers (container ABI)
-    Struct(StructId), Enum(EnumId), Tuple(Vec<KirType>),
-    Nullable(Box<KirType>), Func(..),
+    Str, List(ListId), Map(MapId), Set(SetId),// opaque RC pointers (container ABI)
+    Struct(StructId), Enum(EnumId), Tuple(TupleId),
+    Nullable(NullableId), Func(FuncTyId),
     Boxed,                                    // `dynamic` — KeelBox*
     Handle(HandleKind),                       // DbConnection, datetime, Task[T]
 }
@@ -323,7 +328,9 @@ pub enum Expr {
     Const(..), Local(LocalId),
     Call { target: CallTarget, args: Vec<Expr>, span: SpanId },
     BinOp(..), UnOp(..),
-    FieldGet { .. }, MakeStruct { .. }, MakeEnum { .. }, MakeTuple(..),
+    FieldGet { .. }, MakeStruct { .. }, MakeEnum { .. },
+    MakeTuple { tuple_id: TupleId, elems: Vec<Expr> },
+    TupleGet { base: Box<Expr>, index: usize, ty: KirType },
     Box { value: Box<Expr> },                 // typed -> KeelBox*
     Unbox { value: Box<Expr>, ty: KirType, span: SpanId },  // `as T`, may raise
     NullCheck { .. },                         // from `?.` / `??` desugar
@@ -337,6 +344,25 @@ pub enum CallTarget {
     Indirect(Box<Expr>),                      // lambda value: {fn*, env*} pair
 }
 ```
+
+**Composite types are ID-interned, never inline.** Every composite `KirType`
+carries a `usize` index into a side table on `KirProgram` — `List(ListId)`, not
+`List(Box<KirType>)`; `Tuple(TupleId)`, not `Tuple(Vec<KirType>)`. This keeps
+`KirType` `Copy`, which the implementation relies on pervasively: it is passed
+by value through lowering, codegen, and `verify`, and stored in every `Expr`.
+An inline `Box`/`Vec` payload would take that away and force a clone at each of
+those sites. **Any new composite type must follow the same shape** — add a side
+table plus an id, not a nested payload.
+
+Two interning disciplines, and the distinction is semantic rather than
+incidental:
+
+- **Nominal**, in declaration order — `StructId`, `EnumId`. Two declarations
+  with identical shape stay distinct types, because `type Point {x: int}` and
+  `type Score {x: int}` are not interchangeable (issue #16).
+- **Structural**, deduplicated by shape — `ListId`, `MapId`, `SetId`,
+  `NullableId`, `TupleId`. `(str, int)` written anywhere in the program is one
+  id, because `SPEC.md` §2.8 makes tuples structural; same for `list[int]`.
 
 Fixed pass order (each pass re-runs `verify` in debug builds):
 
@@ -565,7 +591,9 @@ generic namespace dispatch proving out on `io.print`/`log.*`.
 *Exit: a scalar-only example compiles, links, runs, and matches the interpreter.*
 
 **M2 — Data types + errors.**
-Lists/maps/sets/tuples via container ABI (CoW semantics verified), named + anonymous
+Lists/maps/sets via container ABI (CoW semantics verified) — tuples are *not*:
+per §1.1 they are by-value LLVM aggregates with no heap allocation and no RC, so
+they deliberately bypass the container ABI (issue #157). Plus named + anonymous
 structs, enums, `when` exhaustive matching, nullable (`?`, `??`, `?.`), `raise`/`try`/
 `catch` result convention, string interpolation. *Exit: the conformance harness runs a
 curated M2-scope fixture set (not all non-agent, non-I/O examples — most of that corpus

--- a/docs/src/release-notes.md
+++ b/docs/src/release-notes.md
@@ -35,6 +35,9 @@ Nested access needs parentheses — `(t.0).1` rather than `t.0.1` — because
 `0.1` lexes as a float literal. See [issue #185](https://github.com/keel-lang/keel/issues/185)
 and the [Tuples guide](guide/types.md#tuples).
 
+Destructuring (`(a, b) = pair`) and positional reads both compile through
+the native backend as well, matching the interpreter byte for byte.
+
 ### `keel dap` — a step debugger over the Debug Adapter Protocol
 
 Any DAP-speaking editor can now set breakpoints, step, and inspect variables


### PR DESCRIPTION
Closes #157. #186 landed the parser, checker, and interpreter; this adds the native backend, completing the issue's exit criterion.

## The interesting part: first by-value aggregate

Tuples are the first genuinely **by-value aggregate** in the compiled backend — an unnamed LLVM struct built with `insertvalue` and read with `extractvalue`. No heap allocation, no pointer indirection, no refcounting. Heap structs and containers stay on their existing `ptr` paths, and `layout.rs` still rejects an all-scalar struct for exactly the "by-value codegen isn't wired up" reason — so this PR is the code that proves that path out.

## Deviation from the issue body — please sanity-check this one

#157's scope section and `designs/llvm-compilation.md` §2.3 both specify `KirType::Tuple(Vec<KirType>)`. **That cannot compile.** `KirType` derives `Copy` (`types.rs:15`) and every aggregate is ID-interned through a side table on `KirProgram` precisely to keep it that way; a `Vec` payload breaks it. Both documents predate the interning decision.

This uses `Tuple(TupleId)` into a new `KirProgram::tuples` table. Interning is **structural** (like `ListId`, not `StructId`) since `SPEC.md` §2.8 makes tuples structural — `(str, int)` written twice is one id. I left a note on #157 recording this so the design doc can be corrected separately.

## Boxing boundaries got explicit arms, not fallthroughs

There is no `keel_box_tuple`, so a silent `_ =>` would miscompile rather than diagnose. `emit_box_arg`, `unbox_value`, and `emit_binop` each get a named `Tuple` arm. Passing a whole tuple to a namespace method is now:

```
tuple-typed argument to a namespace call (pass an element — `pair.0` — instead; …)
```

with a test pinning it. `io.show("{pair.0}")` works, since that yields a scalar.

## Element restrictions

int/float/bool/str plus **nested tuples** — nesting is free for a by-value aggregate. Containers, structs, enums, and nullables are rejected by name at lowering, since they need the `Value` marshaling this representation exists to avoid.

## Destructuring

`(a, b) = pair` lowers to a subject local plus one `TupleGet` per name, so the RHS is evaluated once however many names it binds — there's a test asserting a side-effecting RHS runs exactly once. `binding_ident` returns a single name and could not express this, so the destructuring path branches at the `let` site instead of widening it. Struct destructuring keeps its existing unsupported error.

## Known caveat, deliberately not fixed here

A `str` element is a boxed `Value*`, so copying a tuple duplicates that pointer **without a retain**. That is consistent with the backend today — `passes::rc::insert_rc` is a no-op, so nothing releases either and there is no double-free — and it is documented on `TupleLayout` to be revisited when that pass becomes real. Solving RC for tuples alone would be inventing a policy the rest of the backend doesn't have.

## Verification

- 7 new codegen tests: scalar tuples, tuples across call boundaries (aggregate params **and** returns), `str` elements, nested aggregates, destructuring, evaluate-once, and the namespace-arg error. All compile → link → run and are asserted byte-identical against the interpreter.
- Conformance harness green under `cargo test --features build-backend` (differential, still exactly one `#[test]`).
- Full workspace: 45 test blocks, 0 failures. `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean. `mdbook build` clean.
- `--emit=kir` now prints tuple shapes (`(int, int)`) rather than a bare `tuple`.

Built and tested against LLVM 22 (`inkwell` `llvm22-1`).

## Not in scope

Nested access without parentheses (`t.0.1`) remains #185 — a lexer limitation, unrelated to codegen.