### PR TITLE
Accept named functions wherever a lambda is expected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to Keel.
 
 ## [Unreleased]
 
-%%TAGLINE%% The LLVM backend closes the gap on stdlib calls and string methods, and lambdas get formal non-capturing semantics.
+%%TAGLINE%% Named functions now work everywhere a lambda does, lambdas get formal non-capturing semantics, and the LLVM backend closes the gap on stdlib calls and string methods.
 
 ### Added
 
@@ -29,6 +29,18 @@ io.show("{"hello world".contains("world")}")  # true — now compiles
 task main() {
   n = 10
   add_n = x => x + n   # now a check error: lambdas do not capture outer variables
+}
+```
+
+- **A named task passed as a function value (`xs.map(triage)`) — documented in SPEC §7 as "named function as a value" — failed at runtime on every closure-taking value method.** `map`, `filter`, `find`, `any`, `all`, `reduce`, `sort(by:)`, and `Range.map`/`.filter` all matched only `Value::Closure` (a lambda literal), never `Value::Task` (what a bare reference to a top-level task evaluates to), so `keel check` accepted the call — its `Ty::Func` inference doesn't distinguish the two — and `keel run` rejected it with "argument must be a function." These 9 sites now dispatch through `Host::call_task` for a `Value::Task` argument, alongside the existing `Host::call_closure` path for a lambda:
+
+```keel
+task triage(x: int) -> int {
+  x * 2
+}
+
+task main() {
+  results = [1, 2, 3].map(triage)   # now works — was "map argument must be a function"
 }
 ```
 

--- a/crates/keel-runtime/src/interpreter/methods.rs
+++ b/crates/keel-runtime/src/interpreter/methods.rs
@@ -22,6 +22,33 @@ const SET_LIST_METHODS: &[&str] = &[
     "reverse", "flatten", "take", "skip", "zip", "first", "last",
 ];
 
+/// Whether `v` is something [`call_fn_value`] can invoke — used by
+/// closure-taking arms to fail fast, with their own specific message, before
+/// entering a loop that calls it repeatedly.
+fn is_fn_value(v: &Value) -> bool {
+    matches!(v, Value::Closure(..) | Value::Task(..))
+}
+
+/// Invokes a value used as a function argument to a closure-taking method
+/// (`map`, `filter`, `sort(by:)`, …) — issue #216. `Value::Closure` (a
+/// lambda literal) dispatches through `Host::call_closure` as before;
+/// `Value::Task` (a named task used as a value, SPEC §7 "named function as a
+/// value" — `globals` holds one `Value::Task` per top-level task,
+/// `interpreter/decl.rs`) now dispatches through `Host::call_task` instead
+/// of being rejected. Callers that need a fast, specific "expects a
+/// function" error before their loop starts should check [`is_fn_value`]
+/// first; this function's own fallback message is generic.
+async fn call_fn_value(host: &mut dyn Host, f: &Value, args: Vec<CallArgValue>) -> Result<Value> {
+    match f {
+        Value::Closure(params, body) => host.call_closure(params, body, args).await,
+        Value::Task(name, decl) => host.call_task(name, decl, args).await,
+        other => Err(runtime_error(format!(
+            "expected a function, got {}",
+            other.type_name()
+        ))),
+    }
+}
+
 /// Total ordering over key values produced by `sort_by` closures.
 /// Matches the same primitive ordering used by `.sort()`.
 fn compare_keys(a: &Value, b: &Value) -> std::cmp::Ordering {
@@ -299,52 +326,48 @@ pub async fn call_method_on_value(
             Value::None
         }),
         (Value::Range(lo, hi), "map") => {
-            let closure = args
+            let f = args
                 .first()
                 .map(|a| a.value.clone())
                 .ok_or_else(|| runtime_error("map expects a function argument"))?;
-            let (params, body) = match closure {
-                Value::Closure(p, b) => (p, b),
-                _ => return Err(runtime_error("map argument must be a function")),
-            };
+            if !is_fn_value(&f) {
+                return Err(runtime_error("map argument must be a function"));
+            }
             let count = if lo <= hi { (hi - lo + 1) as usize } else { 0 };
             let mut out = Vec::with_capacity(count);
             for n in *lo..=*hi {
-                let res = host
-                    .call_closure(
-                        &params,
-                        &body,
-                        vec![CallArgValue {
-                            name: None,
-                            value: Value::Integer(n),
-                        }],
-                    )
-                    .await?;
+                let res = call_fn_value(
+                    host,
+                    &f,
+                    vec![CallArgValue {
+                        name: None,
+                        value: Value::Integer(n),
+                    }],
+                )
+                .await?;
                 out.push(res);
             }
             Ok(Value::List(out))
         }
         (Value::Range(lo, hi), "filter") => {
-            let closure = args
+            let f = args
                 .first()
                 .map(|a| a.value.clone())
                 .ok_or_else(|| runtime_error("filter expects a function argument"))?;
-            let (params, body) = match closure {
-                Value::Closure(p, b) => (p, b),
-                _ => return Err(runtime_error("filter argument must be a function")),
-            };
+            if !is_fn_value(&f) {
+                return Err(runtime_error("filter argument must be a function"));
+            }
             let mut out = Vec::new();
             for n in *lo..=*hi {
-                let res = host
-                    .call_closure(
-                        &params,
-                        &body,
-                        vec![CallArgValue {
-                            name: None,
-                            value: Value::Integer(n),
-                        }],
-                    )
-                    .await?;
+                let res = call_fn_value(
+                    host,
+                    &f,
+                    vec![CallArgValue {
+                        name: None,
+                        value: Value::Integer(n),
+                    }],
+                )
+                .await?;
                 if res.is_truthy() {
                     out.push(Value::Integer(n));
                 }
@@ -367,51 +390,47 @@ pub async fn call_method_on_value(
         (Value::List(items), "first") => Ok(items.first().cloned().unwrap_or(Value::None)),
         (Value::List(items), "last") => Ok(items.last().cloned().unwrap_or(Value::None)),
         (Value::List(items), "map") => {
-            let closure = args
+            let f = args
                 .first()
                 .map(|a| a.value.clone())
                 .ok_or_else(|| runtime_error("map expects a function argument"))?;
-            let (params, body) = match closure {
-                Value::Closure(p, b) => (p, b),
-                _ => return Err(runtime_error("map argument must be a function")),
-            };
+            if !is_fn_value(&f) {
+                return Err(runtime_error("map argument must be a function"));
+            }
             let mut out = Vec::with_capacity(items.len());
             for item in items.iter().cloned() {
-                let res = host
-                    .call_closure(
-                        &params,
-                        &body,
-                        vec![CallArgValue {
-                            name: None,
-                            value: item,
-                        }],
-                    )
-                    .await?;
+                let res = call_fn_value(
+                    host,
+                    &f,
+                    vec![CallArgValue {
+                        name: None,
+                        value: item,
+                    }],
+                )
+                .await?;
                 out.push(res);
             }
             Ok(Value::List(out))
         }
         (Value::List(items), "filter") => {
-            let closure = args
+            let f = args
                 .first()
                 .map(|a| a.value.clone())
                 .ok_or_else(|| runtime_error("filter expects a function argument"))?;
-            let (params, body) = match closure {
-                Value::Closure(p, b) => (p, b),
-                _ => return Err(runtime_error("filter argument must be a function")),
-            };
+            if !is_fn_value(&f) {
+                return Err(runtime_error("filter argument must be a function"));
+            }
             let mut out = Vec::new();
             for item in items.iter().cloned() {
-                let res = host
-                    .call_closure(
-                        &params,
-                        &body,
-                        vec![CallArgValue {
-                            name: None,
-                            value: item.clone(),
-                        }],
-                    )
-                    .await?;
+                let res = call_fn_value(
+                    host,
+                    &f,
+                    vec![CallArgValue {
+                        name: None,
+                        value: item.clone(),
+                    }],
+                )
+                .await?;
                 if res.is_truthy() {
                     out.push(item);
                 }
@@ -426,25 +445,23 @@ pub async fn call_method_on_value(
             Ok(Value::List(result))
         }
         (Value::List(items), "any") => {
-            let closure = args
+            let f = args
                 .first()
                 .map(|a| a.value.clone())
                 .ok_or_else(|| runtime_error("any expects a function argument"))?;
-            let (params, body) = match closure {
-                Value::Closure(p, b) => (p, b),
-                _ => return Err(runtime_error("any: argument must be a function")),
-            };
+            if !is_fn_value(&f) {
+                return Err(runtime_error("any: argument must be a function"));
+            }
             for item in items.iter().cloned() {
-                let res = host
-                    .call_closure(
-                        &params,
-                        &body,
-                        vec![CallArgValue {
-                            name: None,
-                            value: item,
-                        }],
-                    )
-                    .await?;
+                let res = call_fn_value(
+                    host,
+                    &f,
+                    vec![CallArgValue {
+                        name: None,
+                        value: item,
+                    }],
+                )
+                .await?;
                 if res.is_truthy() {
                     return Ok(Value::Bool(true));
                 }
@@ -452,25 +469,23 @@ pub async fn call_method_on_value(
             Ok(Value::Bool(false))
         }
         (Value::List(items), "all") => {
-            let closure = args
+            let f = args
                 .first()
                 .map(|a| a.value.clone())
                 .ok_or_else(|| runtime_error("all expects a function argument"))?;
-            let (params, body) = match closure {
-                Value::Closure(p, b) => (p, b),
-                _ => return Err(runtime_error("all: argument must be a function")),
-            };
+            if !is_fn_value(&f) {
+                return Err(runtime_error("all: argument must be a function"));
+            }
             for item in items.iter().cloned() {
-                let res = host
-                    .call_closure(
-                        &params,
-                        &body,
-                        vec![CallArgValue {
-                            name: None,
-                            value: item,
-                        }],
-                    )
-                    .await?;
+                let res = call_fn_value(
+                    host,
+                    &f,
+                    vec![CallArgValue {
+                        name: None,
+                        value: item,
+                    }],
+                )
+                .await?;
                 if !res.is_truthy() {
                     return Ok(Value::Bool(false));
                 }
@@ -478,25 +493,23 @@ pub async fn call_method_on_value(
             Ok(Value::Bool(true))
         }
         (Value::List(items), "find") => {
-            let closure = args
+            let f = args
                 .first()
                 .map(|a| a.value.clone())
                 .ok_or_else(|| runtime_error("find expects a function argument"))?;
-            let (params, body) = match closure {
-                Value::Closure(p, b) => (p, b),
-                _ => return Err(runtime_error("find: argument must be a function")),
-            };
+            if !is_fn_value(&f) {
+                return Err(runtime_error("find: argument must be a function"));
+            }
             for item in items.iter().cloned() {
-                let res = host
-                    .call_closure(
-                        &params,
-                        &body,
-                        vec![CallArgValue {
-                            name: None,
-                            value: item.clone(),
-                        }],
-                    )
-                    .await?;
+                let res = call_fn_value(
+                    host,
+                    &f,
+                    vec![CallArgValue {
+                        name: None,
+                        value: item.clone(),
+                    }],
+                )
+                .await?;
                 if res.is_truthy() {
                     return Ok(item);
                 }
@@ -504,32 +517,30 @@ pub async fn call_method_on_value(
             Ok(Value::None)
         }
         (Value::List(items), "reduce") => {
-            let closure = args
+            let f = args
                 .first()
                 .map(|a| a.value.clone())
                 .ok_or_else(|| runtime_error("reduce expects a function as first argument"))?;
-            let (params, body) = match closure {
-                Value::Closure(p, b) => (p, b),
-                _ => return Err(runtime_error("reduce: first argument must be a function")),
-            };
+            if !is_fn_value(&f) {
+                return Err(runtime_error("reduce: first argument must be a function"));
+            }
             let mut acc = args.get(1).map(|a| a.value.clone()).unwrap_or(Value::None);
             for item in items.iter().cloned() {
-                acc = host
-                    .call_closure(
-                        &params,
-                        &body,
-                        vec![
-                            CallArgValue {
-                                name: None,
-                                value: acc,
-                            },
-                            CallArgValue {
-                                name: None,
-                                value: item,
-                            },
-                        ],
-                    )
-                    .await?;
+                acc = call_fn_value(
+                    host,
+                    &f,
+                    vec![
+                        CallArgValue {
+                            name: None,
+                            value: acc,
+                        },
+                        CallArgValue {
+                            name: None,
+                            value: item,
+                        },
+                    ],
+                )
+                .await?;
             }
             Ok(acc)
         }
@@ -584,23 +595,21 @@ pub async fn call_method_on_value(
                 .find(|a| a.name.as_deref() == Some("by"))
                 .map(|a| a.value.clone());
             if let Some(by) = by_closure {
-                let (params, body) = match by {
-                    Value::Closure(p, b) => (p, b),
-                    _ => return Err(runtime_error("sort `by:` argument must be a function")),
-                };
+                if !is_fn_value(&by) {
+                    return Err(runtime_error("sort `by:` argument must be a function"));
+                }
                 // Phase 1: compute all keys async, then sort synchronously.
                 let mut keyed: Vec<(Value, Value)> = Vec::with_capacity(items.len());
                 for item in items.iter().cloned() {
-                    let key = host
-                        .call_closure(
-                            &params,
-                            &body,
-                            vec![CallArgValue {
-                                name: None,
-                                value: item.clone(),
-                            }],
-                        )
-                        .await?;
+                    let key = call_fn_value(
+                        host,
+                        &by,
+                        vec![CallArgValue {
+                            name: None,
+                            value: item.clone(),
+                        }],
+                    )
+                    .await?;
                     match &key {
                         Value::Integer(_) | Value::Float(_) | Value::String(_) => {}
                         other => {

--- a/docs/src/release-notes.md
+++ b/docs/src/release-notes.md
@@ -4,6 +4,26 @@
 
 ## Unreleased
 
+### A named task now works everywhere a lambda does
+
+`results = emails.map(triage)` — SPEC §7's own documented "named function as
+a value" example — failed at runtime on every closure-taking value method
+(`map`, `filter`, `find`, `any`, `all`, `reduce`, `sort(by:)`, `Range.map`/
+`.filter`). Each one matched only a lambda literal, never a bare reference
+to a top-level task, so `keel check` accepted the call but `keel run`
+rejected it with "argument must be a function." Named tasks now dispatch
+correctly alongside lambdas everywhere a function value is expected:
+
+```keel
+task triage(x: int) -> int {
+  x * 2
+}
+
+task main() {
+  results = [1, 2, 3].map(triage)   # now works
+}
+```
+
 ### The native backend compiles `str` value methods
 
 `keel build --emit=kir` used to reject any `str` value method

--- a/tests/integration/language/lambdas.rs
+++ b/tests/integration/language/lambdas.rs
@@ -116,3 +116,122 @@ run(SelfInLambda)
         "expected self access to resolve via ambient agent state:\n{stdout}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Named function as a value (SPEC §7) — issue #216
+// ---------------------------------------------------------------------------
+
+#[test]
+fn list_map_accepts_a_named_task_as_a_function_value() {
+    let src = r#"
+use std/io
+
+task triage(x: int) -> int {
+  x * 2
+}
+
+task main() {
+  results = [1, 2, 3].map(triage)
+  io.show("{results}")
+}
+
+main()
+"#;
+    let (ok, stdout, stderr) = run_inline(src, false);
+    assert!(ok, "expected clean run:\n{stderr}");
+    assert!(
+        stdout.contains("[2, 4, 6]"),
+        "expected map(triage) to dispatch through call_task:\n{stdout}"
+    );
+}
+
+#[test]
+fn list_filter_find_any_all_reduce_and_sort_by_accept_a_named_task() {
+    let src = r#"
+use std/io
+
+task is_even(x: int) -> bool {
+  x % 2 == 0
+}
+
+task add(acc: int, x: int) -> int {
+  acc + x
+}
+
+task negate(x: int) -> int {
+  0 - x
+}
+
+task main() {
+  nums = [1, 2, 3, 4, 5]
+  io.show("{nums.filter(is_even)}")
+  io.show("{nums.find(is_even)}")
+  io.show("{nums.any(is_even)}")
+  io.show("{nums.all(is_even)}")
+  io.show("{nums.reduce(add, 0)}")
+  io.show("{nums.sort(by: negate)}")
+}
+
+main()
+"#;
+    let (ok, stdout, stderr) = run_inline(src, false);
+    assert!(ok, "expected clean run:\n{stderr}");
+    assert!(stdout.contains("[2, 4]"), "filter:\n{stdout}");
+    assert!(
+        stdout.contains("2\n") || stdout.contains("  2\n"),
+        "find:\n{stdout}"
+    );
+    assert!(stdout.contains("true"), "any:\n{stdout}");
+    assert!(stdout.contains("false"), "all:\n{stdout}");
+    assert!(stdout.contains("15"), "reduce:\n{stdout}");
+    assert!(
+        stdout.contains("[5, 4, 3, 2, 1]"),
+        "sort(by: negate) descending:\n{stdout}"
+    );
+}
+
+#[test]
+fn range_map_and_filter_accept_a_named_task() {
+    let src = r#"
+use std/io
+
+task double(x: int) -> int {
+  x * 2
+}
+
+task is_odd(x: int) -> bool {
+  x % 2 != 0
+}
+
+task main() {
+  io.show("{(1..3).map(double)}")
+  io.show("{(1..5).filter(is_odd)}")
+}
+
+main()
+"#;
+    let (ok, stdout, stderr) = run_inline(src, false);
+    assert!(ok, "expected clean run:\n{stderr}");
+    assert!(stdout.contains("[2, 4, 6]"), "range map:\n{stdout}");
+    assert!(stdout.contains("[1, 3, 5]"), "range filter:\n{stdout}");
+}
+
+#[test]
+fn a_non_function_value_still_produces_a_clean_error() {
+    let src = r#"
+task main() {
+  [1, 2, 3].map(5)
+}
+
+main()
+"#;
+    let (ok, _stdout, stderr) = run_inline(src, false);
+    assert!(
+        !ok,
+        "expected a runtime error for a non-function map argument"
+    );
+    assert!(
+        stderr.contains("must be a function"),
+        "expected a clean type error, not a panic:\n{stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

- `[1, 2, 3].map(triage)` (a named task passed where a function value is expected) type-checked but panicked at runtime with "argument must be a function" — the 9 closure-taking list/range methods (`map`, `filter`, `any`, `all`, `find`, `reduce`, `sort`'s `by:`) only pattern-matched `Value::Closure`, never `Value::Task`.
- SPEC §7 already documents both lambda literals and named function references as valid function values; only the runtime dispatch was out of sync.
- Added `is_fn_value`/`call_fn_value` helpers in `interpreter/methods.rs` and routed all 9 call sites through them, so `Value::Closure` and `Value::Task` are both accepted uniformly.
- The same gap exists in namespace methods that take closures (`control.retry`, `schedule.every/at/cron/after`, `async.spawn`, `http.serve`) — filed separately as #217, out of scope here.

## Test plan

- [x] `[1, 2, 3].map(triage)` now runs and outputs `[2, 4, 6]` instead of erroring
- [x] New integration tests in `tests/integration/language/lambdas.rs` cover `map`/`filter`/`find`/`any`/`all`/`reduce`/`sort(by:)` on lists and `map`/`filter` on ranges, all with named tasks
- [x] Verified `keel check` accepts a non-function argument like `[1,2,3].map(5)` (loose `Ty::Func` inference), so the "non-function value still produces a clean error" test genuinely exercises the new runtime guard rather than the checker
- [x] `cargo test -q` (full workspace): 533 passed, 3 ignored
- [x] `cargo clippy -q --workspace --all-targets -- -D warnings`: clean
- [x] `mdbook build`: clean

Close #216