### PR TITLE
Make and/or short-circuit in the native backend too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,20 @@ task main() {
 main()
 ```
 
+- **The native backend's `and`/`or` codegen didn't short-circuit either, diverging from the interpreter fix above.** `keel-codegen` emitted `and`/`or` as an eager LLVM `and`/`or` instruction over two unconditionally-evaluated operands — the same bug the interpreter fix removes there, but codegen needed its own fix since it doesn't share the interpreter's evaluator. `emit_binop` now routes `And`/`Or` to a dedicated short-circuit path that branches on the left operand first and only emits the right operand's code inside the taken branch, mirroring the existing `??` short-circuit codegen (`nullable.rs`'s `emit_null_coalesce`). No `keel-kir` lowering changed — `Expr::BinOp{And|Or}` is still a flat node; the branching is entirely a `keel-codegen` concern, so a `while`/`??`/`when`-in-operand position that already compiled continues to:
+
+```keel
+use std/io
+
+task side_effect() -> bool {
+  io.show("evaluated")
+  true
+}
+
+flag = false
+flag and side_effect()   # compiled and interpreted now agree: "evaluated" never prints
+```
+
 - **The native backend miscompiled any namespace call with a non-`Unit` result used as a value.** `emit_ns_call` (`keel-codegen`) was written for M1's `io.show`/`log.*`-only namespace calls and unconditionally returned a hardcoded `i1 false`, discarding the real `KeelRes` payload — but nothing in `keel-kir`'s lowering ever restricted `CallTarget::Ns` to `Unit` results, so a scalar-returning stdlib call (`math.sqrt`, `crypto.sha256`, …) used in value position passed lowering and then panicked codegen on a type mismatch. It now unboxes the payload to the call's real result type, matching the interpreter:
 
 ```keel

--- a/crates/keel-codegen/src/expr.rs
+++ b/crates/keel-codegen/src/expr.rs
@@ -269,6 +269,13 @@ fn emit_binop<'ctx>(
     left: &Expr,
     right: &Expr,
 ) -> Result<BasicValueEnum<'ctx>, CodegenError> {
+    // `and`/`or` short-circuit (issue #225): the right operand must not be
+    // evaluated at all when the left one already decides the result, so it
+    // can't go through the eager "evaluate both, then dispatch on the
+    // operator" path below — branch on the left value first instead.
+    if matches!(op, BinOp::And | BinOp::Or) {
+        return emit_short_circuit(fcx, op, left, right);
+    }
     // Both operands share a type by construction (`infer_binop_ty`), so the
     // left operand's KIR type picks which LLVM instructions to emit.
     let operand_ty = left.ty();
@@ -374,8 +381,8 @@ fn emit_binop<'ctx>(
                     .build_int_compare(IntPredicate::NE, l, r, "bne")
                     .map_err(llvm_err)?
                     .into(),
-                BinOp::And => b.build_and(l, r, "and").map_err(llvm_err)?.into(),
-                BinOp::Or => b.build_or(l, r, "or").map_err(llvm_err)?.into(),
+                // `And`/`Or` never reach here — `emit_binop` routes them to
+                // `emit_short_circuit` before this match.
                 _ => return Err(unreachable_combo(op, operand_ty)),
             };
             Ok(result)
@@ -448,6 +455,85 @@ fn emit_binop<'ctx>(
         | KirType::Nullable(_)
         | KirType::Tuple(_) => Err(unreachable_combo(op, operand_ty)),
     }
+}
+
+/// `left and right` / `left or right` — short-circuits: `right` is only
+/// evaluated, and only its basic block entered, when the left operand
+/// doesn't already decide the result (`false` for `and`, `true` for `or`) —
+/// issue #225, matching the interpreter fix in #224. Uses an `alloca`'d
+/// result slot rather than a phi node, mirroring `nullable.rs`'s
+/// `emit_null_coalesce`: `right`'s own codegen may itself branch (a nested
+/// `and`/`or`, `??`, a call that can raise) and leave the builder positioned
+/// in a different block than the one this function creates, so the merge
+/// block just loads the slot instead of tracking which block to route a phi
+/// incoming from.
+fn emit_short_circuit<'ctx>(
+    fcx: &FuncCtx<'ctx, '_>,
+    op: BinOp,
+    left: &Expr,
+    right: &Expr,
+) -> Result<BasicValueEnum<'ctx>, CodegenError> {
+    // `keel-kir`'s `infer_binop_ty` only accepts `And`/`Or` over `bool`
+    // operands, so anything else reaching here is a codegen bug, not a bad
+    // program — check explicitly rather than letting a wrong-width value
+    // reach `build_conditional_branch`, which LLVM would reject with an
+    // opaque verifier error instead of this crate's own diagnostic.
+    if left.ty() != KirType::Bool {
+        return Err(unreachable_combo(op, left.ty()));
+    }
+    let lv = emit_expr(fcx, left)?.into_int_value();
+    let bool_ty = fcx.context.bool_type();
+
+    let result_ptr = fcx
+        .builder
+        .build_alloca(bool_ty, "shortcircuit.result")
+        .map_err(llvm_err)?;
+
+    let rhs_bb = fcx
+        .context
+        .append_basic_block(fcx.function, "shortcircuit.rhs");
+    let short_bb = fcx
+        .context
+        .append_basic_block(fcx.function, "shortcircuit.short");
+    let merge_bb = fcx
+        .context
+        .append_basic_block(fcx.function, "shortcircuit.merge");
+
+    // `and`: a true left still needs `right`; a false left already decided.
+    // `or`: a true left already decided; a false left still needs `right`.
+    let (true_dest, false_dest) = match op {
+        BinOp::And => (rhs_bb, short_bb),
+        BinOp::Or => (short_bb, rhs_bb),
+        _ => unreachable!("emit_binop only routes And/Or here"),
+    };
+    fcx.builder
+        .build_conditional_branch(lv, true_dest, false_dest)
+        .map_err(llvm_err)?;
+
+    fcx.builder.position_at_end(short_bb);
+    let short_value = match op {
+        BinOp::And => bool_ty.const_int(0, false),
+        BinOp::Or => bool_ty.const_int(1, false),
+        _ => unreachable!("emit_binop only routes And/Or here"),
+    };
+    fcx.builder
+        .build_store(result_ptr, short_value)
+        .map_err(llvm_err)?;
+    fcx.builder
+        .build_unconditional_branch(merge_bb)
+        .map_err(llvm_err)?;
+
+    fcx.builder.position_at_end(rhs_bb);
+    let rv = emit_expr(fcx, right)?;
+    fcx.builder.build_store(result_ptr, rv).map_err(llvm_err)?;
+    fcx.builder
+        .build_unconditional_branch(merge_bb)
+        .map_err(llvm_err)?;
+
+    fcx.builder.position_at_end(merge_bb);
+    fcx.builder
+        .build_load(bool_ty, result_ptr, "shortcircuit.load")
+        .map_err(llvm_err)
 }
 
 fn emit_unop<'ctx>(

--- a/crates/keel-codegen/tests/short_circuit.rs
+++ b/crates/keel-codegen/tests/short_circuit.rs
@@ -1,0 +1,159 @@
+//! Exit criterion for issue #225: `and`/`or` short-circuit in compiled code
+//! the same way #224 made them short-circuit in the interpreter — a
+//! side-effecting right operand must not run when the left operand already
+//! decides the result.
+
+use std::process::Command;
+
+use keel_codegen::BuildOptions;
+
+#[path = "support/mod.rs"]
+mod support;
+
+fn compile_and_run(source: &str) -> std::process::Output {
+    let kir = support::parse_check_and_lower(source);
+
+    let out_dir = tempfile::tempdir().expect("create temp out dir");
+    let opts = BuildOptions {
+        out_dir: out_dir.path().to_path_buf(),
+        runtime_link_args: support::runtime_link_args().clone(),
+    };
+    let bin = keel_codegen::compile(&kir, &opts).expect("compile must succeed");
+    Command::new(&bin).output().expect("run compiled binary")
+}
+
+fn assert_matches_interpreter(source: &str, expected_stdout: &[u8]) {
+    let compiled = compile_and_run(source);
+    let interpreted = support::run_interpreter(source);
+
+    assert_eq!(
+        String::from_utf8_lossy(&compiled.stdout),
+        String::from_utf8_lossy(&interpreted.stdout),
+        "compiled stdout must match the interpreter's"
+    );
+    assert_eq!(compiled.stdout, expected_stdout);
+}
+
+#[test]
+fn and_does_not_run_the_right_operand_when_the_left_is_false() {
+    let source = r#"
+use std/io
+
+task side_effect() -> bool {
+  io.show("evaluated")
+  true
+}
+
+flag = false
+result = flag and side_effect()
+io.show("{result}")
+"#;
+    assert_matches_interpreter(source, b"  false\n");
+}
+
+#[test]
+fn or_does_not_run_the_right_operand_when_the_left_is_true() {
+    let source = r#"
+use std/io
+
+task side_effect() -> bool {
+  io.show("evaluated")
+  true
+}
+
+flag = true
+result = flag or side_effect()
+io.show("{result}")
+"#;
+    assert_matches_interpreter(source, b"  true\n");
+}
+
+#[test]
+fn and_still_runs_the_right_operand_when_the_left_is_true() {
+    let source = r#"
+use std/io
+
+task side_effect() -> bool {
+  io.show("evaluated")
+  false
+}
+
+flag = true
+result = flag and side_effect()
+io.show("{result}")
+"#;
+    assert_matches_interpreter(source, b"  evaluated\n  false\n");
+}
+
+#[test]
+fn or_still_runs_the_right_operand_when_the_left_is_false() {
+    let source = r#"
+use std/io
+
+task side_effect() -> bool {
+  io.show("evaluated")
+  true
+}
+
+flag = false
+result = flag or side_effect()
+io.show("{result}")
+"#;
+    assert_matches_interpreter(source, b"  evaluated\n  true\n");
+}
+
+#[test]
+fn nested_short_circuit_skips_the_inner_expression_entirely() {
+    // The outer `and` short-circuits on `flag = false`, so the right
+    // operand — itself a short-circuiting `or` over two calls — must never
+    // run at all: neither `check_a` nor `check_b` should execute. This is
+    // the case `emit_short_circuit`'s alloca-over-phi design targets: the
+    // inner `or`'s own codegen builds its own basic blocks, so if it ran,
+    // the builder would be left positioned somewhere other than the block
+    // this outer call created.
+    let source = r#"
+use std/io
+
+task check_a() -> bool {
+  io.show("a")
+  true
+}
+
+task check_b() -> bool {
+  io.show("b")
+  true
+}
+
+flag = false
+result = flag and (check_a() or check_b())
+io.show("{result}")
+"#;
+    assert_matches_interpreter(source, b"  false\n");
+}
+
+#[test]
+fn nested_short_circuit_runs_the_inner_expression_when_the_outer_does_not_short_circuit() {
+    // The outer `and`'s left is true, so the right operand runs — and it
+    // is itself a short-circuiting `or`: `check_a` returns true, so
+    // `check_b` must never run. Proves the outer `and` correctly picks up
+    // the inner `or`'s result from whichever block its own short-circuit
+    // left the builder in, not the block this function created.
+    let source = r#"
+use std/io
+
+task check_a() -> bool {
+  io.show("a")
+  true
+}
+
+task check_b() -> bool {
+  io.show("b")
+  true
+}
+
+flag = true
+result = flag and (check_a() or check_b())
+io.show("{result}")
+"#;
+    assert_matches_interpreter(source, b"  a\n  true\n");
+}

--- a/docs/src/release-notes.md
+++ b/docs/src/release-notes.md
@@ -89,6 +89,11 @@ task main() {
 main()
 ```
 
+The native backend's `and`/`or` codegen had the identical bug and is fixed
+too — compiled and interpreted programs now agree on this example, and on
+any other short-circuited `and`/`or`, everywhere the operator is used
+(`while` conditions included).
+
 ### The native backend compiles `str` value methods
 
 `keel build --emit=kir` used to reject any `str` value method


### PR DESCRIPTION
## Summary

- #224 fixed `and`/`or` short-circuiting in the interpreter — the ground-truth baseline. `keel-codegen` had the identical bug: `emit_binop` compiled `and`/`or` to an eager LLVM `and`/`or` instruction over two operands both evaluated unconditionally before the operator was even inspected, so compiled and interpreted programs now diverged on any `and`/`or` with a side-effecting right operand.
- `emit_binop` now routes `BinOp::And`/`BinOp::Or` to a new `emit_short_circuit`, which branches on the left operand's value first and only emits the right operand's codegen inside the taken branch. The result is threaded through an `alloca`'d slot rather than a phi node — mirroring `nullable.rs`'s existing `emit_null_coalesce` (`??`'s short-circuit codegen) — specifically because the right operand's own codegen can itself branch (a nested `and`/`or`, `??`, a call that can raise), leaving the builder positioned in a different block than the one this function created; an alloca sidesteps having to track which block to route a phi incoming from.
- **No `keel-kir` lowering changed.** `Expr::BinOp{And|Or}` stays a flat KIR node — the branching is purely a codegen concern. This matters because a lowering-level fix (declare a result local + hoist an `if`-chain, the pattern `if`/`when`-as-expression already use) would have broken `while cond1 and cond2 { }`: `while`'s condition lowering rejects anything hoisted out of it (`lower/stmt.rs:301-308`), since a hoisted chain would run once ahead of the loop instead of every iteration. Keeping this entirely inside codegen means every existing position that already compiled (`while` conditions included) continues to, with zero lowering-level risk.
- Left a comment on #193 (`when`-expression in short-circuit positions) noting this finding, since #193's own text speculated the two issues would share a branch shape — they don't; #193's `while`-condition case still needs its own `break`-guarded-prelude mechanism, unaffected by this fix.

## Test plan

- [x] New `crates/keel-codegen/tests/short_circuit.rs` — 6 tests, each compiling, linking, running, and diffing against the interpreter byte-for-byte: basic `and`/`or` short-circuit in both directions, both directions still evaluating the right operand when required, and two nested cases (`flag and (check_a() or check_b())`) proving the alloca-over-phi design handles the right operand's own codegen branching internally
- [x] Manually verified `while i < 5 and i >= 0 { ... }` still lowers to a flat `((i < 5) and (i >= 0))` KIR binop (unchanged) via `keel build --emit=kir`, confirming no lowering-level regression
- [x] `cargo test -q --workspace`: all passing
- [x] `cargo test -q --test conformance --features build-backend`: passing — interpreter and compiled backend byte-identical across the full example/fixture corpus, now for the right reason (both short-circuit and agree, not both eagerly evaluating and agreeing by coincidence)
- [x] `cargo clippy -q --workspace --all-targets -- -D warnings`: clean
- [x] `mdbook build`: clean

Close #225