### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,19 @@
 
 All notable changes to Keel.
 
-> **Alpha.** Keel is v0.1. Breaking changes are expected between 0.x releases. Do not build production systems on 0.x.
+> **Alpha.** Keel is pre-1.0. Breaking changes are expected between 0.x releases. Do not build production systems on 0.x.
 
 > **Doc-update rule.** Any feature or spec change — added, updated, or removed — must update the docs in the same release. At minimum: `docs/src/release-notes.md` plus every guide page in `docs/src/guide/` (and `docs/src/examples/`, `docs/src/cli/`, `docs/src/config/` where applicable) that the change touches. `SPEC.md` is part of this rule. A release is not shipped until `mdbook build` runs clean over the updated pages.
 
 ## [Unreleased]
 
-%%TAGLINE%% A stdio Debug Adapter Protocol server lets editors like VS Code set breakpoints, step, and inspect variables — including live agent state — in a running Keel program, alongside the native LLVM backend now compiling, linking, and running the full M2 feature set (structs, enums, containers, tuples, nullable, string interpolation, raise/try/catch) byte-for-byte identical to the interpreter.
+%%TAGLINE%% update this line before releasing — one sentence summary of the release
+
+---
+
+## [0.3.0] — 2026-08-06
+
+Step through a running Keel program in any DAP-speaking editor — breakpoints, stepping, and live agent state — with sets that finally deduplicate, tuple positional access, and map/set mutation, while the LLVM backend behind `keel build` grows to compile and run the full M2 feature set byte-for-byte identical to the interpreter.
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1430,11 +1430,11 @@ dependencies = [
 
 [[package]]
 name = "keel-catalog"
-version = "0.2.4"
+version = "0.3.0"
 
 [[package]]
 name = "keel-codegen"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "inkwell",
  "keel-compiler",
@@ -1446,7 +1446,7 @@ dependencies = [
 
 [[package]]
 name = "keel-compiler"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "keel-catalog",
  "keel-syntax",
@@ -1457,7 +1457,7 @@ dependencies = [
 
 [[package]]
 name = "keel-dap"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "keel-compiler",
  "keel-runtime",
@@ -1472,7 +1472,7 @@ dependencies = [
 
 [[package]]
 name = "keel-kir"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "keel-catalog",
  "keel-compiler",
@@ -1481,7 +1481,7 @@ dependencies = [
 
 [[package]]
 name = "keel-lang"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "clap",
  "colored",
@@ -1509,7 +1509,7 @@ dependencies = [
 
 [[package]]
 name = "keel-rt-ffi"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "keel-catalog",
  "keel-runtime",
@@ -1521,7 +1521,7 @@ dependencies = [
 
 [[package]]
 name = "keel-runtime"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "async-imap",
  "async-native-tls",
@@ -1554,7 +1554,7 @@ dependencies = [
 
 [[package]]
 name = "keel-syntax"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "chumsky",
  "logos",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["crates/*", "tools/mdbook-keel-catalog"]
 
 [workspace.package]
-version = "0.2.4"
+version = "0.3.0"
 edition = "2024"
 license = "MIT"
 

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,6 +1,6 @@
 <section class="keel-hero">
   <img class="keel-hero-logo" src="keel-logo.svg" alt="Keel" />
-  <a class="keel-version-pill" href="release-notes.html">v0.2.4 — latest release</a>
+  <a class="keel-version-pill" href="release-notes.html">v0.3.0 — latest release</a>
   <h1 class="keel-hero-title">The Keel Language</h1>
   <p class="keel-hero-tagline">A small, statically-typed language where AI agents are first-class citizens.</p>
   <div class="keel-hero-actions">
@@ -103,7 +103,7 @@ keel run examples/showcase.keel
 
 > **Alpha.** Keel is pre-1.0. Semver is **not** respected between 0.x minor versions, and breaking changes can land in patch releases.
 
-- **0.2.x** — current alpha. One module system (`use std/<name>` and local file imports), deny-by-default `@tools`, built-in `test` blocks.
+- **0.3.x** — current alpha. Debug Adapter Protocol (DAP) support, real sets with deduplication, tuple positional access, map/set mutation, and further progress on the native LLVM backend.
 - **0.x** — further pre-1.0 releases will keep breaking things where the design demands it. The [changelog](./changelog.md) flags every break.
 - **1.0.x** — first API-stable release. Semver begins.
 

--- a/docs/src/release-notes.md
+++ b/docs/src/release-notes.md
@@ -4,6 +4,10 @@
 
 ## Unreleased
 
+---
+
+## v0.3.0 — 2026-08-06
+
 ### A call in a parameter default no longer crashes `keel build`
 
 `keel build --emit=kir` panicked — `no entry found for key`, with no span, no


### PR DESCRIPTION
Release commit for **v0.3.0**. Version-only changes — no source, no tests, no behaviour.

## Why 0.3.0 and not 0.2.5

The cycle contains a genuine breaking change: the `set[T]` rework changes four observable behaviours for existing programs.

- `set[1, 1, 2].count()` is `2`, was `3`
- `typeof(set[1, 2])` is `"set"`, was `"list"`
- a set renders as `set[1, 2, 3]` in interpolation, `to_str()`, and error messages, where it rendered as `[1, 2, 3]` (`io.show` unchanged)
- a set no longer compares equal to a list with the same elements

Under this repo's 0.x convention the minor is the breaking-change lever, as in 0.2.0. The cycle also spans ~30 changelog entries over ~7 weeks — a new CLI verb (`keel dap`) and new crates (`keel-kir`, `keel-codegen`, `keel-rt-ffi`, the conformance harness) — versus 0.2.1–0.2.4, which were four releases inside nine days.

## Contents

| file | change |
|---|---|
| `Cargo.toml`, `Cargo.lock` | 0.2.4 → 0.3.0 across the workspace |
| `CHANGELOG.md` | `[Unreleased]` stamped as `[0.3.0] — 2026-08-06`; fresh `[Unreleased]` with the `%%TAGLINE%%` placeholder restored |
| `docs/src/release-notes.md` | stamped `v0.3.0 — 2026-08-06`; fresh `Unreleased` |
| `docs/src/introduction.md` | version pill → `v0.3.0`; versioning bullet → `0.3.x` |

## Tagline

The `%%TAGLINE%%` line was rewritten before stamping. The previous one led with the native LLVM backend "compiling, linking, and running the full M2 feature set", which over-promises: per `AGENTS.md` → "Native backend status", plain `keel build` still errors, the only working mode is `--emit=kir` on a single file, and nothing in `src/` calls `keel_codegen::compile`. True of the crates and their tests, misleading as the first sentence a user reads — and this line is stamped into the docs landing page.

It now leads with what a user can actually run (`keel dap`, real sets, tuple positional access, map/set mutation) and frames the backend as progress toward `keel build`.

## Verification

`cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, the full workspace suite, `mdbook build`, and the status-consistency tests all pass.

The conformance harness (`--features build-backend`) initially reported a timeout on `arithmetic_and_calls`. It does not reproduce: two isolated runs pass in 32.67s and 32.40s over the 18-fixture corpus. The per-program budget is 20s (`tests/conformance/main.rs:95`) and each program does a full LLVM compile → link → run in a debug build, so the original failure was CPU contention from a concurrent `clippy --all-targets` plus test-suite run, not a codegen regression. Tracked as #205.

## After merge

Tag `v0.3.0` on the merged commit and push the tag — CI creates the GitHub release. Do not run `gh release create`.