### PR TITLE
Fix native backend miscompile on scalar-returning namespace calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to Keel.
 
 ## [Unreleased]
 
-%%TAGLINE%% Lambdas are now formally non-capturing, closing a check-vs-run soundness gap where a lambda reading an outer variable passed `keel check` and then failed at runtime.
+%%TAGLINE%% Lambdas are now formally non-capturing, closing a check-vs-run soundness gap, and the LLVM backend gains full-type namespace-call results toward M3.
 
 ### Fixed
 
@@ -19,6 +19,15 @@ task main() {
   n = 10
   add_n = x => x + n   # now a check error: lambdas do not capture outer variables
 }
+```
+
+- **The native backend miscompiled any namespace call with a non-`Unit` result used as a value.** `emit_ns_call` (`keel-codegen`) was written for M1's `io.show`/`log.*`-only namespace calls and unconditionally returned a hardcoded `i1 false`, discarding the real `KeelRes` payload — but nothing in `keel-kir`'s lowering ever restricted `CallTarget::Ns` to `Unit` results, so a scalar-returning stdlib call (`math.sqrt`, `crypto.sha256`, …) used in value position passed lowering and then panicked codegen on a type mismatch. It now unboxes the payload to the call's real result type, matching the interpreter:
+
+```keel
+use std/math
+use std/io
+
+io.show("{math.sqrt(4.0)}")   # now compiles and runs — was a codegen panic
 ```
 
 ---

--- a/crates/keel-codegen/src/expr.rs
+++ b/crates/keel-codegen/src/expr.rs
@@ -223,7 +223,7 @@ fn emit_call<'ctx>(
     let func_id = match target {
         CallTarget::Fn(id) => id,
         CallTarget::Ns { ns_id, method_id } => {
-            return crate::ns_call::emit_ns_call(fcx, ns_id, method_id, args, span);
+            return crate::ns_call::emit_ns_call(fcx, ns_id, method_id, args, ty, span);
         }
         CallTarget::Rt(rt_fn) => return crate::rt_call::emit_rt_call(fcx, rt_fn, args, ty),
     };

--- a/crates/keel-codegen/src/ns_call.rs
+++ b/crates/keel-codegen/src/ns_call.rs
@@ -7,10 +7,26 @@
 //! ABI shapes byte-for-byte identical to `keel-rt-ffi`'s `#[repr(C)]`
 //! definitions (`abi::keel_box_*`, `ns_dispatch::KeelRes`).
 //!
-//! M1 only wires `Unit`-returning methods (`io.show`, `log.*` — enforced by
-//! `keel-kir` rejecting any other result type for now), so the returned
-//! `KeelRes` is built with the right calling convention but never inspected:
-//! there is no `try`/`catch` lowering yet to branch on `is_err`.
+//! A non-`Unit`-returning method's `KeelRes` payload (a boxed `*const
+//! Value`) is unboxed to the call's declared `KirType` via
+//! `rt_call::unbox_value` on the way out — `Unit`-returning methods
+//! (`io.show`, `log.*`) skip that step, same as a void `CallTarget::Fn`
+//! call. `keel-kir`'s `result_ty_to_kir` (`lower/expr.rs`) rejects any
+//! catalog result other than `Unit`/`Int`/`Float`/`Bool`/`Str` at lowering
+//! time — `Nullable`/`Uuid`/`Dynamic`/list-shaped results all need Value
+//! marshaling that doesn't exist yet — so those are the only `KirType`s
+//! `unbox_value` ever has to handle here; its `Struct`/`Enum`/`Nullable`/
+//! `Tuple` error arms are unreachable from this call site.
+//!
+//! There is no `try`/`catch` lowering yet for `CallTarget::Ns`, so `is_err`
+//! is not branched on (`raise.rs`): a namespace method that raises still
+//! unboxes `payload`, which `keel_rt_call_ns` always sets to a boxed
+//! `Value::String(report.to_string())` on the error path (`ns_dispatch.rs`)
+//! — never null. Unboxing it against a non-`Str` result type therefore hits
+//! `keel_unbox_*`'s own `unreachable!()` variant check (a clean panic, not
+//! UB), not a crash on a dangling pointer. Wiring the error path into
+//! Keel-level `raise`/`try`/`catch` is a later M3 concern tracked
+//! separately from this issue.
 
 use inkwell::AddressSpace;
 use inkwell::module::Module;
@@ -169,6 +185,7 @@ pub(crate) fn emit_ns_call<'ctx>(
     ns_id: u16,
     method_id: u16,
     args: &[Expr],
+    ty: KirType,
     span_id: u32,
 ) -> Result<BasicValueEnum<'ctx>, CodegenError> {
     let ptr_type = fcx.context.ptr_type(AddressSpace::default());
@@ -242,7 +259,8 @@ pub(crate) fn emit_ns_call<'ctx>(
         )
     });
 
-    fcx.builder
+    let call = fcx
+        .builder
         .build_call(
             keel_rt_call_ns,
             &[
@@ -257,8 +275,20 @@ pub(crate) fn emit_ns_call<'ctx>(
         )
         .map_err(llvm_err)?;
 
-    // M1 only wires Unit-returning methods (enforced by keel-kir's
-    // lower_ns_call), so the caller (expr::emit_call) never inspects this —
-    // same convention as a CallTarget::Fn void call.
-    Ok(fcx.context.bool_type().const_zero().into())
+    if matches!(ty, KirType::Unit) {
+        // No caller ever inspects a Unit-typed result (same convention as a
+        // void CallTarget::Fn call) — skip extracting/unboxing the payload.
+        return Ok(fcx.context.bool_type().const_zero().into());
+    }
+
+    let res = match call.try_as_basic_value() {
+        ValueKind::Basic(v) => v.into_struct_value(),
+        ValueKind::Instruction(_) => unreachable!("keel_rt_call_ns returns KeelRes, never void"),
+    };
+    let payload = fcx
+        .builder
+        .build_extract_value(res, 1, "ns_call.payload")
+        .map_err(llvm_err)?
+        .into_pointer_value();
+    crate::rt_call::unbox_value(fcx, payload, ty)
 }

--- a/crates/keel-codegen/tests/namespace_calls.rs
+++ b/crates/keel-codegen/tests/namespace_calls.rs
@@ -61,6 +61,56 @@ fn log_info_matches_the_interpreter_byte_for_byte() {
     );
 }
 
+// Part of #114: a namespace method with a non-`Unit` `Fixed` result (most of
+// the catalog — `math.*`, `crypto.*`, …) used to reach codegen and get a
+// hardcoded `bool_type().const_zero()` back regardless of its real type,
+// because `emit_ns_call` assumed only `io.show`/`log.*`-shaped `Unit` calls
+// ever landed in value position. `keel-kir` never restricted `CallTarget::Ns`
+// to `Unit` results, so this was a live, untested type mismatch that panicked
+// codegen (a float-typed use got handed an `i1`) the moment a scalar-typed
+// namespace call was actually consumed as a value — as opposed to called for
+// its side effect and discarded, the only shape previously under test.
+
+#[test]
+fn float_returning_ns_call_matches_the_interpreter_byte_for_byte() {
+    let source = "use std/math\nuse std/io\n\nio.show(\"{math.sqrt(4.0)}\")\n";
+
+    let compiled = compile_and_run(source);
+    let interpreted = support::run_interpreter(source);
+
+    assert_eq!(
+        String::from_utf8_lossy(&compiled.stdout),
+        String::from_utf8_lossy(&interpreted.stdout),
+        "compiled stdout must match the interpreter's"
+    );
+    assert!(
+        compiled.stdout.ends_with(b"2\n"),
+        "expected math.sqrt(4.0) to unbox to a float, got: {:?}",
+        String::from_utf8_lossy(&compiled.stdout)
+    );
+}
+
+#[test]
+fn str_returning_ns_call_matches_the_interpreter_byte_for_byte() {
+    let source = "use std/crypto\nuse std/io\n\nio.show(crypto.sha256(\"keel\"))\n";
+
+    let compiled = compile_and_run(source);
+    let interpreted = support::run_interpreter(source);
+
+    assert_eq!(
+        String::from_utf8_lossy(&compiled.stdout),
+        String::from_utf8_lossy(&interpreted.stdout),
+        "compiled stdout must match the interpreter's"
+    );
+    assert!(
+        compiled
+            .stdout
+            .ends_with(b"d6dba7e8a54d32d2cf8eef5b0e648c5c388079827039a1e56a9bfb282fc883ab\n"),
+        "expected crypto.sha256 to unbox to a str, got: {:?}",
+        String::from_utf8_lossy(&compiled.stdout)
+    );
+}
+
 #[test]
 fn multiple_namespace_calls_in_one_program_all_run() {
     let source = "use std/io\nuse std/log\n\nio.show(\"hello\")\nlog.info(\"started\")\n";

--- a/docs/src/release-notes.md
+++ b/docs/src/release-notes.md
@@ -22,6 +22,23 @@ task main() {
 }
 ```
 
+### The native backend no longer miscompiles a scalar-returning namespace call
+
+`emit_ns_call` was written for M1's `io.show`/`log.*`-only calls and always
+returned a hardcoded `i1 false`, discarding the real result — but nothing in
+`keel-kir`'s lowering restricted `CallTarget::Ns` to `Unit` results, so a
+scalar-returning stdlib call (`math.sqrt`, `crypto.sha256`, …) used as a
+value passed lowering and then panicked codegen on a type mismatch. It now
+unboxes the namespace call's payload to its real result type, matching the
+interpreter:
+
+```keel
+use std/math
+use std/io
+
+io.show("{math.sqrt(4.0)}")   # now compiles and runs — was a codegen panic
+```
+
 ---
 
 ## v0.3.0 — 2026-08-06


### PR DESCRIPTION
## Summary

- `emit_ns_call` (`crates/keel-codegen/src/ns_call.rs`) was written for M1's `io.show`/`log.*`-only namespace calls and unconditionally returned a hardcoded `i1 false`, discarding the real `KeelRes` payload.
- Nothing in `keel-kir`'s lowering restricted `CallTarget::Ns` to `Unit` results, so a scalar-returning stdlib call (`math.sqrt`, `crypto.sha256`, …) used in value position passed lowering cleanly and then panicked codegen with a type mismatch the moment it reached LLVM — a live, previously-untested bug.
- It now unboxes the `KeelRes` payload to the call's real result type via the existing `rt_call::unbox_value` helper, matching the interpreter byte-for-byte.
- `keel-kir`'s `result_ty_to_kir` already rejects any catalog result other than `Unit`/`Int`/`Float`/`Bool`/`Str` at lowering time, so this covers every result shape that can currently reach codegen — `Nullable`/`Uuid`/`Dynamic`/list-shaped results still need a later Value-marshaling pass before they lower at all (documented in the updated module doc comment).

Part of #114 (M3: full stdlib dispatch, lambdas, generics, dynamic) — the milestone's remaining open issue; this is one slice of it, not the whole thing.

## Test plan

- [x] Reproduced the panic pre-fix: `math.sqrt(4.0)` used in `io.show("{...}")` compiled through KIR lowering cleanly, then panicked codegen with `Found IntValue ... but expected the FloatValue variant`.
- [x] Added `crates/keel-codegen/tests/namespace_calls.rs` coverage for a float-returning call (`math.sqrt`) and a str-returning call (`crypto.sha256`), both asserting byte-identical output against the interpreter.
- [x] `cargo test -q -p keel-codegen` — all 43 tests pass
- [x] `cargo test -q` (workspace default) — all green (unaffected, keel-codegen is gated behind `build-backend`)
- [x] `cargo clippy --workspace --all-targets -q -- -D warnings` — clean
- [x] `mdbook build` over `docs/` — clean