### PR TITLE
Codify lambdas as non-capturing, close checker/runtime divergence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,18 @@ All notable changes to Keel.
 
 ## [Unreleased]
 
-%%TAGLINE%% update this line before releasing — one sentence summary of the release
+%%TAGLINE%% Lambdas are now formally non-capturing, closing a check-vs-run soundness gap where a lambda reading an outer variable passed `keel check` and then failed at runtime.
+
+### Fixed
+
+- **A lambda reading an outer local variable passed `keel check` and then failed at `keel run`.** The interpreter's closures have never captured anything — `call_closure_inner` builds a fresh, disconnected environment for every call — but the checker type-checked a lambda body as a nested scope of the enclosing function, so it silently accepted a read of an outer local that would fail at runtime with `Undefined: <name>`. Lambdas are now formally non-capturing (SPEC §7): the checker rejects a lambda body that reads a name bound only in an enclosing local scope, with a diagnostic pointing at the identifier. `self.<field>` access inside a lambda is unaffected — it resolves through ambient per-call agent state, not lexical capture.
+
+```keel
+task main() {
+  n = 10
+  add_n = x => x + n   # now a check error: lambdas do not capture outer variables
+}
+```
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1185,6 +1185,27 @@ scored = emails.map(e => {
 results = emails.map(triage)
 ```
 
+### Lambdas are non-capturing
+
+A lambda body sees only its own parameters, `self` (inside an agent context —
+ambient per-call state, not lexical capture), and global names (tasks, agents,
+imported symbols). It cannot read a local variable declared in an enclosing
+scope, including an enclosing lambda's parameters:
+
+```keel
+n = 10
+add_n = x => x + n        # check error: `n` is declared outside this lambda
+
+outer = x => (y => x + y) # check error: inner lambda can't see `x` either
+
+double = n => n * 2       # fine — `n` here is the lambda's own parameter
+```
+
+To use an outer value inside a lambda, pass it in explicitly — as a parameter,
+or by having the caller supply it as an argument to the function the lambda is
+passed to. Lambdas compile to plain function pointers; there is no captured
+environment to allocate or reference-count.
+
 ### Function types
 
 ```keel

--- a/crates/keel-compiler/src/hir/mod.rs
+++ b/crates/keel-compiler/src/hir/mod.rs
@@ -275,6 +275,11 @@ struct Lowerer<'ast> {
     literal_kinds: HashMap<(usize, usize), LiteralKind>,
     diagnostics: Vec<TypeDiagnostic>,
     scopes: Vec<HashMap<String, SymbolId>>,
+    /// `scopes` indices at which a lambda body begins, innermost last.
+    /// Lambdas are non-capturing (SPEC §7): name resolution inside a lambda
+    /// body only searches `scopes[*lambda_boundaries.last()..]`, never the
+    /// frames belonging to the enclosing function.
+    lambda_boundaries: Vec<usize>,
     aliases: HashMap<String, TypeExpr>,
     structs: HashMap<String, Vec<Field>>,
     top_tasks: HashMap<String, Vec<Param>>,
@@ -295,6 +300,7 @@ impl<'ast> Lowerer<'ast> {
             literal_kinds: HashMap::new(),
             diagnostics: Vec::new(),
             scopes: vec![HashMap::new()],
+            lambda_boundaries: Vec::new(),
             aliases: HashMap::new(),
             structs: HashMap::new(),
             top_tasks: HashMap::new(),
@@ -854,6 +860,7 @@ impl<'ast> Lowerer<'ast> {
                 self.lower_when_arms(arms, expected);
             }
             crate::ast::Expr::Lambda { params, body } => {
+                self.lambda_boundaries.push(self.scopes.len());
                 self.push_scope();
                 for param in params {
                     self.define_local(&param.name, expr.span.clone());
@@ -863,6 +870,7 @@ impl<'ast> Lowerer<'ast> {
                     LambdaBody::Block(block) => self.lower_block(block, None),
                 }
                 self.pop_scope();
+                self.lambda_boundaries.pop();
             }
             crate::ast::Expr::Index { object, index } => {
                 self.lower_expr(object, None);
@@ -1004,8 +1012,11 @@ impl<'ast> Lowerer<'ast> {
         span: Span,
         emit_diagnostic: bool,
     ) -> Resolution {
-        let resolution = self
-            .scopes
+        // Lambdas are non-capturing: a name lookup started inside a lambda
+        // body may only see frames pushed at or after the lambda's own
+        // boundary, never the enclosing function's locals.
+        let boundary = self.lambda_boundaries.last().copied().unwrap_or(0);
+        let resolution = self.scopes[boundary..]
             .iter()
             .rev()
             .find_map(|scope| scope.get(name).copied())
@@ -1020,14 +1031,28 @@ impl<'ast> Lowerer<'ast> {
                     .unwrap_or(Resolution::UNRESOLVED)
             });
         if emit_diagnostic && matches!(resolution.kind, NameKind::Unresolved) {
-            match legacy_ambient_hint(name) {
-                Some(hint) => self
-                    .diagnostics
-                    .push(TypeDiagnostic::other(hint, span.clone())),
-                None => self.diagnostics.push(TypeDiagnostic::UndefinedName {
-                    name: name.to_string(),
-                    span: span.clone(),
-                }),
+            let outer_local = boundary > 0
+                && self.scopes[..boundary]
+                    .iter()
+                    .any(|scope| scope.contains_key(name));
+            if outer_local {
+                self.diagnostics.push(TypeDiagnostic::other(
+                    format!(
+                        "lambdas do not capture outer variables — `{name}` is declared \
+                         outside this lambda; pass it as a parameter instead"
+                    ),
+                    span.clone(),
+                ));
+            } else {
+                match legacy_ambient_hint(name) {
+                    Some(hint) => self
+                        .diagnostics
+                        .push(TypeDiagnostic::other(hint, span.clone())),
+                    None => self.diagnostics.push(TypeDiagnostic::UndefinedName {
+                        name: name.to_string(),
+                        span: span.clone(),
+                    }),
+                }
             }
         }
         self.references.insert(span_key(&span), resolution);

--- a/crates/keel-compiler/src/types/checker/expr.rs
+++ b/crates/keel-compiler/src/types/checker/expr.rs
@@ -1153,7 +1153,7 @@ impl Checker<'_, '_> {
             }
 
             Expr::Lambda { params, body } => {
-                scope.push();
+                scope.push_lambda();
                 for p in params {
                     // Unannotated lambda parameters — type inference is not yet
                     // implemented; bind as InferenceLimitation to avoid cascade errors.
@@ -1179,7 +1179,7 @@ impl Checker<'_, '_> {
                         last
                     }
                 };
-                scope.pop();
+                scope.pop_lambda();
                 Ty::Func(
                     params
                         .iter()

--- a/crates/keel-compiler/src/types/scope.rs
+++ b/crates/keel-compiler/src/types/scope.rs
@@ -11,12 +11,17 @@ use crate::types::ty::Ty;
 /// Chained lexical scope: newer scopes on the back of the vec.
 pub(crate) struct Scope {
     pub(crate) frames: Vec<HashMap<String, Ty>>,
+    /// `frames` indices at which a lambda body begins, innermost last.
+    /// Lambdas are non-capturing (mirrors the HIR lowerer's identical
+    /// restriction): [`Scope::get`] never looks below the innermost boundary.
+    lambda_boundaries: Vec<usize>,
 }
 
 impl Scope {
     pub(crate) fn new() -> Self {
         Scope {
             frames: vec![HashMap::new()],
+            lambda_boundaries: Vec::new(),
         }
     }
 
@@ -30,6 +35,19 @@ impl Scope {
         }
     }
 
+    /// Enter a lambda body: like [`Scope::push`], but also records a
+    /// capture boundary so [`Scope::get`] stops at this frame.
+    pub(crate) fn push_lambda(&mut self) {
+        self.lambda_boundaries.push(self.frames.len());
+        self.push();
+    }
+
+    /// Leave a lambda body pushed by [`Scope::push_lambda`].
+    pub(crate) fn pop_lambda(&mut self) {
+        self.pop();
+        self.lambda_boundaries.pop();
+    }
+
     pub(crate) fn define(&mut self, name: String, ty: Ty) {
         if let Some(f) = self.frames.last_mut() {
             f.insert(name, ty);
@@ -37,7 +55,8 @@ impl Scope {
     }
 
     pub(crate) fn get(&self, name: &str) -> Option<&Ty> {
-        for f in self.frames.iter().rev() {
+        let boundary = self.lambda_boundaries.last().copied().unwrap_or(0);
+        for f in self.frames[boundary..].iter().rev() {
             if let Some(t) = f.get(name) {
                 return Some(t);
             }

--- a/docs/src/guide/collections.md
+++ b/docs/src/guide/collections.md
@@ -53,6 +53,14 @@ more = all.push("e")            # ["a", "b", "c", "d", "e"]
 
 All methods accept lambdas (`x => expr`) or task references.
 
+> **Lambdas don't capture outer variables.** A lambda body can only see its
+> own parameters and global names (tasks, agents, `self` inside an agent). It
+> cannot read a local declared outside it — `n = 10; xs.map(x => x + n)` is a
+> check error. Pass the value in another way instead, e.g. as a second
+> parameter via a named task: `xs.map(add_n)` where `add_n(x: int) -> int`
+> closes over nothing and takes everything it needs as arguments. See
+> [SPEC §7](https://github.com/keel-lang/keel/blob/main/SPEC.md#7-lambdas-and-first-class-functions).
+
 ### map — transform each element
 
 ```keel

--- a/docs/src/release-notes.md
+++ b/docs/src/release-notes.md
@@ -4,6 +4,24 @@
 
 ## Unreleased
 
+### A lambda reading an outer variable no longer passes `keel check`
+
+Closures have never captured anything at runtime — every lambda call built a
+fresh, disconnected environment — but the checker type-checked a lambda body
+as a nested scope of its enclosing function, so it silently accepted a read
+of an outer local that then failed at `keel run` with `Undefined: <name>`.
+Lambdas are now formally non-capturing: the checker rejects a lambda body
+that reads a name bound only in an enclosing local scope, pointing at the
+identifier. `self.<field>` access inside a lambda is unaffected — it
+resolves through ambient per-call agent state, not lexical capture.
+
+```keel
+task main() {
+  n = 10
+  add_n = x => x + n   # now a check error: lambdas do not capture outer variables
+}
+```
+
 ---
 
 ## v0.3.0 — 2026-08-06

--- a/tests/integration/language/lambdas.rs
+++ b/tests/integration/language/lambdas.rs
@@ -1,0 +1,118 @@
+use crate::common::*;
+
+// ---------------------------------------------------------------------------
+// Lambdas are non-capturing (issue #208)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn lambda_reading_outer_local_is_a_check_error() {
+    let src = r#"
+use std/io
+
+task main() {
+  n = 10
+  add_n = x => x + n
+  io.show("{add_n(5)}")
+}
+
+main()
+"#;
+    let (ok, _stdout, stderr) = check_inline_output(src);
+    assert!(!ok, "expected a check error for capturing an outer local");
+    assert!(
+        stderr.contains("do not capture"),
+        "expected a non-capturing-lambda diagnostic:\n{stderr}"
+    );
+}
+
+#[test]
+fn augmented_assign_to_outer_local_inside_lambda_is_a_check_error() {
+    let src = r#"
+task main() {
+  n = 10
+  f = () => { n += 1 }
+  f()
+}
+
+main()
+"#;
+    let (ok, _stdout, stderr) = check_inline_output(src);
+    assert!(
+        !ok,
+        "expected a check error for mutating an outer local from a lambda"
+    );
+    assert!(
+        stderr.contains("undefined variable"),
+        "expected an undefined-variable diagnostic:\n{stderr}"
+    );
+}
+
+#[test]
+fn nested_lambda_cannot_capture_outer_lambdas_param() {
+    let src = r#"
+use std/io
+
+task main() {
+  outer = x => (y => x + y)
+  io.show("done")
+}
+
+main()
+"#;
+    let (ok, _stdout, stderr) = check_inline_output(src);
+    assert!(
+        !ok,
+        "expected a check error: inner lambda cannot see outer lambda's param"
+    );
+    assert!(
+        stderr.contains("do not capture"),
+        "expected a non-capturing-lambda diagnostic:\n{stderr}"
+    );
+}
+
+#[test]
+fn lambda_can_reference_its_own_param_and_global_task() {
+    let src = r#"
+use std/io
+
+task score(x: int) -> int {
+  x * 2
+}
+
+task main() {
+  f = x => score(x) + x
+  io.show("{f(5)}")
+}
+
+main()
+"#;
+    let (ok, _stdout, stderr) = check_inline_output(src);
+    assert!(ok, "expected clean check:\n{stderr}");
+}
+
+#[test]
+fn self_access_inside_lambda_still_works() {
+    let src = r#"
+use std/io
+
+agent SelfInLambda {
+  @tools [io]
+  state {
+    count: int = 0
+  }
+  @on_start {
+    self.count = 5
+    f = () => io.show("count is {self.count}")
+    f()
+  }
+}
+
+run(SelfInLambda)
+"#;
+    let (ok, stdout, stderr) = run_inline(src, false);
+    assert!(ok, "expected clean run:\n{stderr}");
+    assert!(
+        stdout.contains("count is 5"),
+        "expected self access to resolve via ambient agent state:\n{stdout}"
+    );
+}

--- a/tests/integration/language/mod.rs
+++ b/tests/integration/language/mod.rs
@@ -2,6 +2,7 @@ mod builtin_interfaces;
 mod control_flow;
 mod errors;
 mod interfaces;
+mod lambdas;
 mod lists;
 mod loops;
 mod maps;


### PR DESCRIPTION
## Summary

- Lambdas capture nothing at runtime (`call_closure_inner` has always built a fresh, disconnected `Environment`), but the checker type-checked a lambda body as a nested scope of the enclosing function — so a lambda reading an outer local passed `keel check` and then failed at `keel run` with `Undefined: <name>`.
- HIR name resolution and the type checker's scope now both track a lambda's capture boundary and reject a read of an outer local at check time, with a diagnostic pointing at the identifier. `self.<field>` access inside a lambda is unaffected — it resolves through ambient per-call agent state, not lexical capture (verified).
- SPEC §7 codifies the rule; CHANGELOG, release notes, and the collections guide page are updated.

## Test plan

- [x] `cargo test -q` (workspace) — all green, +5 new tests in `tests/integration/language/lambdas.rs`
- [x] `cargo clippy --all-targets -q -- -D warnings` — clean
- [x] `mdbook build` over `docs/` — clean
- [x] Every `examples/*.keel` still checks clean
- [x] `keel run` on the original divergence repro now surfaces the checker diagnostic instead of the old raw `Undefined: n`

Close #208