### PR TITLE
Parse nested tuple positional access (t.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,15 +151,27 @@ maybe: (str, int)? = ("hi", 7)
 io.show("{maybe?.0}")             # hi
 
 nested: ((int, int), int) = ((1, 2), 3)
-io.show("{(nested.0).1}")         # 2 — parentheses required, see #185
+io.show("{nested.0.1}")           # 2 — chains to any depth
 ```
 
   Because tuples and lists share one runtime representation in v0.1, `.N` on a
   non-tuple is rejected by the type checker rather than the interpreter:
   `xs.0` on a `list[int]` reports *positional access `.0` is only valid on
-  tuples; index `list[int]` with `[0]`*. Nested access without parentheses
-  (`t.0.1`) still fails to parse — `0.1` matches the float-literal pattern and
-  is claimed as one token — tracked in #185.
+  tuples; index `list[int]` with `[0]`*.
+
+  Nested access (`t.0.1`) parses as well, which took a lexical fix rather than
+  a grammar one: `0.1` matches the float-literal regex and logos keeps the
+  longest match, so where two indices were written the parser saw a single
+  `Token::Float`. Postfix position — and only postfix position — now splits
+  that token back into its two indices, so a float literal in value position
+  (`x = 0.1`) and the `5.minutes` duration sugar are unaffected. `t.0.1` builds
+  exactly what `(t.0).1` builds, each index bounds-checked against its own
+  tuple. `?.` opens a nested access as well (`t?.0.1`), covering the index it
+  is written on — a nullable at every level wants `t?.0?.1`, the same rule that
+  already governs `o?.a.b` on a nullable struct. The fix also repairs `keel fmt`
+  on the old parenthesized workaround: the formatter drops redundant
+  parentheses, so it used to rewrite the working `(t.0).1` into `t.0.1`, which
+  then failed to parse.
 
   The native backend compiles tuples too: construction, positional reads, and
   positional destructuring (`(a, b) = pair`) lower through KIR and codegen, and

--- a/SPEC.md
+++ b/SPEC.md
@@ -325,15 +325,15 @@ Tuples are structural, immutable. Single-element tuples are not a thing (`(str)`
 
 Positional access is bounds-checked at compile time — `pair.2` on a 2-tuple is a type error, not a runtime one — and `.N` is valid only on tuples. Lists and maps use subscripts (`xs[0]`), which is why `xs.0` is rejected. `?.` works too: `maybe_pair?.0`.
 
-Nested positional access currently needs parentheses:
+Nested positional access chains to any depth, with or without parentheses:
 
 ```keel
 t: ((int, int), int) = ((1, 2), 3)
-b = (t.0).1                       # ok
-# b = t.0.1                       # parse error — see below
+b = t.0.1                         # 2
+c = (t.0).1                       # 2 — identical
 ```
 
-This is a lexer limitation rather than a language rule: `0.1` matches the float-literal pattern and is claimed as a single token before the grammar sees two indices. Tracked in [#185](https://github.com/keel-lang/keel/issues/185); the parenthesized form is not going away.
+Each index is bounds-checked against its own tuple. `?.` applies to the index it is written on, so a nullable at every level needs `maybe?.0?.1`.
 
 ### 2.9 The `dynamic` type (FFI/interop only)
 

--- a/crates/keel-codegen/tests/tuples.rs
+++ b/crates/keel-codegen/tests/tuples.rs
@@ -112,12 +112,13 @@ io.show(pair.1)
 fn nested_tuple_nests_as_a_nested_aggregate() {
     // Nested tuples are allowed where nested containers are not: a by-value
     // aggregate nests for free, with no `Value` marshaling
-    // (`is_tuple_element_ty`). Parenthesised read per SPEC §2.8 / #185.
+    // (`is_tuple_element_ty`). Both spellings of the nested read — `t.0.1`
+    // and `(t.0).1` — parse to the same AST, so one KIR path covers both.
     let source = r#"
 use std/io
 
 t: ((int, int), int) = ((1, 2), 3)
-io.show((t.0).1)
+io.show(t.0.1)
 io.show(t.1)
 "#;
     let compiled = compile_and_run(source);

--- a/crates/keel-syntax/src/parser/common.rs
+++ b/crates/keel-syntax/src/parser/common.rs
@@ -122,11 +122,40 @@ pub(super) fn field_name() -> P<String> {
 /// AST variant — `field_name` can never yield an all-digit name, so there
 /// is no ambiguity with a real field.
 ///
-/// Only *flat* indexing parses: `t.0.1` lexes `0.1` as a single
-/// `Token::Float` (logos picks the longest match — see `lexer.rs`'s `Float`
-/// regex), so nested tuple access needs `(t.0).1`. Tracked separately.
+/// Handles one index per `.`; the two-indices-in-one-token case (`t.0.1`)
+/// is [`tuple_index_pair`].
 pub(super) fn postfix_field_name() -> P<String> {
     field_name().or(select! { Token::Integer(n) => n }).boxed()
+}
+
+/// The two indices of a *nested* positional access (`t.0.1`), recovered from
+/// the single token the lexer produced for them.
+///
+/// `0.1` matches the `Float` regex (`[0-9]+\.[0-9]+`) and logos picks the
+/// longest match, so the grammar never sees `Integer Dot Integer` here — see
+/// `lexer.rs`. Rather than make the lexer context-sensitive, postfix position
+/// splits the float's own text back apart. The split is total: the regex
+/// guarantees exactly one `.` with digits on both sides, so both halves are
+/// non-empty integer literals.
+///
+/// Only reachable after a `.` or `?.`, so a float literal in value position
+/// (`x = 0.1`) is untouched.
+///
+/// Yields the two indices plus the source offset just past the first one, so
+/// the caller can span the inner access exactly.
+pub(super) fn tuple_index_pair() -> P<(String, String, usize)> {
+    select! { Token::Float(f) => f }
+        .map_with_span(|f, span| {
+            let (first, second) = f
+                .split_once('.')
+                .expect("lexer's Float regex always contains a '.'");
+            (
+                first.to_string(),
+                second.to_string(),
+                span.start + first.len(),
+            )
+        })
+        .boxed()
 }
 
 /// Map / struct-literal key: a field_name or a string literal (strings

--- a/crates/keel-syntax/src/parser/expr.rs
+++ b/crates/keel-syntax/src/parser/expr.rs
@@ -13,7 +13,7 @@ use crate::lexer::Token;
 
 use super::common::{
     P, block_with, field_name, field_sep, ident, if_body, map_key, map_lit_key, newlines,
-    postfix_field_name, string_lit, when_arm, when_body,
+    postfix_field_name, string_lit, tuple_index_pair, when_arm, when_body,
 };
 use super::types::spanned_type_expr;
 
@@ -28,6 +28,17 @@ enum PostfixOp {
         args: Option<Vec<CallArg>>,
     },
     NullDotAccess(String),
+    /// Nested positional access, `t.0.1` — both indices arrive as one
+    /// `Token::Float` (see [`tuple_index_pair`]). `first_end` is where the
+    /// first index ends in the source; `null_dot` records whether the leading
+    /// operator was `?.`, which applies to the *first* index only.
+    NestedIndex {
+        first: String,
+        second: String,
+        first_end: usize,
+        args: Option<Vec<CallArg>>,
+        null_dot: bool,
+    },
     NullAssert,
     Call(Vec<CallArg>),
     /// Type cast: `as T` — the target annotation carries its source span.
@@ -428,6 +439,21 @@ pub(super) fn expr_parser() -> P<SpannedExpr> {
             just(Token::NullDot)
                 .ignore_then(postfix_field_name())
                 .map(PostfixOp::NullDotAccess),
+            // `t.0.1` / `t?.0.1` — one `Token::Float` holding two indices.
+            // Trailing `(args)` attaches to the second index, matching what
+            // `(t.0).1(x)` parses to.
+            choice((just(Token::Dot).to(false), just(Token::NullDot).to(true)))
+                .then(tuple_index_pair())
+                .then(call_args.clone().or_not())
+                .map(
+                    |((null_dot, (first, second, first_end)), args)| PostfixOp::NestedIndex {
+                        first,
+                        second,
+                        first_end,
+                        args,
+                        null_dot,
+                    },
+                ),
             just(Token::Bang).to(PostfixOp::NullAssert),
             call_args.clone().map(PostfixOp::Call),
             just(Token::As)
@@ -477,6 +503,39 @@ pub(super) fn expr_parser() -> P<SpannedExpr> {
                         Expr::NullFieldAccess(Box::new(lhs_spanned), field),
                         full_span,
                     ),
+                    PostfixOp::NestedIndex {
+                        first,
+                        second,
+                        first_end,
+                        args,
+                        null_dot,
+                    } => {
+                        // Expand to the same shape the parenthesised form
+                        // builds: `t.0.1` is `(t.0).1`.
+                        let inner_span = full_span.start..first_end;
+                        let object = Box::new(lhs_spanned);
+                        let inner = Node::new(
+                            if null_dot {
+                                Expr::NullFieldAccess(object, first)
+                            } else {
+                                Expr::FieldAccess(object, first)
+                            },
+                            inner_span,
+                        );
+                        match args {
+                            Some(args) => Node::new(
+                                Expr::MethodCall {
+                                    object: Box::new(inner),
+                                    method: second,
+                                    args,
+                                },
+                                full_span,
+                            ),
+                            None => {
+                                Node::new(Expr::FieldAccess(Box::new(inner), second), full_span)
+                            }
+                        }
+                    }
                     PostfixOp::NullAssert => {
                         Node::new(Expr::NullAssert(Box::new(lhs_spanned)), full_span)
                     }

--- a/docs/src/guide/types.md
+++ b/docs/src/guide/types.md
@@ -384,16 +384,25 @@ maybe: (str, int)? = ("hi", 7)
 io.show("{maybe?.0}")         # hi
 ```
 
-Nested positional access needs parentheses:
+Nested positional access chains, to any depth:
 
 ```keel
 t: ((int, int), int) = ((1, 2), 3)
 
-b = (t.0).1                   # 2
-# b = t.0.1                   # parse error
+b = t.0.1                     # 2
+c = (t.0).1                   # 2 — same thing, parentheses optional
 ```
 
-This is a lexer limitation, not a language rule — `0.1` matches the float-literal pattern and is claimed as a single token before the grammar sees two separate indices. Tracked in [issue #185](https://github.com/keel-lang/keel/issues/185). The parenthesised form works and will keep working.
+Each index is bounds-checked against its own tuple, so `t.0.5` reports against the inner `(int, int)` and `t.2.1` against the outer `((int, int), int)`.
+
+`?.` covers the index it is written on, not the whole chain — the same rule as `o?.a.b` on a nullable struct. Give every step that can be absent its own `?.`:
+
+```keel
+maybe: ((int, int), int)? = none
+
+io.show("{maybe?.0?.1}")      # none — short-circuits
+# io.show("{maybe?.0.1}")     # raises: cannot access `.1` on none
+```
 
 ## Function types
 

--- a/docs/src/release-notes.md
+++ b/docs/src/release-notes.md
@@ -376,9 +376,10 @@ xs: list[int] = [1, 2, 3]
          #        index `list[int]` with `[0]`
 ```
 
-Nested access needs parentheses — `(t.0).1` rather than `t.0.1` — because
-`0.1` lexes as a float literal. See [issue #185](https://github.com/keel-lang/keel/issues/185)
-and the [Tuples guide](guide/types.md#tuples).
+Nested access chains too — `t.0.1` reads the second element of the first —
+even though `0.1` looks like a float literal to the lexer. Parentheses are
+optional; `(t.0).1` means the same thing. See the
+[Tuples guide](guide/types.md#tuples).
 
 Destructuring (`(a, b) = pair`) and positional reads both compile through
 the native backend as well, matching the interpreter byte for byte.

--- a/tests/integration/language/tuples.rs
+++ b/tests/integration/language/tuples.rs
@@ -111,30 +111,141 @@ io.show("{maybe?.0}")
 }
 
 #[test]
-fn nested_tuple_access_requires_parentheses() {
-    // `t.0.1` cannot parse: the lexer's Float regex (`[0-9]+\.[0-9]+`) claims
-    // `0.1` as one token, and logos picks the longest match. Parenthesizing
-    // is the documented workaround; lifting the restriction is tracked
-    // separately. This test pins both halves so the follow-up has a target.
-    let parenthesized = r#"
+fn nested_tuple_access_parses_without_parentheses() {
+    // Issue #185: the lexer's Float regex (`[0-9]+\.[0-9]+`) claims `0.1` as
+    // one token, so the grammar never sees `Integer Dot Integer`. Postfix
+    // position splits that token back into two indices; both forms must give
+    // the same answer.
+    let src = r#"
+use std/io
+t: ((int, int), int) = ((1, 2), 3)
+io.show("{t.0.1} {(t.0).1}")
+"#;
+    let (ok, stdout, stderr) = run_inline(src, false);
+    assert!(ok, "`t.0.1` must parse: {stderr}");
+    assert!(
+        stdout.contains("2 2"),
+        "bare and parenthesized forms must agree: {stdout}"
+    );
+}
+
+#[test]
+fn three_deep_positional_access() {
+    // `deep.0.0.1` lexes as `Ident Dot Float("0.0") Dot Integer("1")` — the
+    // split arm and the flat arm have to compose.
+    let src = r#"
+use std/io
+deep: (((int, str), int), int) = (((7, "x"), 8), 9)
+io.show("{deep.0.0.0} {deep.0.0.1} {deep.0.1} {deep.1}")
+"#;
+    let (ok, stdout, stderr) = run_inline(src, false);
+    assert!(ok, "three-deep positional access must parse: {stderr}");
+    assert!(stdout.contains("7 x 8 9"), "expected `7 x 8 9`: {stdout}");
+}
+
+#[test]
+fn nested_index_bounds_errors_name_the_right_tuple() {
+    // The two indices must be checked against their own tuples, which only
+    // holds if the split produced nested `FieldAccess` nodes in the right
+    // order (outer index first).
+    let src = r#"
+t: ((int, int), int) = ((1, 2), 3)
+b = t.0.5
+"#;
+    let (ok, _stdout, stderr) = run_inline(src, false);
+    assert!(!ok, "`.5` on the inner 2-tuple is out of bounds");
+    assert!(
+        stderr.contains("index 5") && stderr.contains("(int, int)"),
+        "inner index should be checked against the inner tuple: {stderr}"
+    );
+
+    let src = r#"
+t: ((int, int), int) = ((1, 2), 3)
+b = t.2.1
+"#;
+    let (ok, _stdout, stderr) = run_inline(src, false);
+    assert!(!ok, "`.2` on the outer 2-tuple is out of bounds");
+    assert!(
+        stderr.contains("index 2") && stderr.contains("((int, int), int)"),
+        "outer index should be checked against the outer tuple: {stderr}"
+    );
+}
+
+#[test]
+fn float_literals_are_untouched_by_the_split() {
+    // The split arm only fires after `.` / `?.`. A float in value position —
+    // and the `5.minutes` duration sugar that shares the same lexer mechanic —
+    // must keep working.
+    let src = r#"
+use std/io
+f = 0.1
+io.show("{f} {5.minutes}")
+"#;
+    let (ok, stdout, stderr) = run_inline(src, false);
+    assert!(ok, "float literals must still parse: {stderr}");
+    assert!(stdout.contains("0.1"), "expected the float back: {stdout}");
+}
+
+#[test]
+fn nested_positional_access_after_null_safe_index() {
+    // `?.` opens the access but covers the first index only — exactly like
+    // `o?.a.b` on a nullable struct, where the second `.` is a plain access.
+    // Both spellings must agree; `?.0?.1` is the short-circuiting form.
+    let present = r#"
+use std/io
+maybe: ((int, int), int)? = ((4, 5), 6)
+io.show("{maybe?.0.1} {(maybe?.0).1} {maybe?.0?.1}")
+"#;
+    let (ok, stdout, stderr) = run_inline(present, false);
+    assert!(ok, "`maybe?.0.1` must parse: {stderr}");
+    assert!(stdout.contains("5 5 5"), "all three must agree: {stdout}");
+
+    // On `none`, the trailing plain `.1` raises — the pre-existing behavior of
+    // any `?.`-opened chain, not something the split introduces.
+    let absent = r#"
+use std/io
+maybe: ((int, int), int)? = none
+io.show("{maybe?.0.1}")
+"#;
+    let (ok, _stdout, stderr) = run_inline(absent, false);
+    assert!(!ok, "a plain `.1` past a `none` must not silently succeed");
+    assert!(
+        stderr.contains("Cannot access `.1` on none"),
+        "expected the same error `(maybe?.0).1` raises: {stderr}"
+    );
+
+    let short_circuit = r#"
+use std/io
+maybe: ((int, int), int)? = none
+io.show("{maybe?.0?.1}")
+"#;
+    let (ok, stdout, stderr) = run_inline(short_circuit, false);
+    assert!(ok, "`?.0?.1` must short-circuit: {stderr}");
+    assert!(stdout.contains("none"), "expected `none`: {stdout}");
+}
+
+#[test]
+fn nested_positional_access_formatter_roundtrip() {
+    // The formatter drops the redundant parentheses in `(t.0).1`, so before
+    // #185 it turned working source into source that no longer parsed.
+    let src = r#"
 use std/io
 t: ((int, int), int) = ((1, 2), 3)
 io.show("{(t.0).1}")
 "#;
-    let (ok, stdout, stderr) = run_inline(parenthesized, false);
-    assert!(ok, "`(t.0).1` must work: {stderr}");
-    assert!(stdout.contains('2'), "expected `2`: {stdout}");
-
-    let unparenthesized = r#"
-t: ((int, int), int) = ((1, 2), 3)
-b = t.0.1
-"#;
-    let (ok, _stdout, stderr) = run_inline(unparenthesized, false);
-    assert!(!ok, "`t.0.1` is a known parse limitation, not valid today");
-    assert!(
-        stderr.contains("0.1"),
-        "error should show the Float token that swallowed the indices: {stderr}"
+    let once = keel_lang::session::fmt_source(src, "t.keel").expect("fmt once");
+    let twice = keel_lang::session::fmt_source(&once, "t.keel").expect("fmt twice");
+    assert_eq!(
+        once, twice,
+        "formatter not idempotent:\n--- once ---\n{once}\n--- twice ---\n{twice}"
     );
+    assert!(
+        once.contains("t.0.1"),
+        "formatter should print the unparenthesized form: {once}"
+    );
+    let (ok, stdout, stderr) = run_inline(&once, false);
+    assert!(ok, "formatted output must still run: {stderr}");
+    assert!(stdout.contains('2'), "expected `2`: {stdout}");
 }
 
 #[test]


### PR DESCRIPTION
Closes #185.

`t.0.1` did not parse. The lexer's `Float` regex (`[0-9]+\.[0-9]+`) claims `0.1` as one token and logos keeps the longest match, so where two indices were written the grammar saw `Ident Dot Float`. Parenthesising (`(t.0).1`) was the documented workaround.

## Approach

Purely lexical, fixed in postfix position rather than in the lexer: after `.` or `?.`, a `Token::Float` is split back into the two integer indices it swallowed and expanded into exactly the AST `(t.0).1` already builds. The lexer stays context-free, so a float literal in value position (`x = 0.1`) and the `5.minutes` duration sugar are untouched.

No AST variant, no type-checker change, no KIR change — one new parser helper plus one postfix arm.

```keel
t: ((int, int), int) = ((1, 2), 3)
b = t.0.1                     # 2
c = (t.0).1                   # 2 — parentheses now optional

deep: (((int, str), int), int) = (((7, "x"), 8), 9)
d = deep.0.0.1                # "x" — chains to any depth
```

Each index is bounds-checked against its own tuple: `t.0.5` reports against the inner `(int, int)`, `t.2.1` against the outer `((int, int), int)`.

## Also fixes `keel fmt`

The formatter drops redundant parentheses, so it was rewriting the working `(t.0).1` into `t.0.1` — source that then failed to parse. Pinned with a round-trip test.

## `?.` behaviour

`?.` opens a nested access (`t?.0.1`) and covers the index it is written on, not the whole chain. On `none` the trailing plain `.1` raises, exactly as `(t?.0).1` and `o?.a.b` on a nullable struct already do; `t?.0?.1` short-circuits. Documented in SPEC §2.8 and the types guide rather than left implied.

## Tests

Replaces the pinned `nested_tuple_access_requires_parentheses` with six tests: bare/parenthesised agreement, three-deep access, per-level bounds errors, float literals unaffected, `?.` present/`none`/short-circuit, and the formatter round-trip. `crates/keel-codegen/tests/tuples.rs` now uses the bare spelling, so the native backend covers it and still matches the interpreter byte for byte.

`cargo fmt`, `clippy --all-targets --all-features -D warnings`, the full workspace suite, and `mdbook build` are all clean.

## Docs

Limitation note removed from `SPEC.md` §2.8, `docs/src/guide/types.md`, `docs/src/release-notes.md`, and the `[Unreleased]` tuple entry in `CHANGELOG.md`.