### PR TITLE
Make and/or short-circuit in the interpreter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to Keel.
 
 ## [Unreleased]
 
-%%TAGLINE%% Named functions now work everywhere a lambda does, lambdas get formal non-capturing semantics, `crypto.hmac_*` gets a breaking argument-order fix, and the LLVM backend closes the gap on stdlib calls and string methods.
+%%TAGLINE%% Named functions now work everywhere a lambda does, `and`/`or` finally short-circuit, `crypto.hmac_*` gets a breaking argument-order fix, and the LLVM backend closes the gap on stdlib calls and string methods.
 
 ### Added
 
@@ -66,6 +66,22 @@ use std/crypto
 use std/io
 
 io.show(crypto.hmac_sha256("secret", "message"))   # now the only valid call — was key:-named
+```
+
+- **`and`/`or` never short-circuited — the right operand always ran, even when the left already decided the result.** `Expr::BinaryOp` evaluated both operands unconditionally before ever looking at the operator, so `flag and side_effect()` ran `side_effect()` even with `flag = false`, and likewise for `or` with a truthy left operand. This affected the interpreter itself, not just the native backend — `keel run` was wrong, not just `keel build`. `and`/`or` now short-circuit: the right operand is only evaluated when the left one doesn't already determine the result, matching every other language's boolean operators and the assumption `keel-kir`'s own `when`-lowering already made about this behavior.
+
+```keel
+task side_effect() -> bool {
+  io.show("evaluated")
+  true
+}
+
+task main() {
+  flag = false
+  flag and side_effect()   # "evaluated" no longer prints — was printing unconditionally
+}
+
+main()
 ```
 
 - **The native backend miscompiled any namespace call with a non-`Unit` result used as a value.** `emit_ns_call` (`keel-codegen`) was written for M1's `io.show`/`log.*`-only namespace calls and unconditionally returned a hardcoded `i1 false`, discarding the real `KeelRes` payload — but nothing in `keel-kir`'s lowering ever restricted `CallTarget::Ns` to `Unit` results, so a scalar-returning stdlib call (`math.sqrt`, `crypto.sha256`, …) used in value position passed lowering and then panicked codegen on a type mismatch. It now unboxes the payload to the call's real result type, matching the interpreter:

--- a/SPEC.md
+++ b/SPEC.md
@@ -2260,6 +2260,20 @@ planned.
 | `+=` `-=` `*=` `/=` | Augmented assignment — desugars to `x = x op rhs` |
 | `...expr` | Spread — expands `list[T]` or `set[T]` into variadic slots at a call site |
 
+`and`/`or` short-circuit: the right operand is evaluated only when the
+left one doesn't already decide the result (`false` for `and`, `true` for
+`or`). A right operand with a side effect does not run when short-circuited:
+
+```keel
+task log_and_true() -> bool {
+  io.show("evaluated")
+  true
+}
+
+false and log_and_true()   # "evaluated" never prints — result is false
+true or log_and_true()     # "evaluated" never prints — result is true
+```
+
 ### `as T` coercion rules
 
 `expr as T` coerces the value at runtime. Unsupported conversions raise.

--- a/crates/keel-runtime/src/interpreter/expr.rs
+++ b/crates/keel-runtime/src/interpreter/expr.rs
@@ -4,7 +4,9 @@ use std::pin::Pin;
 
 use miette::Result;
 
-use crate::ast::{CallArg, Expr, Node, SpannedExpr, StringPart, TypeExpr, UnOp, tuple_index};
+use crate::ast::{
+    BinOp, CallArg, Expr, Node, SpannedExpr, StringPart, TypeExpr, UnOp, tuple_index,
+};
 
 use super::environment::Environment;
 use super::host::Host;
@@ -568,6 +570,19 @@ impl Interpreter {
                         ExprFlow::Value(v) => v,
                         early => return Ok(early),
                     };
+                    // `and`/`or` short-circuit: the right operand is only
+                    // evaluated when the left one didn't already decide the
+                    // result (issue #224). Every other operator evaluates
+                    // both operands unconditionally.
+                    match op {
+                        BinOp::And if !l.is_truthy() => {
+                            return Ok(ExprFlow::Value(Value::Bool(false)));
+                        }
+                        BinOp::Or if l.is_truthy() => {
+                            return Ok(ExprFlow::Value(Value::Bool(true)));
+                        }
+                        _ => {}
+                    }
                     let r = match self.eval_expr(right, env).await? {
                         ExprFlow::Value(v) => v,
                         early => return Ok(early),

--- a/docs/src/release-notes.md
+++ b/docs/src/release-notes.md
@@ -66,6 +66,29 @@ io.show(crypto.hmac_sha256("secret", "message"))
 **Breaking:** replace `crypto.hmac_sha256(data, key: secret)` with
 `crypto.hmac_sha256(secret, data)`.
 
+### `and`/`or` now short-circuit
+
+The right operand of `and`/`or` used to run unconditionally — even after
+the left operand already decided the result — in the interpreter itself,
+not just the native backend. `flag and side_effect()` ran `side_effect()`
+even when `flag` was `false`. `and`/`or` now short-circuit like every other
+language's boolean operators: the right operand only runs when the left one
+doesn't already determine the result.
+
+```keel
+task side_effect() -> bool {
+  io.show("evaluated")
+  true
+}
+
+task main() {
+  flag = false
+  flag and side_effect()   # "evaluated" no longer prints
+}
+
+main()
+```
+
 ### The native backend compiles `str` value methods
 
 `keel build --emit=kir` used to reject any `str` value method

--- a/tests/integration/language/operators.rs
+++ b/tests/integration/language/operators.rs
@@ -471,3 +471,115 @@ run(A)
         "expected spread/variadic error:\n{stderr}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// `and`/`or` short-circuit evaluation (issue #224)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn and_does_not_evaluate_right_operand_when_left_is_falsy() {
+    let src = r#"
+use std/io
+
+task side_effect() -> bool {
+  io.show("evaluated")
+  true
+}
+
+task main() {
+  flag = false
+  result = flag and side_effect()
+  io.show("{result}")
+}
+
+main()
+"#;
+    let (ok, stdout, stderr) = run_inline(src, false);
+    assert!(ok, "program failed\nstdout: {stdout}\nstderr: {stderr}");
+    assert!(
+        !stdout.contains("evaluated"),
+        "right operand of `and` must not run when the left is falsy:\n{stdout}"
+    );
+    assert!(stdout.contains("false"), "expected false:\n{stdout}");
+}
+
+#[test]
+fn or_does_not_evaluate_right_operand_when_left_is_truthy() {
+    let src = r#"
+use std/io
+
+task side_effect() -> bool {
+  io.show("evaluated")
+  true
+}
+
+task main() {
+  flag = true
+  result = flag or side_effect()
+  io.show("{result}")
+}
+
+main()
+"#;
+    let (ok, stdout, stderr) = run_inline(src, false);
+    assert!(ok, "program failed\nstdout: {stdout}\nstderr: {stderr}");
+    assert!(
+        !stdout.contains("evaluated"),
+        "right operand of `or` must not run when the left is truthy:\n{stdout}"
+    );
+    assert!(stdout.contains("true"), "expected true:\n{stdout}");
+}
+
+#[test]
+fn and_still_evaluates_right_operand_when_left_is_truthy() {
+    let src = r#"
+use std/io
+
+task side_effect() -> bool {
+  io.show("evaluated")
+  false
+}
+
+task main() {
+  flag = true
+  result = flag and side_effect()
+  io.show("{result}")
+}
+
+main()
+"#;
+    let (ok, stdout, stderr) = run_inline(src, false);
+    assert!(ok, "program failed\nstdout: {stdout}\nstderr: {stderr}");
+    assert!(
+        stdout.contains("evaluated"),
+        "right operand of `and` must still run when the left is truthy:\n{stdout}"
+    );
+    assert!(stdout.contains("false"), "expected false:\n{stdout}");
+}
+
+#[test]
+fn or_still_evaluates_right_operand_when_left_is_falsy() {
+    let src = r#"
+use std/io
+
+task side_effect() -> bool {
+  io.show("evaluated")
+  true
+}
+
+task main() {
+  flag = false
+  result = flag or side_effect()
+  io.show("{result}")
+}
+
+main()
+"#;
+    let (ok, stdout, stderr) = run_inline(src, false);
+    assert!(ok, "program failed\nstdout: {stdout}\nstderr: {stderr}");
+    assert!(
+        stdout.contains("evaluated"),
+        "right operand of `or` must still run when the left is falsy:\n{stdout}"
+    );
+    assert!(stdout.contains("true"), "expected true:\n{stdout}");
+}


### PR DESCRIPTION
## Summary

- `and`/`or` never short-circuited anywhere in Keel — not even in the tree-walking interpreter, the ground-truth execution path. `Expr::BinaryOp` (`crates/keel-runtime/src/interpreter/expr.rs`) evaluated both operands unconditionally before ever inspecting the operator, then handed both values to `eval_binary`, which just computed `a.is_truthy() && b.is_truthy()` over two already-evaluated values.
- This was despite `keel-kir`'s own lowering code (`lower/expr.rs:162-176`) already assuming short-circuiting was real — it rejects hoisting a `when`/`if` out of the right operand of `and`/`or` specifically to preserve that semantic, a premise that was never actually true of any execution path until now.
- Discovered while investigating #193, which is scoped to the compiled backend's `when`-lowering and implicitly assumes the interpreter already short-circuits correctly. It didn't, so #193 couldn't have been correctly built on top of it.
- Fix: `Expr::BinaryOp`'s `And`/`Or` arms now check the left operand's truthiness before evaluating the right one at all, returning early with the already-decided `Bool` result. Value semantics are preserved exactly — the short-circuited result matches what `eval_binary` would have computed, just without the unnecessary (and now potentially wrong) evaluation.
- **Explicitly out of scope:** flow-sensitive type narrowing from a short-circuited `and`/`or` (e.g. `x != none and x!.field` still doesn't type-check) — that's a separate, much larger checker feature. The native backend's `and`/`or` codegen is still eager (unchanged by this PR) — filed separately as #225, since it now diverges from the interpreter on any side-effecting right operand.

## Test plan

- [x] Manual repro: `flag = false; flag and side_effect()` no longer runs `side_effect()`; `flag = true; flag or side_effect()` likewise
- [x] Controls confirmed the right operand still runs when it must: `true and side_effect()`, `false or side_effect()`
- [x] 4 new integration tests in `tests/integration/language/operators.rs`
- [x] `cargo test -q --workspace`: all passing
- [x] `cargo test -q --test conformance --features build-backend`: passing — interpreter and compiled backend still byte-identical across the full example/fixture corpus (no covered program has a side-effecting `and`/`or` right operand, so this doesn't catch the interpreter/compiled divergence #225 tracks, but confirms nothing already in the corpus regressed)
- [x] `cargo clippy -q --workspace --all-targets -- -D warnings`: clean
- [x] `mdbook build`: clean

Close #224