### PR TITLE
checker+interpreter: reject a task call missing a required argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,19 @@ io.show("{"hello world".contains("world")}")  # true — now compiles
 
 ### Fixed
 
+- **A task call omitting a required parameter passed `keel check` silently, and the interpreter bound the missing argument to `none` instead of erroring** — violating the parameter's declared type, not just leaving it unset. Failures downstream were confusing (`Cannot apply `Add` to int and none`) or, worse, entirely silent if the missing value was never used:
+
+```keel
+task f(a: int, b: int) -> int {
+  return a + b
+}
+
+f(1)   # now a check error: task `f`: missing required argument `b`
+       # previously: keel check passed, keel run silently bound b = none
+```
+
+  `keel check` now rejects the call directly, naming the missing parameter — covering plain task calls, `self.task(...)` agent-task calls, generic tasks, and calls through a local module binding. The interpreter's own param-binding fallback (silently reaching for `Value::None` when nothing else matched) is now a hard error too, as defense in depth for any call shape the checker can't see by name (a destructuring `{a, b}` parameter). A parameter with a declared default is unaffected — omitting it still uses the default, exactly as before.
+
 - **A lambda reading an outer local variable passed `keel check` and then failed at `keel run`.** The interpreter's closures have never captured anything — `call_closure_inner` builds a fresh, disconnected environment for every call — but the checker type-checked a lambda body as a nested scope of the enclosing function, so it silently accepted a read of an outer local that would fail at runtime with `Undefined: <name>`. Lambdas are now formally non-capturing (SPEC §7): the checker rejects a lambda body that reads a name bound only in an enclosing local scope, with a diagnostic pointing at the identifier. `self.<field>` access inside a lambda is unaffected — it resolves through ambient per-call agent state, not lexical capture.
 
 ```keel

--- a/crates/keel-compiler/src/types/checker.rs
+++ b/crates/keel-compiler/src/types/checker.rs
@@ -43,6 +43,11 @@ use crate::types::scope::Scope;
 #[derive(Debug, Clone)]
 struct TaskSig {
     params: Vec<(String, Ty)>,
+    /// Parallel to `params`: `true` where that parameter has no default
+    /// value, so a call site must supply it (issue #235) — a variadic
+    /// param's own slot is always `false` here, since omitting it entirely
+    /// (zero rest-args) is legal.
+    required: Vec<bool>,
     return_type: Ty,
     /// True if the last param is variadic (`...name: T`).
     variadic: bool,
@@ -1921,6 +1926,57 @@ task call_it() {
 }
 "#,
             "argument",
+        );
+    }
+
+    // Issue #235: a call omitting a required (no-default) parameter used to
+    // pass `keel check` silently, with the interpreter binding the missing
+    // param to `none` rather than erroring.
+    #[test]
+    fn error_missing_required_arg() {
+        expect_error(
+            r#"
+task f(a: int, b: int) -> int {
+  return a + b
+}
+
+task call_it() {
+  x = f(1)
+}
+"#,
+            "missing required argument `b`",
+        );
+    }
+
+    #[test]
+    fn valid_missing_arg_with_a_default_value() {
+        type_ok(
+            r#"
+task f(a: int, b: int = 2) -> int {
+  return a + b
+}
+
+task call_it() {
+  x = f(1)
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn error_missing_required_arg_on_self_task_call() {
+        expect_error(
+            r#"
+agent A {
+    task f(a: int, b: int) -> int {
+        return a + b
+    }
+    @on_start {
+        x = self.f(1)
+    }
+}
+"#,
+            "missing required argument `b`",
         );
     }
 

--- a/crates/keel-compiler/src/types/checker/call.rs
+++ b/crates/keel-compiler/src/types/checker/call.rs
@@ -16,13 +16,24 @@ impl Checker<'_, '_> {
     /// When `variadic` is true the last param is a rest-parameter (`...name: T`):
     ///   - plain positional args beyond the fixed params are each checked as `T`
     ///   - spread args (`...expr`) must be `list[T]` or `set[T]`
+    ///
+    /// `required` is parallel to `params`: a `true` entry with no matching
+    /// named or positional arg is a missing-argument error (issue #235) —
+    /// previously this silently `continue`d, so the interpreter's own
+    /// param-binding fallback (`Value::None` for a param with no default)
+    /// was the only thing that ran, undetected by `keel check`. `span` is
+    /// the call site's own span, used for that diagnostic since a missing
+    /// argument has no argument-level span of its own to point at.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn check_call_args(
         &mut self,
         params: &[(String, Ty)],
+        required: &[bool],
         variadic: bool,
         args: &[CallArg],
         arg_tys: &[Ty],
         callee: &str,
+        span: crate::lexer::Span,
     ) {
         if !variadic && args.iter().any(|a| a.spread) {
             self.err(format!(
@@ -48,15 +59,22 @@ impl Checker<'_, '_> {
         } else {
             params
         };
+        let fixed_required = &required[..fixed_params.len()];
 
         let mut pos_idx = 0;
-        for (param_name, param_ty) in fixed_params {
+        for ((param_name, param_ty), is_required) in fixed_params.iter().zip(fixed_required) {
             let (arg_ty, arg) = if let Some((ty, arg)) = named.get(param_name.as_str()) {
                 (*ty, *arg)
             } else if let Some((ty, arg)) = positional.get(pos_idx) {
                 pos_idx += 1;
                 (*ty, *arg)
             } else {
+                if *is_required {
+                    self.err_at(
+                        format!("{callee}: missing required argument `{param_name}`"),
+                        span.clone(),
+                    );
+                }
                 continue;
             };
             self.expect_at(

--- a/crates/keel-compiler/src/types/checker/collect.rs
+++ b/crates/keel-compiler/src/types/checker/collect.rs
@@ -171,6 +171,14 @@ impl Checker<'_, '_> {
                 (name, self.resolve_type(&p.ty.kind))
             })
             .collect();
+        // A variadic param's own slot is never required — omitting the rest
+        // entirely (zero variadic args) is legal — regardless of whether it
+        // happens to carry a `default` in the AST.
+        let required = t
+            .params
+            .iter()
+            .map(|p| !p.variadic && p.default.is_none())
+            .collect();
         let return_type = t
             .return_type
             .as_ref()
@@ -178,6 +186,7 @@ impl Checker<'_, '_> {
             .unwrap_or(Ty::None_);
         TaskSig {
             params,
+            required,
             return_type,
             variadic,
         }

--- a/crates/keel-compiler/src/types/checker/expr.rs
+++ b/crates/keel-compiler/src/types/checker/expr.rs
@@ -565,10 +565,12 @@ impl Checker<'_, '_> {
                     }
                     self.check_call_args(
                         &sig.params,
+                        &sig.required,
                         sig.variadic,
                         args,
                         &arg_tys,
                         &format!("task `{agent_name}.{task_name}`"),
+                        spanned.span.clone(),
                     );
                     return sig.return_type;
                 }
@@ -637,12 +639,19 @@ impl Checker<'_, '_> {
                                             )
                                         })
                                         .collect();
+                                    let resolved_required: Vec<bool> = td
+                                        .params
+                                        .iter()
+                                        .map(|p| !p.variadic && p.default.is_none())
+                                        .collect();
                                     self.check_call_args(
                                         &resolved_params,
+                                        &resolved_required,
                                         td_variadic,
                                         args,
                                         &arg_tys,
                                         &format!("task `{name}`"),
+                                        spanned.span.clone(),
                                     );
                                     if let Some(ret_node) = &td.return_type {
                                         return self
@@ -652,10 +661,12 @@ impl Checker<'_, '_> {
                                 }
                                 self.check_call_args(
                                     &sig.params,
+                                    &sig.required,
                                     sig.variadic,
                                     args,
                                     &arg_tys,
                                     &format!("task `{name}`"),
+                                    spanned.span.clone(),
                                 );
                                 return sig.return_type.clone();
                             }
@@ -848,10 +859,12 @@ impl Checker<'_, '_> {
                     }
                     self.check_call_args(
                         &sig.params,
+                        &sig.required,
                         sig.variadic,
                         args,
                         &arg_tys,
                         &format!("task `{agent_name}.{method}`"),
+                        spanned.span.clone(),
                     );
                     return sig.return_type;
                 }
@@ -1305,10 +1318,12 @@ impl Checker<'_, '_> {
                     if let Some(sig) = self.top_tasks.get(method).cloned() {
                         self.check_call_args(
                             &sig.params,
+                            &sig.required,
                             sig.variadic,
                             args,
                             arg_tys,
                             &format!("task `{module_name}.{method}`"),
+                            span.clone(),
                         );
                         return sig.return_type;
                     }

--- a/crates/keel-runtime/src/interpreter/call.rs
+++ b/crates/keel-runtime/src/interpreter/call.rs
@@ -174,7 +174,19 @@ impl Interpreter {
                     ExprFlow::Value(v) | ExprFlow::Return(v) => v,
                 }
             } else {
-                Value::None
+                // No default and no matching arg. `keel check` rejects this
+                // call shape (issue #235's checker fix), so this is a defense-
+                // in-depth guard against reaching here at all — via a
+                // destructuring param (unnamed, so uncheckable by name) or a
+                // caller that skipped the checker. Previously fell through to
+                // `Value::None`, silently violating the param's declared type
+                // rather than erroring.
+                let label = param_name.unwrap_or("<destructured>");
+                return Err(miette::miette!(
+                    "task `{}`: missing required argument `{}`",
+                    decl.name,
+                    label
+                ));
             };
             let v = promote_value(v, &p.ty.kind, &self.struct_types, &self.struct_aliases);
             bind_value(&p.name, v, &mut env)?;

--- a/docs/src/release-notes.md
+++ b/docs/src/release-notes.md
@@ -4,6 +4,26 @@
 
 ## Unreleased
 
+### A task call missing a required argument is now a check-time error
+
+Omitting a required (no-default) parameter used to pass `keel check`
+silently — the interpreter bound the missing argument to `none` instead of
+erroring, violating its declared type. The failure that followed was often
+confusing (a type error far from the real cause) or, if the value happened
+to go unused, completely silent:
+
+```keel
+task f(a: int, b: int) -> int {
+  return a + b
+}
+
+f(1)   # now: task `f`: missing required argument `b`
+```
+
+Covers plain task calls, `self.task(...)` agent-task calls, generic tasks,
+and calls through a local module binding. A parameter with a declared
+default is unaffected — omitting it still uses the default.
+
 ### A named task now works everywhere a lambda does
 
 `results = emails.map(triage)` — SPEC §7's own documented "named function as

--- a/tests/integration/language/errors.rs
+++ b/tests/integration/language/errors.rs
@@ -70,6 +70,32 @@ run(A)
     );
 }
 
+// Issue #235: a call omitting a required (no-default) parameter used to pass
+// `keel check` silently, with the interpreter binding the missing param to
+// `none` rather than erroring — `keel run` would then either crash on an
+// unrelated type error deep inside the task body, or (worse, with no
+// observable effect at all) succeed silently.
+#[test]
+fn missing_required_arg_is_a_check_error_not_a_silent_none() {
+    let src = r#"
+task f(a: int, b: int) -> int {
+  return a + b
+}
+agent A {
+  @on_start {
+    r = f(1)
+  }
+}
+run(A)
+"#;
+    let (ok, _stdout, stderr) = check_inline_output(src);
+    assert!(!ok, "expected a missing-argument type error");
+    assert!(
+        stderr.contains('b'),
+        "error should name the missing param `b`:\n{stderr}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Regressions
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

A call omitting a required (no-default) parameter previously passed `keel check` silently, and the interpreter's own param-binding fallback quietly reached for `Value::None` instead of erroring — violating the parameter's declared type, not just leaving it unset:

```keel
task f(a: int, b: int) -> int {
  return a + b
}

f(1)   # keel check: valid. keel run: exit 0, no output, no error.
```

With an observable side effect the silent binding shows up as a confusing failure far from the real cause instead of a clear diagnostic:

```
a=1 b=none
Error:   × Cannot apply `Add` to int and none
```

`keel build --emit=kir` already rejected this correctly (`` `f` takes 2 argument(s), got 1 ``) — this was a checker+interpreter gap, not a KIR one.

- `TaskSig` gains a `required: Vec<bool>` field parallel to `params`, computed from each parameter's absence of a default value (a variadic param's own slot is never required — omitting the rest entirely is legal).
- `check_call_args` takes that alongside the call site's own span, and now reports a missing required argument by name instead of silently `continue`-ing past it. Threaded through all five call sites: plain task calls, `self.task(...)` agent-task calls, generic tasks, and calls through a local module binding.
- `call_task_inner`'s fallback for a parameter with no matching arg and no default now returns an error instead of `Value::None`. In practice this is defense in depth once the checker gate is in place — but it covers a destructuring `{a, b}` parameter (not matchable by name at the checker's positional/named split) and any caller that reaches the interpreter without going through `keel check` first.

Found and deliberately **not** fixed here, filed separately: #238, the identical bug for lambda calls (`call_closure_inner`) — a different code path with its own checker story (lambda params have no default at all, and it's unclear whether the checker validates a `Ty::Func` call site's arity today), kept out of this PR's scope.

## Test plan

- [x] `crates/keel-compiler/src/types/checker.rs`: 3 new unit tests — missing-required-arg is rejected, a defaulted param is unaffected, and the `self.task(...)` call path also catches it
- [x] `tests/integration/language/errors.rs`: end-to-end test through the real CLI pipeline
- [x] Full workspace build, test suite (`cargo test --workspace`), and `cargo clippy --all-targets --features build-backend -- -D warnings` clean
- [x] `cargo test --test conformance --features build-backend` clean
- [x] Full `examples/` corpus still passes `keel check` (all 64 examples spot-checked directly, not just via the `examples_all_parse` test)
- [x] `mdbook build` clean over updated `docs/src/release-notes.md`

Close #235