### PR TITLE
Fix crypto.hmac_* argument order to match the catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to Keel.
 
 ## [Unreleased]
 
-%%TAGLINE%% Named functions now work everywhere a lambda does, lambdas get formal non-capturing semantics, and the LLVM backend closes the gap on stdlib calls and string methods.
+%%TAGLINE%% Named functions now work everywhere a lambda does, lambdas get formal non-capturing semantics, `crypto.hmac_*` gets a breaking argument-order fix, and the LLVM backend closes the gap on stdlib calls and string methods.
 
 ### Added
 
@@ -57,6 +57,15 @@ task work() -> int {
 task main() {
   io.show("{control.retry(3, work)}")   # now works — was "missing closure argument"
 }
+```
+
+- **`crypto.hmac_sha224`/`hmac_sha256`/`hmac_sha384`/`hmac_sha512`/`hmac_sha512_224`/`hmac_sha512_256` read arguments in the opposite order from what the catalog declared.** The catalog (`keel-catalog`) has always declared both params required and positional, in the order `key, data` — and `keel check` validated calls against that — but the runtime read `data` positionally at index 0 and `key` by name only, so `crypto.hmac_sha256("k", "d")` passed `keel check` and then failed at `keel run` with `` missing `key:` argument ``; the only call that actually worked was `crypto.hmac_sha256("d", key: "k")`, which contradicted the declared order and every other namespace method's "required params are positional" convention. Both arguments are now read positionally, `key` then `data`, matching the catalog and `keel check`. **Breaking:** any call passing `key:` by name (`crypto.hmac_sha256(data, key: secret)`) must switch to positional order (`crypto.hmac_sha256(secret, data)`).
+
+```keel
+use std/crypto
+use std/io
+
+io.show(crypto.hmac_sha256("secret", "message"))   # now the only valid call — was key:-named
 ```
 
 - **The native backend miscompiled any namespace call with a non-`Unit` result used as a value.** `emit_ns_call` (`keel-codegen`) was written for M1's `io.show`/`log.*`-only namespace calls and unconditionally returned a hardcoded `i1 false`, discarding the real `KeelRes` payload — but nothing in `keel-kir`'s lowering ever restricted `CallTarget::Ns` to `Unit` results, so a scalar-returning stdlib call (`math.sqrt`, `crypto.sha256`, …) used in value position passed lowering and then panicked codegen on a type mismatch. It now unboxes the payload to the call's real result type, matching the interpreter:

--- a/SPEC.md
+++ b/SPEC.md
@@ -506,7 +506,7 @@ The Keel standard library lives in a set of modules imported with `use std/<name
 | `std/log` | Structured logging | `info`, `warn`, `error`, `debug` |
 | `std/random` | Pseudo-random generation | `float()`, `int(min:, max:)`, `bool()` |
 | `std/uuid` | UUID constructors (the `Uuid` *type* is built in) | `v4()`, `v7()`, `v5(ns:, name:)`, `parse(s)` |
-| `std/crypto` | Cryptographic primitives | `sha256(data)`, `hmac_sha256(data, key:)`, `token(bytes:)`, `random_bytes(n)` |
+| `std/crypto` | Cryptographic primitives | `sha256(data)`, `hmac_sha256(key, data)`, `token(bytes:)`, `random_bytes(n)` |
 | `std/math` | Transcendental and power functions | `PI()`, `E()`, `sqrt(x)`, `pow(x, y)`, `exp(x)`, `log(x)`, `log2(x)`, `log10(x)`, `sin(x)`, `cos(x)`, `tan(x)`, `asin(x)`, `acos(x)`, `atan(x)`, `atan2(y, x)` |
 | `std/csv` | CSV serialization | `parse(text)`, `parse_records(text)`, `stringify(rows)` |
 | `std/testing` | Test doubles | `mock(module.method)` (§19) |
@@ -1929,19 +1929,19 @@ id.format(as: "simple")                            # "f47ac10b58cc4372a5670e02b2
 | `crypto.sha512(data)` | `str` | SHA-512 hex digest |
 | `crypto.sha512_224(data)` | `str` | SHA-512/224 hex digest |
 | `crypto.sha512_256(data)` | `str` | SHA-512/256 hex digest |
-| `crypto.hmac_sha224(data, key:)` | `str` | HMAC-SHA-224 hex signature |
-| `crypto.hmac_sha256(data, key:)` | `str` | HMAC-SHA-256 hex signature |
-| `crypto.hmac_sha384(data, key:)` | `str` | HMAC-SHA-384 hex signature |
-| `crypto.hmac_sha512(data, key:)` | `str` | HMAC-SHA-512 hex signature |
-| `crypto.hmac_sha512_224(data, key:)` | `str` | HMAC-SHA-512/224 hex signature |
-| `crypto.hmac_sha512_256(data, key:)` | `str` | HMAC-SHA-512/256 hex signature |
+| `crypto.hmac_sha224(key, data)` | `str` | HMAC-SHA-224 hex signature |
+| `crypto.hmac_sha256(key, data)` | `str` | HMAC-SHA-256 hex signature |
+| `crypto.hmac_sha384(key, data)` | `str` | HMAC-SHA-384 hex signature |
+| `crypto.hmac_sha512(key, data)` | `str` | HMAC-SHA-512 hex signature |
+| `crypto.hmac_sha512_224(key, data)` | `str` | HMAC-SHA-512/224 hex signature |
+| `crypto.hmac_sha512_256(key, data)` | `str` | HMAC-SHA-512/256 hex signature |
 | `crypto.token(bytes: 32)` | `str` | Cryptographically secure random hex token |
 | `crypto.random_bytes(n)` | `list[int]` | `n` CSPRNG bytes |
 
 ```keel
 crypto.sha256("hello")                        # "2cf24db..."
 crypto.sha384("hello")
-crypto.hmac_sha256("msg", key: secret)
+crypto.hmac_sha256(secret, "msg")
 crypto.token()                                # 64-char hex string (32 bytes)
 crypto.token(bytes: 16)                       # 32-char hex string
 crypto.random_bytes(16)                       # list[int] of 16 bytes

--- a/crates/keel-runtime/src/runtime/namespaces/crypto.rs
+++ b/crates/keel-runtime/src/runtime/namespaces/crypto.rs
@@ -2,7 +2,7 @@ use sha2::{Digest, Sha224, Sha256, Sha384, Sha512, Sha512_224, Sha512_256};
 
 use crate::interpreter::value::Value;
 use crate::interpreter::{CallArgValue, Namespace};
-use crate::runtime::args::{expect_int, expect_str, expect_str_named};
+use crate::runtime::args::{expect_int, expect_str};
 use crate::runtime::namespace::{find_arg, ns, positional};
 
 const DEFAULT_TOKEN_BYTES: usize = 32;
@@ -83,9 +83,8 @@ fn hash_call(args: Vec<CallArgValue>, algo: HashAlgo, context: &str) -> miette::
 }
 
 fn hmac_call(args: Vec<CallArgValue>, algo: HashAlgo, context: &str) -> miette::Result<Value> {
-    let data = expect_str(&args, 0, context)?;
-    let key = expect_str_named(&args, "key", context)?
-        .ok_or_else(|| miette::miette!("{context}: missing `key:` argument"))?;
+    let key = expect_str(&args, 0, context)?;
+    let data = expect_str(&args, 1, context)?;
     Ok(Value::String(hmac_hex(
         key.as_bytes(),
         data.as_bytes(),

--- a/docs/src/guide/stdlib.md
+++ b/docs/src/guide/stdlib.md
@@ -146,7 +146,7 @@ simple = id.format(as: "simple")
 ```keel
 digest = crypto.sha256("hello")
 wide = crypto.sha384("hello")
-sig = crypto.hmac_sha256("message", key: secret)
+sig = crypto.hmac_sha256(secret, "message")
 token = crypto.token(bytes: 32)
 bytes = crypto.random_bytes(16)
 ```

--- a/docs/src/release-notes.md
+++ b/docs/src/release-notes.md
@@ -46,6 +46,26 @@ task main() {
 }
 ```
 
+### `crypto.hmac_*` now takes `key, data` positionally — no more `key:`
+
+The HMAC family (`hmac_sha224`/`hmac_sha256`/`hmac_sha384`/`hmac_sha512`/
+`hmac_sha512_224`/`hmac_sha512_256`) read arguments in the opposite order
+from what the catalog declared: `key` was name-only and `data` was
+positional, even though `keel check` validated calls against the declared
+`key, data` positional order. `crypto.hmac_sha256("k", "d")` passed `keel
+check` and then failed at `keel run`. Both arguments are now positional,
+`key` then `data`, matching what `keel check` always expected.
+
+```keel
+use std/crypto
+use std/io
+
+io.show(crypto.hmac_sha256("secret", "message"))
+```
+
+**Breaking:** replace `crypto.hmac_sha256(data, key: secret)` with
+`crypto.hmac_sha256(secret, data)`.
+
 ### The native backend compiles `str` value methods
 
 `keel build --emit=kir` used to reject any `str` value method

--- a/examples/crypto_demo.keel
+++ b/examples/crypto_demo.keel
@@ -6,7 +6,7 @@ agent CryptoDemo {
   @on_start {
     digest = crypto.sha256("hello")
     wide = crypto.sha384("hello")
-    sig = crypto.hmac_sha256("message", key: "secret")
+    sig = crypto.hmac_sha256("secret", "message")
     token = crypto.token(bytes: 16)
     bytes = crypto.random_bytes(8)
     io.show("digest={digest} wide={wide} sig={sig} token={token} bytes={bytes}")
@@ -22,7 +22,7 @@ test "sha256 of a known input" {
 }
 
 test "hmac-sha256 with a known key" {
-  assert crypto.hmac_sha256("message", key: "secret") == "8b5f48702995c1598c573db1e21866a9b825d4a794d169d7060a03605796360b"
+  assert crypto.hmac_sha256("secret", "message") == "8b5f48702995c1598c573db1e21866a9b825d4a794d169d7060a03605796360b"
 }
 
 test "token length follows the byte count" {

--- a/examples/trading_bot/execution.keel
+++ b/examples/trading_bot/execution.keel
@@ -8,7 +8,7 @@ use OrderSide, TradeRecord, TradingDecision, Portfolio from "./types.keel"
 
 task sign_payload(side: OrderSide, qty: float, price: float) -> str {
   payload = "side={side}&qty={qty:.8f}&price={price:.2f}&ts={time.epoch_ms()}"
-  crypto.hmac_sha256(payload, key: "paper-trading-secret")
+  crypto.hmac_sha256("paper-trading-secret", payload)
 }
 
 task simulate_fill(decision: TradingDecision, side: OrderSide, qty: float, price: float) -> TradeRecord {

--- a/tests/integration/namespaces/data.rs
+++ b/tests/integration/namespaces/data.rs
@@ -151,7 +151,7 @@ agent A {
     @on_start {
         digest = crypto.sha256("hello")
         wide = crypto.sha384("hello")
-        sig = crypto.hmac_sha256("The quick brown fox jumps over the lazy dog", key: "key")
+        sig = crypto.hmac_sha256("key", "The quick brown fox jumps over the lazy dog")
         token = crypto.token(bytes: 16)
         bytes = crypto.random_bytes(4)
         if digest == "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824" and wide == "59e1748777448c69de6b800d7a33bbfb9ff1b463e44354c3553bcdb9c666fa90125a3c79f90397bdf5f6a13de828684f" and sig == "f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8" and token.len() == 32 and bytes.len() == 4 {
@@ -168,6 +168,31 @@ run(A)
         "Crypto namespace program failed\nstdout: {stdout}\nstderr: {stderr}"
     );
     assert!(stdout.contains("crypto-ok"), "{stdout}");
+}
+
+// Regression: hmac_sha256 read `data` positionally and `key` by name only,
+// diverging from the catalog's declared `key, data` positional order —
+// `keel check` accepted `hmac_sha256("k", "d")` and `keel run` rejected it
+// with "missing `key:` argument" (issue #211).
+#[test]
+fn hmac_sha256_takes_key_then_data_positionally_matching_the_checker() {
+    let src = r#"
+use std/crypto
+use std/io
+task main() {
+    io.show(crypto.hmac_sha256("key", "The quick brown fox jumps over the lazy dog"))
+}
+main()
+"#;
+    let (ok, stdout, stderr) = run_inline(src, false);
+    assert!(
+        ok,
+        "hmac_sha256(key, data) should run cleanly\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8"),
+        "expected the known HMAC-SHA256 test vector:\n{stdout}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- `crypto.hmac_sha224`/`hmac_sha256`/`hmac_sha384`/`hmac_sha512`/`hmac_sha512_224`/`hmac_sha512_256` read `data` positionally at index 0 and `key` by name only, even though the catalog (`keel-catalog`) has always declared both params required and positional, in the order `key, data`.
- `keel check` validates calls against the catalog's declared signature, so `crypto.hmac_sha256("k", "d")` passed check — and then failed at `keel run` with `` missing `key:` argument ``. The only call that actually worked was `crypto.hmac_sha256("d", key: "k")`, which contradicted the declared order and every other namespace method's "required params are positional" convention (`file.write(path, content)`, `file.copy(src, dst)`, …).
- Both arguments are now read positionally, `key` then `data`, matching the catalog and `keel check`.
- **Breaking:** any call using `key:` by name (`crypto.hmac_sha256(data, key: secret)`) must switch to positional order (`crypto.hmac_sha256(secret, data)`). Updated all in-repo call sites: `examples/crypto_demo.keel`, `examples/trading_bot/execution.keel`, `tests/integration/namespaces/data.rs`.

## Scope note

While verifying the fix, I found that `keel check` never actually validates a namespace call's argument names/arity against the catalog's declared `params` at all — confirmed with `file.write(content:, path:)`, an unrelated namespace method, showing the identical check-passes/run-fails pattern for a keyword-named required-positional arg. That's a much broader, pre-existing gap across all 23 `std/*` namespaces, not specific to hmac, and fixing it means building real argument validation into the checker — out of scope for this argument-*order* fix. Filed separately as #222.

## Test plan

- [x] Verified the repro from #211: `crypto.hmac_sha256("k", "d")` now passes both `keel check` and `keel run` and produces a value (previously ran but errored)
- [x] New regression test in `tests/integration/namespaces/data.rs` against the known HMAC-SHA256 test vector (`key="key"`, `data="The quick brown fox..."` → `f7bc83f4...`), confirming `key`/`data` didn't silently swap semantics
- [x] Updated the existing crypto namespace integration test and both example files (`crypto_demo.keel`, `trading_bot/execution.keel`) to the new positional call form; `keel check`/`keel test` pass on both
- [x] `cargo test -q --workspace`: all passing
- [x] `cargo clippy -q --workspace --all-targets -- -D warnings`: clean
- [x] `mdbook build`: clean

Close #211