### PR TITLE
Compile str value methods in the native backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,18 @@ All notable changes to Keel.
 
 ## [Unreleased]
 
-%%TAGLINE%% Lambdas are now formally non-capturing, closing a check-vs-run soundness gap, and the LLVM backend gains full-type namespace-call results toward M3.
+%%TAGLINE%% The LLVM backend closes the gap on stdlib calls and string methods, and lambdas get formal non-capturing semantics.
+
+### Added
+
+- **The native backend compiles `str` value methods** (`s.upper()`, `s.contains(x)`, `s.length()`, `s.is_empty()`, `s.lower()`, `s.trim()`/`.strip()`, `s.starts_with(x)`, `s.ends_with(x)`, `s.replace(a, b)`) — previously rejected outright by `keel build --emit=kir` with a generic "method call" error, even though `keel check`/`keel run` supported them. A new `keel_rt_call_value_method` FFI entry point dispatches through the exact same `call_method_on_value` match arms the interpreter uses (issue #213), so the compiled and interpreted paths can't drift. Closure-taking methods (`.map`/`.filter`/…) and non-`str` receivers still aren't lowered — that needs lambdas as values first (#114):
+
+```keel
+use std/io
+
+io.show("keel".upper())               # KEEL — now compiles
+io.show("{"hello world".contains("world")}")  # true — now compiles
+```
 
 ### Fixed
 

--- a/crates/keel-codegen/src/expr.rs
+++ b/crates/keel-codegen/src/expr.rs
@@ -57,7 +57,7 @@ pub(crate) fn emit_expr<'ctx>(
             args,
             ty,
             span,
-        } => emit_call(fcx, *target, args, *ty, *span),
+        } => emit_call(fcx, target.clone(), args, *ty, *span),
         Expr::MakeStruct { struct_id, fields } => emit_make_struct(fcx, *struct_id, fields),
         Expr::FieldGet {
             base,
@@ -226,6 +226,9 @@ fn emit_call<'ctx>(
             return crate::ns_call::emit_ns_call(fcx, ns_id, method_id, args, ty, span);
         }
         CallTarget::Rt(rt_fn) => return crate::rt_call::emit_rt_call(fcx, rt_fn, args, ty),
+        CallTarget::ValueMethod { method } => {
+            return crate::value_call::emit_value_method_call(fcx, &method, args, ty, span);
+        }
     };
     let callee = fcx.functions[func_id]
         .expect("declare_functions declares every non-toplevel FuncId before any body is emitted");

--- a/crates/keel-codegen/src/lib.rs
+++ b/crates/keel-codegen/src/lib.rs
@@ -25,6 +25,7 @@ mod nullable;
 mod raise;
 mod rt_call;
 mod stmt;
+mod value_call;
 
 use std::path::PathBuf;
 

--- a/crates/keel-codegen/src/value_call.rs
+++ b/crates/keel-codegen/src/value_call.rs
@@ -1,0 +1,161 @@
+//! `CallTarget::ValueMethod` codegen (issue #214): structurally identical to
+//! `ns_call.rs`'s `emit_ns_call` — box every argument, call the one generic
+//! runtime dispatch entry point, unbox the result — except the receiver is
+//! boxed and passed separately, and dispatch goes by method *name* (embedded
+//! as a NUL-terminated C string constant) rather than a numeric
+//! `ns_id`/`method_id` pair, since value methods aren't in the
+//! `keel-catalog` namespace registry.
+
+use inkwell::AddressSpace;
+use inkwell::values::{BasicValueEnum, ValueKind};
+
+use keel_kir::ir::Expr;
+use keel_kir::types::KirType;
+
+use crate::CodegenError;
+use crate::func::FuncCtx;
+use crate::ns_call::{declare_or_get, emit_box_arg};
+
+fn llvm_err(e: impl std::fmt::Display) -> CodegenError {
+    CodegenError::Llvm(e.to_string())
+}
+
+/// Embeds `s` as a NUL-terminated C string constant and returns a pointer to
+/// it — the `*const c_char` shape `keel_rt_call_value_method`'s `method`
+/// parameter expects, distinct from `ns_call::emit_box_str_const`'s boxed
+/// `Value::String` (a `KeelBox`, not a bare C string).
+fn emit_cstr_const<'ctx>(
+    fcx: &FuncCtx<'ctx, '_>,
+    s: &str,
+) -> Result<inkwell::values::PointerValue<'ctx>, CodegenError> {
+    let const_arr = fcx.context.const_string(s.as_bytes(), true);
+    let arr_ty = fcx.context.i8_type().array_type(s.len() as u32 + 1);
+
+    // Every call site adds a global under the same base name ("method_name")
+    // regardless of which method it names — LLVM auto-uniquifies same-named
+    // globals with *different* initializers (appends `.N`), so two distinct
+    // method names never collide into one buffer; only two call sites naming
+    // the *same* method could ever share a global, which is safe since their
+    // content is identical. Verified end to end by
+    // `value_method_calls.rs`'s `distinct_method_name_constants_do_not_collide`.
+    let global = fcx.module.add_global(arr_ty, None, "method_name");
+    global.set_initializer(&const_arr);
+    global.set_constant(true);
+    Ok(global.as_pointer_value())
+}
+
+/// Emits a `CallTarget::ValueMethod { method }` call site. `args[0]` is the
+/// receiver (boxed separately from the rest, matching
+/// `keel_rt_call_value_method`'s signature); `args[1..]` are the method's
+/// own arguments.
+pub(crate) fn emit_value_method_call<'ctx>(
+    fcx: &FuncCtx<'ctx, '_>,
+    method: &str,
+    args: &[Expr],
+    ty: KirType,
+    span_id: u32,
+) -> Result<BasicValueEnum<'ctx>, CodegenError> {
+    let ptr_type = fcx.context.ptr_type(AddressSpace::default());
+    let i32_type = fcx.context.i32_type();
+
+    let [receiver, rest @ ..] = args else {
+        unreachable!("verified KIR: CallTarget::ValueMethod always has a receiver in args[0]");
+    };
+    let receiver_ptr = emit_box_arg(fcx, receiver)?;
+    let method_ptr = emit_cstr_const(fcx, method)?;
+
+    let boxed: Vec<_> = rest
+        .iter()
+        .map(|arg| emit_box_arg(fcx, arg))
+        .collect::<Result<_, _>>()?;
+
+    let nargs = u32::try_from(boxed.len()).expect("KIR call arg count fits u32");
+    let array_ty = ptr_type.array_type(nargs.max(1));
+    let args_alloca = fcx
+        .builder
+        .build_alloca(array_ty, "vm_args")
+        .map_err(llvm_err)?;
+    let names_alloca = fcx
+        .builder
+        .build_alloca(array_ty, "vm_arg_names")
+        .map_err(llvm_err)?;
+
+    for (i, ptr) in boxed.iter().enumerate() {
+        let idx = i32_type.const_int(i as u64, false);
+        // SAFETY: `idx` is always in bounds — it ranges over `boxed`, whose
+        // length is exactly `array_ty`'s element count (or less, when the
+        // `.max(1)` padding above allocated one unused slot for `nargs == 0`).
+        let slot = unsafe {
+            fcx.builder
+                .build_gep(
+                    array_ty,
+                    args_alloca,
+                    &[i32_type.const_zero(), idx],
+                    "arg_slot",
+                )
+                .map_err(llvm_err)?
+        };
+        fcx.builder.build_store(slot, *ptr).map_err(llvm_err)?;
+
+        // SAFETY: see above.
+        let name_slot = unsafe {
+            fcx.builder
+                .build_gep(
+                    array_ty,
+                    names_alloca,
+                    &[i32_type.const_zero(), idx],
+                    "name_slot",
+                )
+                .map_err(llvm_err)?
+        };
+        fcx.builder
+            .build_store(name_slot, ptr_type.const_null())
+            .map_err(llvm_err)?;
+    }
+
+    let keel_res_ty = fcx
+        .context
+        .struct_type(&[fcx.context.i8_type().into(), ptr_type.into()], false);
+    let keel_rt_call_value_method = declare_or_get(fcx.module, "keel_rt_call_value_method", || {
+        keel_res_ty.fn_type(
+            &[
+                ptr_type.into(),
+                ptr_type.into(),
+                ptr_type.into(),
+                ptr_type.into(),
+                i32_type.into(),
+                i32_type.into(),
+            ],
+            false,
+        )
+    });
+
+    let call = fcx
+        .builder
+        .build_call(
+            keel_rt_call_value_method,
+            &[
+                receiver_ptr.into(),
+                method_ptr.into(),
+                args_alloca.into(),
+                names_alloca.into(),
+                i32_type.const_int(u64::from(nargs), false).into(),
+                i32_type.const_int(u64::from(span_id), false).into(),
+            ],
+            "value_method_call",
+        )
+        .map_err(llvm_err)?;
+
+    let res = match call.try_as_basic_value() {
+        ValueKind::Basic(v) => v.into_struct_value(),
+        ValueKind::Instruction(_) => {
+            unreachable!("keel_rt_call_value_method returns KeelRes, never void")
+        }
+    };
+    let payload = fcx
+        .builder
+        .build_extract_value(res, 1, "value_method_call.payload")
+        .map_err(llvm_err)?
+        .into_pointer_value();
+    crate::rt_call::unbox_value(fcx, payload, ty)
+}

--- a/crates/keel-codegen/tests/value_method_calls.rs
+++ b/crates/keel-codegen/tests/value_method_calls.rs
@@ -1,0 +1,116 @@
+//! Exit criterion for issue #214: a compiled program calling a `str`
+//! value method produces byte-identical output to the interpreter running
+//! the same source — proving `CallTarget::ValueMethod` codegen reaches the
+//! exact same `call_method_on_value` match arms via
+//! `keel_rt_call_value_method`/`CompiledHost`, not a separately-written
+//! compiled-path reimplementation that could drift. Mirrors
+//! `namespace_calls.rs`'s shape.
+
+use std::process::Command;
+
+use keel_codegen::BuildOptions;
+
+#[path = "support/mod.rs"]
+mod support;
+
+fn compile_and_run(source: &str) -> std::process::Output {
+    let kir = support::parse_check_and_lower(source);
+
+    let out_dir = tempfile::tempdir().expect("create temp out dir");
+    let opts = BuildOptions {
+        out_dir: out_dir.path().to_path_buf(),
+        runtime_link_args: support::runtime_link_args().clone(),
+    };
+    let bin = keel_codegen::compile(&kir, &opts).expect("compile must succeed");
+    Command::new(&bin).output().expect("run compiled binary")
+}
+
+#[test]
+fn str_upper_matches_the_interpreter_byte_for_byte() {
+    let source = "use std/io\n\nio.show(\"keel\".upper())\n";
+
+    let compiled = compile_and_run(source);
+    let interpreted = support::run_interpreter(source);
+
+    assert_eq!(
+        String::from_utf8_lossy(&compiled.stdout),
+        String::from_utf8_lossy(&interpreted.stdout),
+        "compiled stdout must match the interpreter's"
+    );
+    assert!(
+        compiled.stdout.ends_with(b"KEEL\n"),
+        "expected str.upper()'s output on stdout, got: {:?}",
+        String::from_utf8_lossy(&compiled.stdout)
+    );
+}
+
+#[test]
+fn str_contains_with_an_argument_matches_the_interpreter_byte_for_byte() {
+    let source = "use std/io\n\nio.show(\"{\"hello world\".contains(\"world\")}\")\n";
+
+    let compiled = compile_and_run(source);
+    let interpreted = support::run_interpreter(source);
+
+    assert_eq!(
+        String::from_utf8_lossy(&compiled.stdout),
+        String::from_utf8_lossy(&interpreted.stdout),
+        "compiled stdout must match the interpreter's"
+    );
+    assert!(
+        compiled.stdout.ends_with(b"true\n"),
+        "expected str.contains(...)'s output on stdout, got: {:?}",
+        String::from_utf8_lossy(&compiled.stdout)
+    );
+}
+
+#[test]
+fn str_length_matches_the_interpreter_byte_for_byte() {
+    let source = "use std/io\n\nio.show(\"{\"hello\".length()}\")\n";
+
+    let compiled = compile_and_run(source);
+    let interpreted = support::run_interpreter(source);
+
+    assert_eq!(
+        String::from_utf8_lossy(&compiled.stdout),
+        String::from_utf8_lossy(&interpreted.stdout),
+        "compiled stdout must match the interpreter's"
+    );
+    assert!(
+        compiled.stdout.ends_with(b"5\n"),
+        "expected str.length()'s output on stdout, got: {:?}",
+        String::from_utf8_lossy(&compiled.stdout)
+    );
+}
+
+#[test]
+fn multiple_str_method_calls_in_one_program_all_run() {
+    let source = "use std/io\n\nio.show(\"a\".upper())\nio.show(\"{\"b\".is_empty()}\")\n";
+
+    let compiled = compile_and_run(source);
+    let interpreted = support::run_interpreter(source);
+
+    assert_eq!(
+        String::from_utf8_lossy(&compiled.stdout),
+        String::from_utf8_lossy(&interpreted.stdout)
+    );
+}
+
+#[test]
+fn distinct_method_name_constants_do_not_collide() {
+    // Two different method-name globals (`emit_cstr_const`'s "method_name"
+    // symbol, auto-uniquified by LLVM) in one program — pins that each call
+    // site's global keeps its own content rather than one shadowing the
+    // other, which would surface as a wrong dispatch, not a compile error.
+    let source = "use std/io\n\nio.show(\"keel\".upper())\nio.show(\"{\"keel\".length()}\")\n";
+
+    let compiled = compile_and_run(source);
+    let interpreted = support::run_interpreter(source);
+
+    assert_eq!(
+        String::from_utf8_lossy(&compiled.stdout),
+        String::from_utf8_lossy(&interpreted.stdout)
+    );
+    let out = String::from_utf8_lossy(&compiled.stdout);
+    assert!(out.contains("KEEL"), "expected KEEL in output: {out}");
+    assert!(out.contains('4'), "expected 4 in output: {out}");
+}

--- a/crates/keel-kir/src/dump.rs
+++ b/crates/keel-kir/src/dump.rs
@@ -242,7 +242,7 @@ fn fmt_expr(program: &KirProgram, func: &KirFunction, expr: &Expr) -> String {
             format!("({}{})", unop_symbol(*op), fmt_expr(program, func, operand))
         }
         Expr::Call { target, args, .. } => {
-            let name = call_target_name(program, *target);
+            let name = call_target_name(program, target.clone());
             let args = args
                 .iter()
                 .map(|a| fmt_expr(program, func, a))
@@ -342,6 +342,7 @@ fn call_target_name(program: &KirProgram, target: CallTarget) -> String {
             .map(|m| format!("{}.{}", m.namespace, m.name))
             .unwrap_or_else(|| format!("ns#{ns_id}.method#{method_id}")),
         CallTarget::Rt(rt_fn) => format!("rt.{}", rt_fn_name(rt_fn)),
+        CallTarget::ValueMethod { method } => format!(".{method}"),
     }
 }
 

--- a/crates/keel-kir/src/ir.rs
+++ b/crates/keel-kir/src/ir.rs
@@ -447,7 +447,7 @@ pub enum Expr {
 }
 
 /// What an `Expr::Call` invokes.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CallTarget {
     /// Direct call to another compiled Keel task.
     Fn(FuncId),
@@ -461,6 +461,16 @@ pub enum CallTarget {
     /// to codegen... synchronous `CallTarget::Rt` calls into the container
     /// ABI from day one"), never inline LLVM logic.
     Rt(RtFn),
+    /// A value-method dispatch (`s.upper()`, `s.contains(x)`, …) — issue
+    /// #214. Unlike `Ns`, there's no numeric id: value methods aren't in
+    /// the `keel-catalog` namespace registry, they're a hardcoded match in
+    /// `keel_runtime::interpreter::call_method_on_value`, so `method` is
+    /// carried as a name and resolved by `keel_rt_call_value_method` at
+    /// runtime. The associated `Expr::Call`'s `args[0]` is the receiver;
+    /// `args[1..]` are the method's own arguments (`lower_str_method_call`).
+    /// Only a `Str` receiver lowers today — see its doc for the closure-free
+    /// method subset.
+    ValueMethod { method: String },
 }
 
 /// One `keel-rt-ffi` container-ABI entry point. Each maps to exactly one

--- a/crates/keel-kir/src/lower/expr.rs
+++ b/crates/keel-kir/src/lower/expr.rs
@@ -423,8 +423,11 @@ pub(crate) fn lower_expr(
             // shadowed by a local — mirrors the checker's "lexical locals
             // shadow globals" precedence (`db = db.connect(...)` rebinds
             // `db` to a connection value; see `checker/expr.rs`). Anything
-            // else (a real value method call, `xs.map(f)`) isn't lowered
-            // yet — value methods land alongside the container ABI (M2+).
+            // else is a real value method call, dispatched below by the
+            // receiver's KirType — list/map/set through the container ABI,
+            // str through `CallTarget::ValueMethod` (issue #214). A
+            // closure-taking method (`xs.map(f)`) still isn't lowered:
+            // `ast::Expr::Lambda` itself is a flat rejection (issue #114).
             if let ast::Expr::Ident(obj_name) = &object.kind
                 && ctx.resolve(obj_name).is_none()
                 && let Some(namespace) = lcx.ns_bindings.get(obj_name)
@@ -441,6 +444,9 @@ pub(crate) fn lower_expr(
                 }
                 KirType::Set(_) => {
                     lower_set_method_call(object_e, method, args, ctx, lcx, table, &expr.span)
+                }
+                KirType::Str => {
+                    lower_str_method_call(object_e, method, args, ctx, lcx, table, &expr.span)
                 }
                 _ => Err(LowerError::unsupported("method call", expr.span.clone())),
             }
@@ -1455,6 +1461,92 @@ fn lower_list_method_call(
             call_span.clone(),
         )),
     }
+}
+
+/// Lowers a value method call on a `str`-typed receiver (issue #214) via
+/// `CallTarget::ValueMethod` — dispatched at runtime through
+/// `keel_rt_call_value_method` to the exact same
+/// `keel_runtime::interpreter::call_method_on_value` match arms the
+/// interpreter uses (`crates/keel-runtime/src/interpreter/methods.rs`),
+/// unlike list/map/set methods above, which go through the dedicated
+/// container-ABI `CallTarget::Rt` ops instead.
+///
+/// Only the closure-free, `Fixed`-scalar-result subset lowers: everything
+/// else (`split`/`to_int`/`to_float`/… — list or nullable results need Value
+/// marshaling `rt_call::unbox_value` doesn't support yet) stays rejected
+/// with a clear "M3 concern" diagnostic, same convention as `lower_ns_call`.
+fn lower_str_method_call(
+    object_e: Expr,
+    method: &str,
+    args: &[ast::CallArg],
+    ctx: &mut FnCtx,
+    lcx: &LowerCtx<'_>,
+    table: &mut SpanTable,
+    call_span: &Span,
+) -> Result<Expr, LowerError> {
+    debug_assert!(
+        matches!(object_e.ty(), KirType::Str),
+        "caller only invokes lower_str_method_call on a KirType::Str receiver"
+    );
+    for arg in args {
+        if arg.name.is_some() || arg.spread {
+            return Err(LowerError::unsupported(
+                "named or spread arguments to a str method call",
+                arg.value.span.clone(),
+            ));
+        }
+    }
+
+    let result_ty = match method {
+        "length" | "len" | "count" => KirType::I64,
+        "is_empty" | "contains" | "starts_with" | "ends_with" => KirType::Bool,
+        "upper" | "lower" | "trim" | "strip" | "replace" => KirType::Str,
+        other => {
+            return Err(LowerError::unsupported(
+                &format!(
+                    "str method `{other}` (only length/len/count/is_empty/upper/lower/trim/\
+                     strip/contains/starts_with/ends_with/replace are lowered so far)"
+                ),
+                call_span.clone(),
+            ));
+        }
+    };
+    let expected_arity: usize = match method {
+        "length" | "len" | "count" | "is_empty" | "upper" | "lower" | "trim" | "strip" => 0,
+        "contains" | "starts_with" | "ends_with" => 1,
+        "replace" => 2,
+        _ => unreachable!("every method arm above is covered by the result_ty match"),
+    };
+    if args.len() != expected_arity {
+        return Err(LowerError::new(
+            format!(
+                "`{method}` takes {expected_arity} argument(s), got {}",
+                args.len()
+            ),
+            call_span.clone(),
+        ));
+    }
+
+    let span_id = table.intern(call_span.clone());
+    // The receiver was lowered before any argument, so it's their left
+    // sibling in evaluation order — same hoist-ordering convention as
+    // `lower_ns_call`'s argument loop.
+    let mut lowered_args = vec![object_e];
+    for arg in args {
+        let mark = ctx.hoist_mark();
+        let arg_e = lower_expr_expecting(&arg.value, KirType::Str, ctx, lcx, table)?;
+        ctx.keep_order(mark, &mut lowered_args, &arg.value.span)?;
+        lowered_args.push(arg_e);
+    }
+
+    Ok(Expr::Call {
+        target: CallTarget::ValueMethod {
+            method: method.to_string(),
+        },
+        args: lowered_args,
+        ty: result_ty,
+        span: span_id,
+    })
 }
 
 /// Lowers a value method call on a `map[str, V]`-typed receiver (`m.get(k)`,

--- a/crates/keel-kir/src/passes/verify.rs
+++ b/crates/keel-kir/src/passes/verify.rs
@@ -385,6 +385,7 @@ fn verify_expr(program: &KirProgram, func: &KirFunction, expr: &Expr) -> Result<
                     verify_ns_call(*ns_id, *method_id, args, *ty)
                 }
                 CallTarget::Rt(rt_fn) => verify_rt_call(program, *rt_fn, args, *ty),
+                CallTarget::ValueMethod { method } => verify_value_method_call(method, args, *ty),
             }
         }
         Expr::MakeStruct { struct_id, fields } => {
@@ -680,6 +681,37 @@ fn verify_ns_call(ns_id: u16, method_id: u16, args: &[Expr], ty: KirType) -> Res
         ));
     }
     Ok(())
+}
+
+/// Verifies a `CallTarget::ValueMethod` call shape. Unlike `Ns`, there is no
+/// catalog to cross-check arity/result type against (value methods aren't
+/// registered there — `lower_str_method_call` is the sole source of truth
+/// for which methods/arities exist), so this only checks the structural
+/// invariant every value-method call must satisfy: a `Str` receiver in
+/// `args[0]` and a result type in the closure-free subset `keel-codegen`
+/// can actually unbox (`rt_call::unbox_value`). Keep this arm's type set in
+/// sync when extending `lower_str_method_call`'s allowlist — e.g. adding
+/// `split` (a `List` result) needs a new arm here too, or it fails as a
+/// confusing verify error instead of a clear "not yet supported" one at the
+/// codegen boundary that actually can't handle it.
+fn verify_value_method_call(method: &str, args: &[Expr], ty: KirType) -> Result<(), String> {
+    let [receiver, ..] = args else {
+        return Err(format!(
+            "value-method call `.{method}` has no receiver argument"
+        ));
+    };
+    if receiver.ty() != KirType::Str {
+        return Err(format!(
+            "value-method call `.{method}` receiver is {}, only Str lowers today",
+            receiver.ty()
+        ));
+    }
+    match ty {
+        KirType::I64 | KirType::Bool | KirType::Str => Ok(()),
+        other => Err(format!(
+            "value-method call `.{method}` result is {other}, expected int/bool/str"
+        )),
+    }
 }
 
 /// Verifies a `CallTarget::Rt` call shape against the arity/type each

--- a/crates/keel-rt-ffi/src/lib.rs
+++ b/crates/keel-rt-ffi/src/lib.rs
@@ -10,7 +10,9 @@ pub mod abi;
 pub mod host;
 pub mod ns_dispatch;
 mod scheduler;
+pub mod value_dispatch;
 
 pub use host::CompiledHost;
 pub use ns_dispatch::{KeelRes, keel_rt_call_ns};
 pub use scheduler::keel_rt_start;
+pub use value_dispatch::keel_rt_call_value_method;

--- a/crates/keel-rt-ffi/src/scheduler.rs
+++ b/crates/keel-rt-ffi/src/scheduler.rs
@@ -84,3 +84,26 @@ pub(crate) fn block_on_namespace_call(
         handle.block_on(host.call_namespace_method(ns, method, args))
     })
 }
+
+/// Dispatches a value-method call (`xs.map`, `s.upper`, …) through the
+/// current thread's `CompiledHost`, blocking this (synchronous, LLVM-emitted)
+/// call site until the async dispatch completes. Used by
+/// [`crate::value_dispatch::keel_rt_call_value_method`].
+///
+/// # Panics
+///
+/// If called from a thread `keel_rt_start` never ran on.
+pub(crate) fn block_on_value_method_call(
+    obj: Value,
+    method: &str,
+    args: Vec<CallArgValue>,
+) -> miette::Result<Value> {
+    CONTEXT.with(|c| {
+        let mut binding = c.borrow_mut();
+        let (host, handle) = binding
+            .as_mut()
+            .expect("keel_rt_call_value_method invoked on a thread keel_rt_start never ran on");
+        let handle = handle.clone();
+        handle.block_on(host.call_method_on_value(obj, method, args))
+    })
+}

--- a/crates/keel-rt-ffi/src/value_dispatch.rs
+++ b/crates/keel-rt-ffi/src/value_dispatch.rs
@@ -1,0 +1,63 @@
+//! `keel_rt_call_value_method` — the generic value-method dispatch entry
+//! point `keel-codegen` compiles every value-method call site into
+//! (`designs/llvm-compilation.md` §2.7, issue #214). Structurally identical
+//! to [`crate::ns_dispatch::keel_rt_call_ns`] except the receiver is passed
+//! as an extra boxed arg and dispatch goes by method *name* rather than a
+//! numeric `ns_id`/`method_id` pair — value methods (`xs.map`, `s.upper`, …)
+//! aren't in the `keel-catalog` namespace registry, they're a hardcoded
+//! match in `keel_runtime::interpreter::call_method_on_value` (issue #213).
+//! Runs through `CompiledHost::call_method_on_value` — the exact same
+//! dispatch the interpreter uses.
+
+use std::ffi::{CStr, c_char};
+
+use keel_runtime::interpreter::CallArgValue;
+use keel_runtime::interpreter::value::Value;
+
+use crate::abi;
+use crate::ns_dispatch::KeelRes;
+use crate::scheduler::block_on_value_method_call;
+
+/// # Safety
+///
+/// `receiver` must be a live `KeelBox` this call borrows, not consumes.
+/// `method` must be a valid, NUL-terminated C string. `args`/`arg_names`
+/// follow [`crate::ns_dispatch::keel_rt_call_ns`]'s contract exactly.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn keel_rt_call_value_method(
+    receiver: *const Value,
+    method: *const c_char,
+    args: *const *const Value,
+    arg_names: *const *const c_char,
+    nargs: u32,
+    _span_id: u32,
+) -> KeelRes {
+    // SAFETY: caller's contract (see this fn's doc).
+    let receiver = unsafe { abi::borrow(receiver) };
+    // SAFETY: caller's contract (see this fn's doc).
+    let method = unsafe { CStr::from_ptr(method) }.to_string_lossy();
+
+    let mut call_args = Vec::with_capacity(nargs as usize);
+    for i in 0..nargs as usize {
+        // SAFETY: caller's contract (see this fn's doc).
+        let value = unsafe { abi::borrow(*args.add(i)) };
+        let name_ptr = unsafe { *arg_names.add(i) };
+        let name = (!name_ptr.is_null()).then(|| {
+            unsafe { CStr::from_ptr(name_ptr) }
+                .to_string_lossy()
+                .into_owned()
+        });
+        call_args.push(CallArgValue { name, value });
+    }
+
+    match block_on_value_method_call(receiver, &method, call_args) {
+        Ok(value) => KeelRes {
+            is_err: 0,
+            payload: abi::boxed(value),
+        },
+        Err(report) => KeelRes {
+            is_err: 1,
+            payload: abi::boxed(Value::String(report.to_string())),
+        },
+    }
+}

--- a/crates/keel-rt-ffi/tests/full_value_method_call.rs
+++ b/crates/keel-rt-ffi/tests/full_value_method_call.rs
@@ -1,0 +1,71 @@
+//! Exercises the exact path `keel-codegen` will generate for a value-method
+//! call site (issue #214): `keel_rt_start` boots the runtime, the (mock)
+//! compiled toplevel boxes a string receiver and an argument via
+//! `keel_box_str`, and calls `keel_rt_call_value_method` with `"upper"` and
+//! `"contains"`, exactly as `keel-kir`'s lowering would. Mirrors
+//! `full_ns_call.rs`'s shape — proves the runtime side accepts this call
+//! convention end to end with no LLVM involved.
+
+use std::ffi::CString;
+
+use keel_rt::value_dispatch::keel_rt_call_value_method;
+use keel_runtime::interpreter::value::Value;
+
+#[unsafe(no_mangle)]
+pub extern "C" fn keel_user_toplevel() -> i32 {
+    let receiver = "keel";
+    let receiver_boxed = unsafe { keel_rt::abi::keel_box_str(receiver.as_ptr(), receiver.len()) };
+    let method = CString::new("upper").unwrap();
+
+    let res = unsafe {
+        keel_rt_call_value_method(
+            receiver_boxed,
+            method.as_ptr(),
+            std::ptr::null(),
+            std::ptr::null(),
+            0,
+            0,
+        )
+    };
+    if res.is_err != 0 {
+        return 1;
+    }
+    // SAFETY: `payload` is a live `KeelBox` `keel_rt_call_value_method` just
+    // returned ownership of.
+    let value = unsafe { &*res.payload };
+    if *value != Value::String("KEEL".to_string()) {
+        return 2;
+    }
+
+    let arg = unsafe { keel_rt::abi::keel_box_str("ee".as_ptr(), 2) };
+    let args = [arg];
+    let contains = CString::new("contains").unwrap();
+    let res = unsafe {
+        keel_rt_call_value_method(
+            receiver_boxed,
+            contains.as_ptr(),
+            args.as_ptr(),
+            [std::ptr::null()].as_ptr(),
+            1,
+            0,
+        )
+    };
+    if res.is_err != 0 {
+        return 3;
+    }
+    let value = unsafe { &*res.payload };
+    if *value != Value::Bool(true) {
+        return 4;
+    }
+
+    0
+}
+
+#[test]
+fn keel_rt_call_value_method_dispatches_str_upper_and_contains_end_to_end() {
+    assert_eq!(
+        keel_rt::keel_rt_start(),
+        0,
+        "s.upper()/s.contains() must not error"
+    );
+}

--- a/docs/src/release-notes.md
+++ b/docs/src/release-notes.md
@@ -4,6 +4,24 @@
 
 ## Unreleased
 
+### The native backend compiles `str` value methods
+
+`keel build --emit=kir` used to reject any `str` value method
+(`s.upper()`, `s.contains(x)`, …) outright with a generic "method call"
+error, even though `keel check`/`keel run` supported them fine. A new
+runtime dispatch entry point routes a compiled call through the exact same
+match arms the interpreter uses, so the two paths can't drift:
+
+```keel
+use std/io
+
+io.show("keel".upper())                       # KEEL — now compiles
+io.show("{"hello world".contains("world")}")   # true — now compiles
+```
+
+Closure-taking methods (`.map`/`.filter`/…) and non-`str` receivers still
+aren't lowered yet — that needs lambdas as values first.
+
 ### A lambda reading an outer variable no longer passes `keel check`
 
 Closures have never captured anything at runtime — every lambda call built a


### PR DESCRIPTION
## Summary

`keel build --emit=kir` rejected any `str` value method (`s.upper()`, `s.contains(x)`, `s.length()`, …) outright with a generic "method call" error, even though `keel check`/`keel run` supported them fine — there was no lowering path for a value-method call on anything but list/map/set receivers.

- **`keel-rt-ffi`**: new `keel_rt_call_value_method` FFI entry point, dispatching through `CompiledHost::call_method_on_value` (#213) — the exact same match arms the interpreter uses, so the compiled and interpreted paths can't drift.
- **`keel-kir`**: new `CallTarget::ValueMethod` + `lower_str_method_call`, scoped to the closure-free `Str`-receiver subset with a `Fixed` scalar/str result: `length`/`len`/`count`, `is_empty`, `upper`, `lower`, `trim`/`strip`, `contains`, `starts_with`, `ends_with`, `replace`. Everything else (other receivers, closure-taking methods, `split`/`to_int`/`to_float` — which need Value marshaling `unbox_value` doesn't support yet) stays rejected with a clear diagnostic, same convention as `lower_ns_call`.
- **`keel-codegen`**: new `emit_value_method_call`, reusing `ns_call.rs`'s box/unbox machinery — structurally identical to a namespace call except the receiver is boxed separately and dispatch goes by method *name* (a NUL-terminated C string constant) rather than a numeric id, since value methods aren't in the `keel-catalog` namespace registry.

Verified end to end: compile → link → run byte-identical to the interpreter for `upper`/`contains`/`length`, plus a two-different-methods-in-one-program test pinning that each call site's method-name global constant keeps its own content rather than colliding with another (LLVM auto-uniquifies same-named globals with different initializers — verified directly, not just reasoned about).

Closure-taking methods (`.map`/`.filter`/…) and non-`str` receivers are still out of scope — that needs lambdas as values first (#114).

Close #214 (sub-issue of #114 — M3: full stdlib dispatch, lambdas, generics, dynamic)

## Test plan

- [x] Reproduced the pre-fix rejection: `"keel".upper()` failed KIR lowering with a generic "method call" error
- [x] `crates/keel-codegen/tests/value_method_calls.rs` (new, 5 tests) — `upper`, `contains` with an arg, `length`, multiple calls in one program, and the distinct-method-name-globals pinning test — all byte-identical to the interpreter
- [x] `crates/keel-rt-ffi/tests/full_value_method_call.rs` (new) — raw FFI-level test with no LLVM involved, mirroring `full_ns_call.rs`
- [x] `cargo test -q -p keel-codegen` / `-p keel-rt-ffi` / workspace default — all green
- [x] `cargo clippy --workspace --all-targets -q -- -D warnings` — clean
- [x] `mdbook build` over `docs/` — clean