### PR TITLE
Accept named functions in closure-taking namespace methods too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,21 @@ task main() {
 }
 ```
 
+- **The same named-function-as-value gap also affected every closure-taking namespace method and the global `min`/`max`.** `control.retry`, `control.with_timeout`, `control.with_deadline`, `schedule.every`/`.at`/`.cron`/`.after`, `async.spawn`, `http.serve`, and `min`/`max(by:)` all extracted a `Value::Closure`'s `(params, body)` directly and rejected a `Value::Task`, so a named task worked as a `list.map` argument but not as a scheduler callback or retry body. `ScheduledClosure` (the record `Schedule.*`/`Http.serve` register for later firing) and `Host::spawn_closure` now hold the function value itself instead of pre-destructured params/body, and every site dispatches through the same `call_fn_value` helper `Value::Closure`/`Value::Task` share:
+
+```keel
+use std/control
+use std/io
+
+task work() -> int {
+  42
+}
+
+task main() {
+  io.show("{control.retry(3, work)}")   # now works — was "missing closure argument"
+}
+```
+
 - **The native backend miscompiled any namespace call with a non-`Unit` result used as a value.** `emit_ns_call` (`keel-codegen`) was written for M1's `io.show`/`log.*`-only namespace calls and unconditionally returned a hardcoded `i1 false`, discarding the real `KeelRes` payload — but nothing in `keel-kir`'s lowering ever restricted `CallTarget::Ns` to `Unit` results, so a scalar-returning stdlib call (`math.sqrt`, `crypto.sha256`, …) used in value position passed lowering and then panicked codegen on a type mismatch. It now unboxes the payload to the call's real result type, matching the interpreter:
 
 ```keel

--- a/crates/keel-rt-ffi/src/host.rs
+++ b/crates/keel-rt-ffi/src/host.rs
@@ -199,20 +199,11 @@ impl Host for CompiledHost {
         todo!("Http.serve is not compiled yet")
     }
 
-    fn register_closure(
-        &mut self,
-        _agent_name: String,
-        _params: Vec<LambdaParam>,
-        _body: LambdaBody,
-    ) -> u64 {
+    fn register_closure(&mut self, _agent_name: String, _f: Value) -> u64 {
         todo!("closures are not compiled yet")
     }
 
-    fn spawn_closure<'a>(
-        &'a mut self,
-        _params: Vec<LambdaParam>,
-        _body: LambdaBody,
-    ) -> HostFuture<'a, u64> {
+    fn spawn_closure<'a>(&'a mut self, _f: Value) -> HostFuture<'a, u64> {
         todo!("Async.spawn is not compiled yet")
     }
 

--- a/crates/keel-runtime/src/interpreter/entry.rs
+++ b/crates/keel-runtime/src/interpreter/entry.rs
@@ -722,16 +722,15 @@ impl Interpreter {
                         // debugger's module/breakpoint tracking, nothing more.
                         let module_id = self.agent_module.get(&c.agent_name).copied();
                         let turn = self.begin_agent_turn(None, module_id);
-                        let result = self
-                            .call_closure(
-                                &c.params,
-                                &c.body,
-                                vec![CallArgValue {
-                                    name: None,
-                                    value: request_val,
-                                }],
-                            )
-                            .await;
+                        let result = super::methods::call_fn_value(
+                            self,
+                            &c.f,
+                            vec![CallArgValue {
+                                name: None,
+                                value: request_val,
+                            }],
+                        )
+                        .await;
                         self.end_agent_turn(turn);
                         // Serialize result back to JSON string
                         let resp_val = result.unwrap_or_else(|err| {
@@ -985,7 +984,10 @@ mod tests {
             ty: None,
         }];
         let body = LambdaBody::Expr(Box::new(Node::synthetic(Expr::Ident("req".to_string()))));
-        let closure_id = interp.register_closure("test_agent".to_string(), params, body);
+        let closure_id = interp.register_closure(
+            "test_agent".to_string(),
+            Value::Closure(params, Box::new(body)),
+        );
 
         // Keep event loop alive by faking an active server
         interp.active_http_servers.fetch_add(1, Ordering::Relaxed);
@@ -1075,7 +1077,10 @@ mod tests {
             ty: None,
         }];
         let body = LambdaBody::Expr(Box::new(Node::synthetic(Expr::Ident("req".to_string()))));
-        let closure_id = interp.register_closure("test_agent".to_string(), params, body);
+        let closure_id = interp.register_closure(
+            "test_agent".to_string(),
+            Value::Closure(params, Box::new(body)),
+        );
 
         interp.active_http_servers.fetch_add(1, Ordering::Relaxed);
 
@@ -1121,7 +1126,10 @@ mod tests {
             ty: None,
         }];
         let body = LambdaBody::Expr(Box::new(Node::synthetic(Expr::None_)));
-        let closure_id = interp.register_closure("test_agent".to_string(), params, body);
+        let closure_id = interp.register_closure(
+            "test_agent".to_string(),
+            Value::Closure(params, Box::new(body)),
+        );
 
         interp.active_http_servers.fetch_add(1, Ordering::Relaxed);
 

--- a/crates/keel-runtime/src/interpreter/host.rs
+++ b/crates/keel-runtime/src/interpreter/host.rs
@@ -159,26 +159,19 @@ pub trait Host: Send {
     /// Counter tracking active `Http.serve` listeners.
     fn active_http_servers(&self) -> &Arc<AtomicU64>;
 
-    /// Register a closure for later firing via `Event::FireClosure`.
+    /// Register a function value (`Value::Closure` or `Value::Task`, SPEC §7)
+    /// for later firing via `Event::FireClosure`.
     ///
     /// Returns the closure id to embed in scheduled events.
-    fn register_closure(
-        &mut self,
-        agent_name: String,
-        params: Vec<LambdaParam>,
-        body: LambdaBody,
-    ) -> u64;
+    fn register_closure(&mut self, agent_name: String, f: Value) -> u64;
 
-    /// Spawn a closure as an independent Tokio task with a snapshotted interpreter state.
+    /// Spawn a function value as an independent Tokio task with a snapshotted
+    /// interpreter state.
     ///
     /// Returns the async handle id that callers can pass to `Async.join_all` or
     /// `Async.select`. The concrete implementation constructs a child interpreter
     /// sharing the parent's event infrastructure and symbol tables.
-    fn spawn_closure<'a>(
-        &'a mut self,
-        params: Vec<LambdaParam>,
-        body: LambdaBody,
-    ) -> HostFuture<'a, u64>;
+    fn spawn_closure<'a>(&'a mut self, f: Value) -> HostFuture<'a, u64>;
 
     // ── prelude installation ──────────────────────────────────────────────
 
@@ -329,20 +322,11 @@ impl Host for Interpreter {
         &self.active_http_servers
     }
 
-    fn register_closure(
-        &mut self,
-        agent_name: String,
-        params: Vec<LambdaParam>,
-        body: LambdaBody,
-    ) -> u64 {
-        Interpreter::register_closure(self, agent_name, params, body)
+    fn register_closure(&mut self, agent_name: String, f: Value) -> u64 {
+        Interpreter::register_closure(self, agent_name, f)
     }
 
-    fn spawn_closure<'a>(
-        &'a mut self,
-        params: Vec<LambdaParam>,
-        body: LambdaBody,
-    ) -> HostFuture<'a, u64> {
+    fn spawn_closure<'a>(&'a mut self, f: Value) -> HostFuture<'a, u64> {
         Box::pin(async move {
             let handle_id = self.runtime.next_async_handle_id();
             let runtime = self.runtime.clone();
@@ -387,8 +371,7 @@ impl Host for Interpreter {
                 local_interp.program_name = program_name;
                 local_interp.installed_provider = installed_provider;
                 local_interp.active_providers = active_providers;
-                local_interp
-                    .call_closure(&params, &body, vec![])
+                super::methods::call_fn_value(&mut local_interp, &f, vec![])
                     .await
                     .map_err(|err| err.to_string())
             });
@@ -567,20 +550,11 @@ impl Host for MockHost {
         unimplemented!("MockHost does not support active_http_servers")
     }
 
-    fn register_closure(
-        &mut self,
-        _agent_name: String,
-        _params: Vec<LambdaParam>,
-        _body: LambdaBody,
-    ) -> u64 {
+    fn register_closure(&mut self, _agent_name: String, _f: Value) -> u64 {
         unimplemented!("MockHost does not support register_closure")
     }
 
-    fn spawn_closure<'a>(
-        &'a mut self,
-        _params: Vec<LambdaParam>,
-        _body: LambdaBody,
-    ) -> HostFuture<'a, u64> {
+    fn spawn_closure<'a>(&'a mut self, _f: Value) -> HostFuture<'a, u64> {
         unimplemented!("MockHost does not support spawn_closure")
     }
 

--- a/crates/keel-runtime/src/interpreter/methods.rs
+++ b/crates/keel-runtime/src/interpreter/methods.rs
@@ -4,7 +4,7 @@ use miette::Result;
 
 use crate::ast::TaskDecl;
 
-use super::host::Host;
+use super::host::{Host, HostFuture};
 use super::runtime_error;
 use super::state::{CallArgValue, Interpreter};
 use super::value::{self, MapKey, Value};
@@ -25,8 +25,19 @@ const SET_LIST_METHODS: &[&str] = &[
 /// Whether `v` is something [`call_fn_value`] can invoke — used by
 /// closure-taking arms to fail fast, with their own specific message, before
 /// entering a loop that calls it repeatedly.
-fn is_fn_value(v: &Value) -> bool {
+pub(crate) fn is_fn_value(v: &Value) -> bool {
     matches!(v, Value::Closure(..) | Value::Task(..))
+}
+
+/// Finds the first function-value argument (`Value::Closure` or
+/// `Value::Task`) among `args`, regardless of position or name — the same
+/// search every closure-taking namespace method (`control.retry`,
+/// `schedule.every`, `async.spawn`, `http.serve`, …) used to run inline
+/// against `Value::Closure` alone (issue #217).
+pub(crate) fn find_fn_value(args: &[CallArgValue]) -> Option<Value> {
+    args.iter()
+        .find(|a| is_fn_value(&a.value))
+        .map(|a| a.value.clone())
 }
 
 /// Invokes a value used as a function argument to a closure-taking method
@@ -38,14 +49,22 @@ fn is_fn_value(v: &Value) -> bool {
 /// of being rejected. Callers that need a fast, specific "expects a
 /// function" error before their loop starts should check [`is_fn_value`]
 /// first; this function's own fallback message is generic.
-async fn call_fn_value(host: &mut dyn Host, f: &Value, args: Vec<CallArgValue>) -> Result<Value> {
+///
+/// Returns a boxed future rather than being `async fn` so callers that need
+/// to race it against something else (`tokio::time::timeout` in
+/// `control.with_timeout`/`control.with_deadline`) can do so directly.
+pub(crate) fn call_fn_value<'a>(
+    host: &'a mut dyn Host,
+    f: &'a Value,
+    args: Vec<CallArgValue>,
+) -> HostFuture<'a, Value> {
     match f {
-        Value::Closure(params, body) => host.call_closure(params, body, args).await,
-        Value::Task(name, decl) => host.call_task(name, decl, args).await,
-        other => Err(runtime_error(format!(
-            "expected a function, got {}",
-            other.type_name()
-        ))),
+        Value::Closure(params, body) => host.call_closure(params, body, args),
+        Value::Task(name, decl) => host.call_task(name, decl, args),
+        other => {
+            let msg = format!("expected a function, got {}", other.type_name());
+            Box::pin(async move { Err(runtime_error(msg)) })
+        }
     }
 }
 

--- a/crates/keel-runtime/src/interpreter/mod.rs
+++ b/crates/keel-runtime/src/interpreter/mod.rs
@@ -36,5 +36,6 @@ pub use host::Host;
 #[cfg(test)]
 pub use host::MockHost;
 pub use methods::call_method_on_value;
+pub(crate) use methods::{call_fn_value, find_fn_value, is_fn_value};
 pub use state::{BuiltinFn, CallArgValue, Event, Interpreter, Namespace};
 pub use stmt::StmtOutcome;

--- a/crates/keel-runtime/src/interpreter/state.rs
+++ b/crates/keel-runtime/src/interpreter/state.rs
@@ -11,8 +11,8 @@ use tokio::sync::mpsc::{Receiver, Sender, channel};
 
 use super::store::ProgramStore;
 use crate::ast::{
-    AttributeBody, AttributeDecl, Binding, Expr, LambdaBody, LambdaParam, Node, OnHandler, Param,
-    StateField, StringPart, TaskDecl, TaskSig, TypeExpr,
+    AttributeBody, AttributeDecl, Binding, Expr, Node, OnHandler, Param, StateField, StringPart,
+    TaskDecl, TaskSig, TypeExpr,
 };
 use crate::types::interface::TypeEnv;
 
@@ -160,13 +160,15 @@ pub enum Event {
     Shutdown,
 }
 
-/// A scheduled closure awaiting firing via an `Event::FireClosure`.
+/// A scheduled function value awaiting firing via an `Event::FireClosure`.
+/// `f` is `Value::Closure` for a lambda literal or `Value::Task` for a named
+/// task used as a value (SPEC §7) — dispatched uniformly via
+/// `call_fn_value` (issue #217).
 #[allow(dead_code)]
 #[derive(Clone)]
 pub struct ScheduledClosure {
     pub agent_name: String,
-    pub params: Vec<LambdaParam>,
-    pub body: LambdaBody,
+    pub f: Value,
 }
 
 pub struct Interpreter {
@@ -361,23 +363,13 @@ impl Interpreter {
             })
     }
 
-    /// Register a closure for later firing via `Event::FireClosure`.
+    /// Register a function value for later firing via `Event::FireClosure`.
     /// Returns the id to embed in scheduled events.
-    pub fn register_closure(
-        &mut self,
-        agent_name: String,
-        params: Vec<LambdaParam>,
-        body: LambdaBody,
-    ) -> u64 {
+    pub fn register_closure(&mut self, agent_name: String, f: Value) -> u64 {
         let id = self.next_closure_id.fetch_add(1, Ordering::Relaxed);
-        self.closures.lock().insert(
-            id,
-            ScheduledClosure {
-                agent_name,
-                params,
-                body,
-            },
-        );
+        self.closures
+            .lock()
+            .insert(id, ScheduledClosure { agent_name, f });
         id
     }
 
@@ -449,7 +441,7 @@ impl Interpreter {
         };
         let module_id = self.agent_module.get(agent_name).copied();
         let turn = self.begin_agent_turn(Some(agent_inst), module_id);
-        let result = self.call_closure(&c.params, &c.body, vec![]).await;
+        let result = super::methods::call_fn_value(self, &c.f, vec![]).await;
         self.end_agent_turn(turn);
         result.map(|_| ())
     }

--- a/crates/keel-runtime/src/runtime/mod.rs
+++ b/crates/keel-runtime/src/runtime/mod.rs
@@ -9,7 +9,7 @@
 use std::sync::Arc;
 
 use crate::interpreter::value::Value;
-use crate::interpreter::{CallArgValue, Host};
+use crate::interpreter::{CallArgValue, Host, call_fn_value, is_fn_value};
 
 pub(crate) mod args;
 pub mod context;
@@ -141,36 +141,29 @@ fn install_min_max(host: &mut dyn Host) {
                     };
                     match by_val {
                         Some(by) => {
-                            let (params, body) = match by {
-                                Value::Closure(p, b) => (p, *b),
-                                _ => {
-                                    return Err(miette::miette!(
-                                        "`by:` argument must be a function"
-                                    ));
-                                }
-                            };
+                            if !is_fn_value(&by) {
+                                return Err(miette::miette!("`by:` argument must be a function"));
+                            }
                             let mut best = items[0].clone();
-                            let mut best_key = host
-                                .call_closure(
-                                    &params,
-                                    &body,
+                            let mut best_key = call_fn_value(
+                                host,
+                                &by,
+                                vec![CallArgValue {
+                                    name: None,
+                                    value: best.clone(),
+                                }],
+                            )
+                            .await?;
+                            for item in items.into_iter().skip(1) {
+                                let key = call_fn_value(
+                                    host,
+                                    &by,
                                     vec![CallArgValue {
                                         name: None,
-                                        value: best.clone(),
+                                        value: item.clone(),
                                     }],
                                 )
                                 .await?;
-                            for item in items.into_iter().skip(1) {
-                                let key = host
-                                    .call_closure(
-                                        &params,
-                                        &body,
-                                        vec![CallArgValue {
-                                            name: None,
-                                            value: item.clone(),
-                                        }],
-                                    )
-                                    .await?;
                                 if cmp_values(&key, &best_key)? == target {
                                     best = item;
                                     best_key = key;

--- a/crates/keel-runtime/src/runtime/namespaces/asynchronous.rs
+++ b/crates/keel-runtime/src/runtime/namespaces/asynchronous.rs
@@ -4,7 +4,7 @@ use std::pin::Pin;
 use std::task::Poll;
 
 use crate::interpreter::value::{MapKey, Value};
-use crate::interpreter::{CallArgValue, Namespace};
+use crate::interpreter::{CallArgValue, Namespace, find_fn_value};
 use crate::runtime::args::expect_duration;
 use crate::runtime::namespace::{ns, positional};
 
@@ -13,12 +13,10 @@ pub(crate) fn namespace() -> Namespace {
         // Async.spawn(fn) — spawn fn as an independent Tokio task.
         // Returns a handle map with `_id` and `_status` fields.
         "spawn" => |host, args| Box::pin(async move {
-            let (params, body) = args.iter().find_map(|a| match &a.value {
-                Value::Closure(p, b) => Some((p.clone(), (**b).clone())),
-                _ => None,
-            }).ok_or_else(|| miette::miette!("async.spawn: missing closure argument"))?;
+            let f = find_fn_value(&args)
+                .ok_or_else(|| miette::miette!("async.spawn: missing closure argument"))?;
 
-            let handle_id = host.spawn_closure(params, body).await?;
+            let handle_id = host.spawn_closure(f).await?;
 
             let mut handle_map = HashMap::new();
             handle_map.insert(MapKey::Str("_id".into()), Value::Integer(handle_id as i64));

--- a/crates/keel-runtime/src/runtime/namespaces/control.rs
+++ b/crates/keel-runtime/src/runtime/namespaces/control.rs
@@ -1,5 +1,5 @@
 use crate::interpreter::value::Value;
-use crate::interpreter::{Namespace, RuntimeErrorKind};
+use crate::interpreter::{Namespace, RuntimeErrorKind, call_fn_value, find_fn_value, is_fn_value};
 use crate::runtime::args::{expect_duration, expect_str};
 use crate::runtime::namespace::{make_typed_report, ns, positional};
 use crate::runtime::namespaces::schedule::parse_datetime;
@@ -13,14 +13,12 @@ pub(crate) fn namespace() -> Namespace {
                 Some(Value::Integer(n)) if *n > 0 => *n as usize,
                 _ => return Err(miette::miette!("control.retry: first argument must be a positive integer")),
             };
-            let (params, body) = args.iter().find_map(|a| match &a.value {
-                Value::Closure(p, b) => Some((p.clone(), (**b).clone())),
-                _ => None,
-            }).ok_or_else(|| miette::miette!("control.retry: missing closure argument"))?;
+            let f = find_fn_value(&args)
+                .ok_or_else(|| miette::miette!("control.retry: missing closure argument"))?;
 
             let mut last_err: Option<miette::Report> = None;
             for _ in 0..attempts {
-                match host.call_closure(&params, &body, vec![]).await {
+                match call_fn_value(host, &f, vec![]).await {
                     Ok(v) => return Ok(v),
                     Err(e) => last_err = Some(e),
                 }
@@ -30,19 +28,18 @@ pub(crate) fn namespace() -> Namespace {
         // Control.with_timeout(duration, fn) — abort fn if it doesn't
         // complete within `duration`. Raises TimeoutError on expiry.
         "with_timeout" => |host, args| Box::pin(async move {
-            if matches!(positional(&args, 0), None | Some(Value::Closure(_, _))) {
+            let pos0_is_fn = positional(&args, 0).map(is_fn_value).unwrap_or(false);
+            if positional(&args, 0).is_none() || pos0_is_fn {
                 return Err(miette::miette!(
                     "control.with_timeout: missing duration argument"
                 ));
             }
             let duration = expect_duration(&args, 0, "control.with_timeout")?;
-            let (params, body) = args.iter().find_map(|a| match &a.value {
-                Value::Closure(p, b) => Some((p.clone(), (**b).clone())),
-                _ => None,
-            }).ok_or_else(|| miette::miette!("control.with_timeout: missing closure argument"))?;
+            let f = find_fn_value(&args)
+                .ok_or_else(|| miette::miette!("control.with_timeout: missing closure argument"))?;
 
             let dur = std::time::Duration::from_secs_f64(duration);
-            let fut = host.call_closure(&params, &body, vec![]);
+            let fut = call_fn_value(host, &f, vec![]);
             match tokio::time::timeout(dur, fut).await {
                 Ok(Ok(v)) => Ok(v),
                 Ok(Err(e)) => Err(e),
@@ -57,13 +54,11 @@ pub(crate) fn namespace() -> Namespace {
                 .ok_or_else(|| miette::miette!("control.with_deadline: cannot parse `{when_str}` as an ISO 8601 datetime"))?;
             let now = host.runtime().clock.now_utc();
             let remaining = (target - now).num_milliseconds().max(0) as u64;
-            let (params, body) = args.iter().find_map(|a| match &a.value {
-                Value::Closure(p, b) => Some((p.clone(), (**b).clone())),
-                _ => None,
-            }).ok_or_else(|| miette::miette!("control.with_deadline: missing closure argument"))?;
+            let f = find_fn_value(&args)
+                .ok_or_else(|| miette::miette!("control.with_deadline: missing closure argument"))?;
 
             let dur = std::time::Duration::from_millis(remaining);
-            let fut = host.call_closure(&params, &body, vec![]);
+            let fut = call_fn_value(host, &f, vec![]);
             match tokio::time::timeout(dur, fut).await {
                 Ok(Ok(v)) => Ok(v),
                 Ok(Err(e)) => Err(e),

--- a/crates/keel-runtime/src/runtime/namespaces/http.rs
+++ b/crates/keel-runtime/src/runtime/namespaces/http.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::LazyLock;
 
 use crate::interpreter::value::{MapKey, Value};
-use crate::interpreter::{Namespace, RuntimeErrorKind};
+use crate::interpreter::{Namespace, RuntimeErrorKind, find_fn_value};
 use crate::runtime::args::{expect_int, expect_str, expect_str_value};
 use crate::runtime::convert::value_to_json;
 use crate::runtime::namespace::{find_arg, make_typed_report, ns, positional};
@@ -95,13 +95,11 @@ pub(crate) fn namespace() -> Namespace {
                 }
             };
 
-            // Extract closure from args
-            let (params, body) = args.iter().find_map(|a| match &a.value {
-                Value::Closure(p, b) => Some((p.clone(), (**b).clone())),
-                _ => None,
-            }).ok_or_else(|| miette::miette!("http.serve: missing closure argument"))?;
+            // Extract the function value from args
+            let f = find_fn_value(&args)
+                .ok_or_else(|| miette::miette!("http.serve: missing closure argument"))?;
 
-            let closure_id = host.register_closure("__http_serve__".to_string(), params, body);
+            let closure_id = host.register_closure("__http_serve__".to_string(), f);
             let event_tx = host.background_event_tx();
             let server_counter = host.active_http_servers().clone();
 

--- a/crates/keel-runtime/src/runtime/namespaces/schedule.rs
+++ b/crates/keel-runtime/src/runtime/namespaces/schedule.rs
@@ -1,7 +1,7 @@
 use tokio::sync::mpsc::error::TrySendError;
 
 use crate::interpreter::value::Value;
-use crate::interpreter::{CallArgValue, Event, Host, Namespace};
+use crate::interpreter::{CallArgValue, Event, Host, Namespace, find_fn_value};
 use crate::runtime::args::{expect_duration, expect_str};
 use crate::runtime::namespace::ns;
 
@@ -49,19 +49,14 @@ async fn schedule_at(host: &mut dyn Host, args: Vec<CallArgValue>) -> miette::Re
     let now = host.runtime().clock.now_utc();
     let delay_secs = (target - now).num_seconds().max(0) as f64;
 
-    let (params, body) = args
-        .iter()
-        .find_map(|a| match &a.value {
-            Value::Closure(p, b) => Some((p.clone(), (**b).clone())),
-            _ => None,
-        })
+    let f = find_fn_value(&args)
         .ok_or_else(|| miette::miette!("schedule.at: missing closure argument"))?;
 
     let agent_name = host
         .current_agent_name()
         .ok_or_else(|| miette::miette!("schedule.at must be called from within an agent"))?;
 
-    let closure_id = host.register_closure(agent_name.clone(), params, body);
+    let closure_id = host.register_closure(agent_name.clone(), f);
     let tx = host.background_event_tx();
     tokio::spawn(async move {
         tokio::time::sleep(std::time::Duration::from_secs_f64(delay_secs)).await;
@@ -108,19 +103,14 @@ pub(crate) fn parse_datetime(s: &str) -> Option<chrono::DateTime<chrono::Utc>> {
 async fn schedule_cron(host: &mut dyn Host, args: Vec<CallArgValue>) -> miette::Result<Value> {
     let expr_str = expect_str(&args, 0, "schedule.cron")?.to_owned();
 
-    let (params, body) = args
-        .iter()
-        .find_map(|a| match &a.value {
-            Value::Closure(p, b) => Some((p.clone(), (**b).clone())),
-            _ => None,
-        })
+    let f = find_fn_value(&args)
         .ok_or_else(|| miette::miette!("schedule.cron: missing closure argument"))?;
 
     let agent_name = host
         .current_agent_name()
         .ok_or_else(|| miette::miette!("schedule.cron must be called from within an agent"))?;
 
-    let closure_id = host.register_closure(agent_name.clone(), params, body);
+    let closure_id = host.register_closure(agent_name.clone(), f);
     let tx = host.background_event_tx();
     let clock = host.runtime().clock.clone();
 
@@ -281,19 +271,14 @@ async fn schedule_fire(
 ) -> miette::Result<Value> {
     let duration = expect_duration(&args, 0, "Schedule")?;
 
-    let (params, body) = args
-        .iter()
-        .find_map(|a| match &a.value {
-            Value::Closure(p, b) => Some((p.clone(), (**b).clone())),
-            _ => None,
-        })
+    let f = find_fn_value(&args)
         .ok_or_else(|| miette::miette!("Schedule: missing closure argument"))?;
 
     let agent_name = host
         .current_agent_name()
         .ok_or_else(|| miette::miette!("Schedule must be called from within an agent"))?;
 
-    let closure_id = host.register_closure(agent_name.clone(), params, body);
+    let closure_id = host.register_closure(agent_name.clone(), f);
     let tx = host.background_event_tx();
     let dur = std::time::Duration::from_secs_f64(duration);
 

--- a/docs/src/guide/connections.md
+++ b/docs/src/guide/connections.md
@@ -120,6 +120,7 @@ http.serve(8080, (request) => {
 
 - `request` — map with `method`, `path`, `body` (all strings)
 - Return a map with `status` (integer, 100–999) and `body` (string)
+- `http.serve` accepts a named task in place of the lambda literal shown above
 - The server runs in a background task; `http.serve` returns immediately
 - The event loop stays alive as long as at least one server is active, even with no running agents
 - **When the event queue is full**, incoming HTTP requests receive a `503 Service Unavailable` response automatically. No user code runs for that request.

--- a/docs/src/guide/error-handling.md
+++ b/docs/src/guide/error-handling.md
@@ -203,6 +203,9 @@ try {
 }
 ```
 
+`control.retry`, `control.with_timeout`, and `control.with_deadline` all accept
+a named task in place of the lambda literal: `control.retry(3, send_email)`.
+
 ## Null-safe access — `?.`
 
 Returns `none` instead of crashing if the left side is `none`:

--- a/docs/src/guide/scheduling.md
+++ b/docs/src/guide/scheduling.md
@@ -4,6 +4,9 @@ The `schedule` module (`use std/schedule`) provides recurring, delayed, and one-
 
 Under the hood, `schedule` sits on top of the runtime's timer primitives and the agent mailbox, and emits events into whichever agent registered the schedule.
 
+> `schedule.every`, `schedule.after`, `schedule.at`, and `schedule.cron` all accept a
+> named task in place of the lambda literal shown below: `schedule.every(5.minutes, check_inbox)`.
+
 ## `schedule.every` — recurring execution
 
 ```keel

--- a/docs/src/guide/stdlib.md
+++ b/docs/src/guide/stdlib.md
@@ -101,6 +101,8 @@ min(people, by: p => p.age)            # {name: "Bob", age: 25}
 max(people, by: p => p.age)            # {name: "Alice", age: 30}
 ```
 
+`by:` accepts a named task in place of the lambda literal shown above: `min(people, by: age_of)`.
+
 ## Random
 
 `Random` produces non-cryptographic pseudo-random values for simulation, sampling, games, and tests where security is not involved. Use `Crypto` for tokens, secrets, signatures, or key material.
@@ -295,6 +297,8 @@ winner = async.select([task1, task2])
 ```
 
 `async.select` cancels any handles that haven't completed yet once a winner is found.
+
+`async.spawn` accepts a named task in place of the lambda literal shown above: `async.spawn(fetch_price)`.
 
 > **v0.1 scope.** Anything marked ⏳ is reserved in the grammar but not yet wired. 🟡 means partial: something works, but not everything. `Search` is registered and raises a clear "planned for v0.2" error; `ai.embed` returns an empty list. The status column in the table above is authoritative.
 

--- a/docs/src/release-notes.md
+++ b/docs/src/release-notes.md
@@ -24,6 +24,28 @@ task main() {
 }
 ```
 
+### Named tasks now work as scheduler, retry, and spawn callbacks too
+
+The same gap fixed above for value methods also affected `control.retry`,
+`control.with_timeout`, `control.with_deadline`, `schedule.every`/`.at`/
+`.cron`/`.after`, `async.spawn`, `http.serve`, and the global `min`/
+`max(by:)` — each one destructured a lambda literal's params/body directly
+and rejected a named task. A named task now works as a callback everywhere
+a lambda literal does:
+
+```keel
+use std/control
+use std/io
+
+task work() -> int {
+  42
+}
+
+task main() {
+  io.show("{control.retry(3, work)}")   # now works
+}
+```
+
 ### The native backend compiles `str` value methods
 
 `keel build --emit=kir` used to reject any `str` value method

--- a/tests/integration/util.rs
+++ b/tests/integration/util.rs
@@ -264,6 +264,33 @@ run(A)
 }
 
 #[test]
+fn control_with_timeout_rejects_missing_duration_with_a_named_task() {
+    let src = r#"
+use std/control
+
+task work() -> str {
+    "ok"
+}
+
+agent A {
+    @on_start {
+        control.with_timeout(work)
+    }
+}
+run(A)
+"#;
+    let (ok, _stdout, stderr) = run_inline(src, false);
+    assert!(
+        !ok,
+        "expected non-zero exit for missing duration with a named task"
+    );
+    assert!(
+        stderr.contains("missing duration"),
+        "expected 'missing duration' error:\n{stderr}"
+    );
+}
+
+#[test]
 fn control_with_timeout_rejects_missing_closure() {
     let src = r#"
 use std/control
@@ -1071,4 +1098,153 @@ run(AsyncTest)
         stdout.contains("42"),
         "spawned closure should be able to call user-defined task 'double':\n{stdout}"
     );
+}
+
+// ---------------------------------------------------------------------------
+// A named task works everywhere a lambda does, in closure-taking namespace
+// methods and the global min/max — issue #217. #216 fixed the 9 value
+// methods (`list.map`, …); these are the remaining sites that destructured
+// the argument into `Value::Closure`'s `(params, body)` directly and
+// rejected `Value::Task`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn control_retry_accepts_a_named_task() {
+    let src = r#"
+use std/control
+use std/io
+
+task work() -> int {
+  42
+}
+
+task main() {
+  io.show("{control.retry(3, work)}")
+}
+
+main()
+"#;
+    let (ok, stdout, stderr) = run_inline(src, false);
+    assert!(ok, "expected clean run:\n{stderr}");
+    assert!(stdout.contains("42"), "control.retry(work):\n{stdout}");
+}
+
+#[test]
+fn control_with_timeout_accepts_a_named_task() {
+    let src = r#"
+use std/control
+use std/io
+
+task work() -> int {
+  42
+}
+
+task main() {
+  io.show("{control.with_timeout(5.seconds, work)}")
+}
+
+main()
+"#;
+    let (ok, stdout, stderr) = run_inline(src, false);
+    assert!(ok, "expected clean run:\n{stderr}");
+    assert!(
+        stdout.contains("42"),
+        "control.with_timeout(work):\n{stdout}"
+    );
+}
+
+#[test]
+fn control_with_deadline_accepts_a_named_task() {
+    let src = r#"
+use std/control
+use std/io
+
+task work() -> int {
+  42
+}
+
+task main() {
+  result = control.with_deadline("2099-01-01T00:00:00Z", work)
+  io.show("{result}")
+}
+
+main()
+"#;
+    let (ok, stdout, stderr) = run_inline(src, false);
+    assert!(ok, "expected clean run:\n{stderr}");
+    assert!(
+        stdout.contains("42"),
+        "control.with_deadline(work):\n{stdout}"
+    );
+}
+
+#[test]
+fn schedule_every_accepts_a_named_task() {
+    let src = r#"
+use std/io
+use std/schedule
+
+task tick() {
+  io.show("tick")
+}
+
+agent Ticker {
+  @tools [io]
+  @on_start {
+    schedule.every(3.seconds, tick)
+  }
+}
+run(Ticker)
+"#;
+    let (ok, stdout, stderr) = run_inline(src, false);
+    assert!(ok, "expected clean run:\n{stderr}");
+    assert!(stdout.contains("tick"), "schedule.every(tick):\n{stdout}");
+}
+
+#[test]
+fn async_spawn_accepts_a_named_task() {
+    let src = r#"
+use std/async
+use std/io
+
+task work() -> int {
+  42
+}
+
+agent AsyncTest {
+    @tools [io]
+    @on_start {
+        h = async.spawn(work)
+        results = async.join_all([h])
+        io.show("{results}")
+        stop(self)
+    }
+}
+run(AsyncTest)
+"#;
+    let (ok, stdout, stderr) = run_inline(src, false);
+    assert!(ok, "expected clean run:\n{stderr}");
+    assert!(stdout.contains("42"), "async.spawn(work):\n{stdout}");
+}
+
+#[test]
+fn min_and_max_by_accept_a_named_task() {
+    let src = r#"
+use std/io
+
+task negate(x: int) -> int {
+  0 - x
+}
+
+task main() {
+  io.show("{min([1, 2, 3], by: negate)}")
+  io.show("{max([1, 2, 3], by: negate)}")
+}
+
+main()
+"#;
+    let (ok, stdout, stderr) = run_inline(src, false);
+    assert!(ok, "expected clean run:\n{stderr}");
+    assert!(stdout.contains('3'), "min(by: negate):\n{stdout}");
+    assert!(stdout.contains('1'), "max(by: negate):\n{stdout}");
 }


### PR DESCRIPTION
## Summary

- #216 fixed 9 closure-taking value methods (`list.map`, …) that only accepted `Value::Closure`, never a named task used as a value (`Value::Task`, SPEC §7). The same gap existed at 10 more sites that destructured a function argument straight into a `Value::Closure`'s `(params, body)`:
  - `control.retry`, `control.with_timeout`, `control.with_deadline`
  - `schedule.every`, `schedule.at`, `schedule.cron`, `schedule.after`
  - `async.spawn`
  - `http.serve`
  - the global `min`/`max(by:)`
- `schedule.every(5.minutes, my_task)` (a named task instead of a `() => {...}` lambda) failed the same way `list.map(my_task)` did before #216 — `keel check` accepts it, `keel run` rejects it with "missing closure argument".
- `ScheduledClosure` (the record `schedule.*`/`http.serve` register for later firing via `Event::FireClosure`) now stores the function `Value` itself instead of pre-destructured `params`/`body`, and `Host::spawn_closure` takes a `Value` too. Every call site now dispatches through the same `call_fn_value`/`find_fn_value`/`is_fn_value` helpers introduced for #216, so `Value::Closure` and `Value::Task` are handled uniformly everywhere a function value is accepted.
- `control.with_timeout`'s "missing duration" guard also only recognized `Value::Closure` at position 0 — a named task there previously slipped past it into a worse `expect_duration` error. Fixed alongside the rest.

## Test plan

- [x] Verified all four exit-criterion calls diverge before the fix (`keel check` accepts, `keel run` rejects) for `control.retry`, `schedule.every`, `async.spawn`, `http.serve`, plus the `min`/`max(by:)` site found during the sweep
- [x] New integration tests in `tests/integration/util.rs`: named-task coverage for `control.retry`, `control.with_timeout`, `control.with_deadline` (including the `with_timeout` missing-duration guard with a named task at position 0), `schedule.every`, `async.spawn`, and `min`/`max(by:)`
- [x] `http.serve` verified manually end-to-end (`curl` against a named-task handler returned the expected body) rather than with an automated test — the repo has no `http.serve` test harness today (it's excluded from the conformance corpus by name as a long-running server), so adding port-binding test infra was out of scope here
- [x] `cargo test -q --workspace`: all passing
- [x] `cargo clippy -q --workspace --all-targets -- -D warnings`: clean
- [x] `mdbook build`: clean

Close #217