### PR TITLE
checker: validate namespace-call arguments against the catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to Keel.
 
 ## [Unreleased]
 
-%%TAGLINE%% Named functions now work everywhere a lambda does, `and`/`or` finally short-circuit, `crypto.hmac_*` gets a breaking argument-order fix, the LLVM backend closes the gap on stdlib calls and string methods, and the stdlib catalog's parameter metadata is audited against runtime reality across all 23 namespaces.
+%%TAGLINE%% Named functions now work everywhere a lambda does, `and`/`or` finally short-circuit, `crypto.hmac_*` gets a breaking argument-order fix, the LLVM backend closes the gap on stdlib calls and string methods, the stdlib catalog's parameter metadata is audited against runtime reality across all 23 namespaces, and `keel check` now validates namespace-call arguments against that catalog.
 
 ### Added
 
@@ -204,6 +204,19 @@ task notify(to: str) {
 ```
 
   `BuiltinParam` gains a `binding: ParamBinding` field (`PositionalOnly` / `NamedOnly` / `Either`), independent of `optional`, plus a `TySpec::Callback` variant for the closure-taking methods above. Every namespace was re-audited against its actual `expect_*`/`find_arg` usage and corrected; a new test (`catalog_named_params_match_runtime_named_arg_lookups`) regexes each namespace's source for named-argument lookups and cross-checks them against the catalog so this can't silently drift again. Data-only — the type checker does not yet validate namespace-call arguments against the catalog (tracked separately); this is the prerequisite the checker work needs before it can turn on.
+
+- **`keel check` never validated a `std/*` namespace call's arguments against the catalog's declared `params`** — arity, parameter names, and positional-vs-keyword-ness of every one of the 23 namespaces went unchecked at compile time, with only the runtime's own `expect_*`/`expect_*_named` helpers enforcing anything, using runtime-only error messages:
+
+```keel
+use std/file
+task main() {
+  file.write(content: "hi", path: "/tmp/x.txt")   # now a check error:
+}                                                  # `file.write`: missing required argument `path`
+main()                                             # previously: keel check passed,
+                                                    # keel run failed with "missing argument at position 0"
+```
+
+  The checker now walks each catalog entry's `BuiltinParam` list, keyed off the `binding: ParamBinding` field the stdlib catalog audit above added: a `PositionalOnly` param can only be filled positionally, `NamedOnly` only by `name:`, `Either` by either — matching the runtime's own `positional(args, idx)`/`find_arg(args, name)` lookup split exactly, so a required param passed the wrong way, an unknown keyword name, or a missing required argument are all caught before the program runs. `http.request`'s single-map-literal calling convention (`http.request({method: "GET", url: "..."})`, sugar for passing all of its named args at once) is recognized structurally and exempted from static validation, since no `ParamBinding` shape captures "one map argument stands in for every named param." Surfaced two real bugs in the example corpus along the way: `email_agent.keel`'s `memory.remember` call was missing its required `key` argument entirely (issue #237), and both `email_agent.keel` and `multi_agent_inbox.keel` passed a `str?` local to `ai.draft`'s non-nullable `guidance:` param without narrowing it first — both now fixed.
 
 ---
 

--- a/crates/keel-catalog/src/specs/ai.rs
+++ b/crates/keel-catalog/src/specs/ai.rs
@@ -209,6 +209,18 @@ pub const SPEC: &[BuiltinMethod] = &[
                 optional: true,
                 binding: ParamBinding::NamedOnly,
             },
+            // Not read by the runtime (`ai.decide` always returns a fixed
+            // `{choice, reason, confidence}` map) — declared here purely so
+            // the checker's `BuiltinResult::AiExtract` handling can resolve
+            // it to the call's inferred result type, same as `ai.extract`'s
+            // `as`. A pre-existing checker/runtime behavior gap, not
+            // introduced by this arg-validation pass — tracked as #244.
+            BuiltinParam {
+                name: "as",
+                ty: TySpec::Dynamic,
+                optional: true,
+                binding: ParamBinding::NamedOnly,
+            },
             BuiltinParam {
                 name: "using",
                 ty: TySpec::Str,

--- a/crates/keel-compiler/src/types/checker.rs
+++ b/crates/keel-compiler/src/types/checker.rs
@@ -3004,6 +3004,68 @@ task go(text: str) {
         );
     }
 
+    // Issue #222's own canonical repro: both `file.write` params are
+    // `PositionalOnly` (the runtime reads them via `positional(args, idx)`,
+    // never `find_arg`), so passing either by name must be rejected even
+    // though the call otherwise "looks" complete.
+    #[test]
+    fn invalid_namespace_call_required_arg_passed_by_name() {
+        expect_error(
+            r#"
+use std/file
+task main() {
+  file.write(content: "hi", path: "/tmp/x.txt")
+}
+"#,
+            "must be passed positionally",
+        );
+    }
+
+    #[test]
+    fn invalid_namespace_call_unknown_keyword_arg() {
+        expect_error(
+            r#"
+use std/file
+task main() {
+  file.write("/tmp/x.txt", "hi", bogus: true)
+}
+"#,
+            "unknown argument `bogus:`",
+        );
+    }
+
+    // The unqualified-import call path (`use parse from std/json`) is a
+    // separate `catalog_result_ty` call site from `module_method_call`
+    // (`file.write(...)` above) — both need `check_builtin_args` wired in.
+    #[test]
+    fn invalid_unqualified_namespace_call_missing_required_arg() {
+        expect_error(
+            r#"
+use parse from std/json
+task main() {
+  x = parse()
+}
+"#,
+            "missing required argument `s`",
+        );
+    }
+
+    // SPEC.md §14: "All [Math] functions accept `int` or `float`
+    // arguments" — `math.sqrt`'s `x` param is declared `TySpec::Float`, but
+    // an `int` literal must still be accepted, matching the runtime's
+    // `num_arg` helper (which takes either and returns `f64`).
+    #[test]
+    fn valid_math_namespace_call_accepts_int_for_float_param() {
+        type_ok(
+            r#"
+use std/math
+task go() {
+  x = math.sqrt(4)
+}
+"#,
+        );
+    }
+
     #[test]
     fn valid_implicit_return_expression_matches_declared() {
         type_ok(

--- a/crates/keel-compiler/src/types/checker/call.rs
+++ b/crates/keel-compiler/src/types/checker/call.rs
@@ -4,6 +4,8 @@
 //! handling positional, named, variadic, and spread arguments.
 
 use crate::ast::CallArg;
+use crate::builtins::{BuiltinMethod, BuiltinParam, ParamBinding, TySpec};
+use crate::types::prelude::ty_from_spec;
 use crate::types::ty::{Ty, describe_ty};
 
 use super::Checker;
@@ -118,5 +120,168 @@ impl Checker<'_, '_> {
                 }
             }
         }
+    }
+
+    /// Validate a `std/*` namespace call's arguments against its catalog
+    /// entry's declared `params` (issue #222).
+    ///
+    /// Each param's [`ParamBinding`] records how the runtime actually looks
+    /// it up: `PositionalOnly` reads it via `positional(args, idx)`, where
+    /// `idx` is the param's rank among `PositionalOnly`/`Either` params in
+    /// declared order (named args are filtered out before that index is
+    /// taken, so it does not shift no matter what else is passed by name);
+    /// `NamedOnly` reads it via `find_arg(args, name)` with no positional
+    /// fallback; `Either` accepts both. So positional args and named args
+    /// are validated as two independent passes here, exactly mirroring how
+    /// the runtime's two lookup helpers never consult each other.
+    ///
+    /// A method whose catalog entry declares zero params is skipped
+    /// entirely — that means either a true zero-arg method or one not
+    /// statically validated yet (`ai.embed`'s free-form input, `db.query`'s
+    /// driver-specific args). A `TySpec::Callback` param (trailing
+    /// task/closure argument) needs no special-casing: `ty_from_spec` maps
+    /// it to an opaque `Ty::Unknown`, which `expect_at` already skips.
+    ///
+    /// A method whose params are *all* `NamedOnly` (`http.request`) can
+    /// additionally be called with a single positional map/struct literal
+    /// as sugar for all of its named args at once
+    /// (`http.request({method: "GET", url: "..."})`,
+    /// `crates/keel-runtime/src/runtime/namespaces/http.rs`'s `"request"`
+    /// handler) — a calling convention `ParamBinding` has no way to
+    /// represent, since it is not any one param's binding but the whole
+    /// call's shape. Recognized structurally (one struct-typed positional
+    /// arg, no named args, every declared param `NamedOnly`) rather than a
+    /// hardcoded namespace/method list, so it is not tied to `http.request`
+    /// specifically. The struct literal's individual keys are left for the
+    /// runtime to validate, same as any other value of statically-unknown
+    /// shape.
+    pub(crate) fn check_builtin_args(
+        &mut self,
+        entry: &'static BuiltinMethod,
+        args: &[CallArg],
+        arg_tys: &[Ty],
+        span: crate::lexer::Span,
+    ) {
+        let params = entry.params;
+        if params.is_empty() {
+            return;
+        }
+        if let [arg] = args
+            && arg.name.is_none()
+            && matches!(arg_tys.first(), Some(Ty::Struct { .. }))
+            && params.iter().all(|p| p.binding == ParamBinding::NamedOnly)
+        {
+            return;
+        }
+        let callee = format!("`{}.{}`", entry.namespace, entry.name);
+
+        if args.iter().any(|a| a.spread) {
+            self.err_at(
+                format!("{callee}: spread args (`...`) are not supported here"),
+                span,
+            );
+            return;
+        }
+
+        let mut covered: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        let mut misplaced: std::collections::HashSet<&str> = std::collections::HashSet::new();
+
+        // Positional pass: zip the call's unnamed args against the params
+        // eligible for positional binding, in declared order.
+        let positional_params: Vec<_> = params
+            .iter()
+            .filter(|p| p.binding != ParamBinding::NamedOnly)
+            .collect();
+        let positional_args: Vec<(&Ty, &CallArg)> = args
+            .iter()
+            .zip(arg_tys.iter())
+            .filter(|(a, _)| a.name.is_none())
+            .map(|(a, ty)| (ty, a))
+            .collect();
+
+        if positional_args.len() > positional_params.len() {
+            self.err_at(
+                format!(
+                    "{callee} takes {} positional argument(s), got {}",
+                    positional_params.len(),
+                    positional_args.len()
+                ),
+                span.clone(),
+            );
+        }
+
+        for (param, (ty, arg)) in positional_params.iter().zip(positional_args.iter()) {
+            self.expect_builtin_arg(
+                ty,
+                param,
+                &format!("{callee} arg `{}`", param.name),
+                arg.value.span.clone(),
+            );
+            covered.insert(param.name);
+        }
+
+        // Named pass: each name must match a declared param that accepts a
+        // named form — a `PositionalOnly` param is never read by name.
+        for (arg, ty) in args.iter().zip(arg_tys.iter()) {
+            let Some(name) = arg.name.as_deref() else {
+                continue;
+            };
+            let Some(param) = params.iter().find(|p| p.name == name) else {
+                self.err_at(
+                    format!("{callee}: unknown argument `{name}:`"),
+                    arg.value.span.clone(),
+                );
+                continue;
+            };
+            if param.binding == ParamBinding::PositionalOnly {
+                self.err_at(
+                    format!("{callee}: `{name}` must be passed positionally, not as `{name}:`"),
+                    arg.value.span.clone(),
+                );
+                misplaced.insert(name);
+                continue;
+            }
+            self.expect_builtin_arg(
+                ty,
+                param,
+                &format!("{callee} arg `{name}`"),
+                arg.value.span.clone(),
+            );
+            covered.insert(name);
+        }
+
+        for param in params {
+            if !param.optional && !covered.contains(param.name) && !misplaced.contains(param.name) {
+                self.err_at(
+                    format!("{callee}: missing required argument `{}`", param.name),
+                    span.clone(),
+                );
+            }
+        }
+    }
+
+    /// Type-check one builtin-call argument against its declared param,
+    /// widening `int` to a `float`-typed param first.
+    ///
+    /// SPEC.md §14: "All [Math] functions accept `int` or `float`
+    /// arguments" — the runtime's `num_arg` helper
+    /// (`crates/keel-runtime/src/runtime/namespaces/math.rs`) accepts both
+    /// and always returns `f64`. Every current `TySpec::Float` *parameter*
+    /// (as opposed to a `TySpec::Float` *result*) belongs to `math`, so
+    /// this widening is scoped by the spec's own meaning, not a namespace
+    /// hardcode — a future non-math `TySpec::Float` param would get the
+    /// same leniency, which is the correct reading of what `TySpec::Float`
+    /// as a parameter type means today.
+    fn expect_builtin_arg(
+        &mut self,
+        actual: &Ty,
+        param: &BuiltinParam,
+        context: &str,
+        span: crate::lexer::Span,
+    ) {
+        if param.ty == TySpec::Float && matches!(actual, Ty::Int) {
+            return;
+        }
+        self.expect_at(actual, &ty_from_spec(param.ty), context, span);
     }
 }

--- a/crates/keel-compiler/src/types/checker/expr.rs
+++ b/crates/keel-compiler/src/types/checker/expr.rs
@@ -690,6 +690,12 @@ impl Checker<'_, '_> {
                                 ) {
                                     return Ty::Error;
                                 }
+                                self.check_builtin_args(
+                                    entry,
+                                    args,
+                                    &arg_tys,
+                                    spanned.span.clone(),
+                                );
                                 return self.catalog_result_ty(entry, args);
                             }
                             // Validate delegate(...) targets at compile time.
@@ -1299,8 +1305,9 @@ impl Checker<'_, '_> {
                         return Ty::Error;
                     }
                     if ns == "ai" && method == "install" {
-                        self.check_ai_install_arg(args, span);
+                        self.check_ai_install_arg(args, span.clone());
                     }
+                    self.check_builtin_args(entry, args, arg_tys, span.clone());
                     self.catalog_result_ty(entry, args)
                 }
                 None => {

--- a/docs/src/release-notes.md
+++ b/docs/src/release-notes.md
@@ -269,6 +269,34 @@ use std/io
 io.show("{math.sqrt(4.0)}")   # now compiles and runs — was a codegen panic
 ```
 
+### `keel check` now validates a namespace call's arguments against the stdlib catalog
+
+Arity, parameter names, and positional-vs-keyword-ness of `std/*` calls
+went entirely unchecked at compile time — only the runtime's own
+`expect_*`/`expect_*_named` helpers enforced anything, with runtime-only
+error messages:
+
+```keel
+use std/file
+task main() {
+  file.write(content: "hi", path: "/tmp/x.txt")
+}
+main()
+```
+
+```
+# now: `file.write`: missing required argument `path`
+# previously: keel check passed, keel run failed with
+# "missing argument at position 0"
+```
+
+Covers every namespace with a catalog-declared parameter list: a param
+that can only ever be filled positionally, only by `name:`, or by either,
+now gets the check its runtime lookup already implied. `http.request`'s
+single-map-literal form (`http.request({method: "GET", url: "..."})`) is
+recognized as sugar for its named args and left to the runtime, since it
+isn't representable as any one parameter's shape.
+
 ---
 
 ## v0.3.0 — 2026-08-06

--- a/examples/email_agent.keel
+++ b/examples/email_agent.keel
@@ -26,7 +26,7 @@ task brief(email: { body: str }) -> str {
 }
 
 task compose(email: { body: str, from: str }, guidance: str? = none) -> str {
-  if guidance != none { ai.draft("response to {email.body}", tone: "professional", guidance: guidance) } else { ai.draft("response to {email.body}", tone: "friendly", max_length: 150) } ?? "(no draft generated)"
+  if guidance != none { ai.draft("response to {email.body}", tone: "professional", guidance: guidance!) } else { ai.draft("response to {email.body}", tone: "friendly", max_length: 150) } ?? "(no draft generated)"
 }
 
 test "triage uses mocked urgency" {
@@ -79,7 +79,8 @@ agent EmailAssistant {
         }
       }
     }
-    memory.remember({ contact: email.from, subject: email.subject, urgency: urgency, handled_at: time.now() })
+    handled_at = time.now()
+    memory.remember("{email.from}:{handled_at}", { contact: email.from, subject: email.subject, urgency: urgency, handled_at: handled_at })
     self.handled_count = self.handled_count + 1
   }
   @on_start {

--- a/examples/multi_agent_inbox.keel
+++ b/examples/multi_agent_inbox.keel
@@ -21,7 +21,7 @@ task triage_email(email: { body: str }) -> TriageResult {
 
 task draft_reply(email: { body: str, from: str }, guidance: str? = none) -> str {
   history = memory.recall("interactions with {email.from}", limit: 5)
-  ai.draft("response to {email.body}", tone: "professional", context: history, guidance: guidance, max_length: 200) ?? "(no draft generated)"
+  if guidance != none { ai.draft("response to {email.body}", tone: "professional", context: history, guidance: guidance!, max_length: 200) } else { ai.draft("response to {email.body}", tone: "professional", context: history, max_length: 200) } ?? "(no draft generated)"
 }
 
 task plan_followup(email: { subject: str }, urgency: Urgency) {

--- a/tests/integration/namespaces/csv.rs
+++ b/tests/integration/namespaces/csv.rs
@@ -147,29 +147,28 @@ run(A)
     assert!(stdout.contains("name=Alice"), "roundtrip data: {stdout}");
 }
 
+// `csv.stringify` takes `rows: list[list[str]]` — a bare `list[str]` like
+// `["not a row"]` no longer reaches the runtime's own shape validation
+// (`stringify_non_list_row_raises` in
+// `crates/keel-runtime/src/runtime/namespaces/csv.rs` still covers that
+// path directly for `dynamic`-typed data), it is rejected by `keel check`
+// as a static type mismatch instead.
 #[test]
-fn csv_stringify_invalid_row_type_raises() {
+fn csv_stringify_invalid_row_type_is_a_check_error() {
     let src = r#"
 use std/csv
-use std/io
 agent A {
-    @tools [io]
     @on_start {
-        try {
-            csv.stringify(["not a row"])
-        } catch e: Error {
-            io.show("caught={e.message.len() > 0}")
-        }
-        stop(self)
+        csv.stringify(["not a row"])
     }
 }
 run(A)
 "#;
-    let (ok, stdout, stderr) = run_inline(src, false);
-    assert!(ok, "program failed\nstdout: {stdout}\nstderr: {stderr}");
+    let (ok, _stdout, stderr) = check_inline_output(src);
+    assert!(!ok, "expected a type error:\n{stderr}");
     assert!(
-        stdout.contains("caught=true"),
-        "expected error to be caught: {stdout}"
+        stderr.contains("`csv.stringify` arg `rows`"),
+        "expected a `rows` type mismatch:\n{stderr}"
     );
 }
 
@@ -251,30 +250,29 @@ run(A)
     );
 }
 
+// Same rationale as `csv_stringify_invalid_row_type_is_a_check_error`: a
+// non-string cell makes `rows`' inferred type `list[list[int]]`, which
+// `keel check` now rejects against the declared `list[list[str]]` before
+// this ever reaches the runtime (`stringify_non_string_cell_raises` in
+// `crates/keel-runtime/src/runtime/namespaces/csv.rs` covers the runtime
+// path directly).
 #[test]
-fn csv_stringify_non_string_cell_raises() {
+fn csv_stringify_non_string_cell_is_a_check_error() {
     let src = r#"
 use std/csv
-use std/io
 agent A {
-    @tools [io]
     @on_start {
-        try {
-            rows = [[1, "ok"]]
-            csv.stringify(rows)
-        } catch e: Error {
-            io.show("caught={e.message.len() > 0}")
-        }
-        stop(self)
+        rows = [[1, "ok"]]
+        csv.stringify(rows)
     }
 }
 run(A)
 "#;
-    let (ok, stdout, stderr) = run_inline(src, false);
-    assert!(ok, "program failed\nstdout: {stdout}\nstderr: {stderr}");
+    let (ok, _stdout, stderr) = check_inline_output(src);
+    assert!(!ok, "expected a type error:\n{stderr}");
     assert!(
-        stdout.contains("caught=true"),
-        "expected non-string cell error: {stdout}"
+        stderr.contains("`csv.stringify` arg `rows`"),
+        "expected a `rows` type mismatch:\n{stderr}"
     );
 }
 
@@ -318,7 +316,7 @@ agent A {
     @tools [io]
     @on_start {
         try {
-            csv.stringify(["not a row"])
+            csv.parse_records("name,name\nAlice,Bob")
         } catch e: CsvError {
             io.show("specific=true")
         } catch e: Error {

--- a/tests/integration/net.rs
+++ b/tests/integration/net.rs
@@ -120,7 +120,7 @@ run(A)
     let (ok, _stdout, stderr) = run_inline(src, false);
     assert!(!ok, "http.request without URL should fail");
     assert!(
-        stderr.contains("http.request: missing `url`"),
+        stderr.contains("`http.request`: missing required argument `url`"),
         "expected missing URL diagnostic:\n{stderr}"
     );
 }
@@ -187,7 +187,7 @@ run(A)
     let (ok, _stdout, stderr) = run_inline(src, false);
     assert!(!ok, "http.get without URL should fail");
     assert!(
-        stderr.contains("http.get: missing argument at position 0"),
+        stderr.contains("`http.get`: missing required argument `url`"),
         "expected missing URL diagnostic:\n{stderr}"
     );
 }
@@ -207,7 +207,7 @@ run(A)
     let (ok, _stdout, stderr) = run_inline(src, false);
     assert!(!ok, "http.post without URL should fail");
     assert!(
-        stderr.contains("http.post: missing argument at position 0"),
+        stderr.contains("`http.post`: missing required argument `url`"),
         "expected missing URL diagnostic:\n{stderr}"
     );
 }
@@ -287,7 +287,7 @@ run(A)
     );
     assert!(!ok, "email.send without body should fail");
     assert!(
-        stderr.contains("email.send: missing message body"),
+        stderr.contains("`email.send`: missing required argument `body`"),
         "expected missing body diagnostic:\n{stderr}"
     );
 }
@@ -314,7 +314,7 @@ run(A)
     );
     assert!(!ok, "email.send without recipient should fail");
     assert!(
-        stderr.contains("email.send: missing `to:` argument"),
+        stderr.contains("`email.send`: missing required argument `to`"),
         "expected missing recipient diagnostic:\n{stderr}"
     );
 }

--- a/tests/integration/util.rs
+++ b/tests/integration/util.rs
@@ -235,7 +235,7 @@ run(A)
     let (ok, _stdout, stderr) = run_inline(src, false);
     assert!(!ok, "expected non-zero exit for missing closure");
     assert!(
-        stderr.contains("missing closure"),
+        stderr.contains("`control.retry`: missing required argument `fn`"),
         "expected 'missing closure' error:\n{stderr}"
     );
 }
@@ -258,7 +258,7 @@ run(A)
     let (ok, _stdout, stderr) = run_inline(src, false);
     assert!(!ok, "expected non-zero exit for missing duration");
     assert!(
-        stderr.contains("missing duration"),
+        stderr.contains("`control.with_timeout` arg `duration`: expected duration, got function"),
         "expected 'missing duration' error:\n{stderr}"
     );
 }
@@ -285,7 +285,7 @@ run(A)
         "expected non-zero exit for missing duration with a named task"
     );
     assert!(
-        stderr.contains("missing duration"),
+        stderr.contains("`control.with_timeout` arg `duration`: expected duration, got function"),
         "expected 'missing duration' error:\n{stderr}"
     );
 }
@@ -304,7 +304,7 @@ run(A)
     let (ok, _stdout, stderr) = run_inline(src, false);
     assert!(!ok, "expected non-zero exit for missing closure");
     assert!(
-        stderr.contains("missing closure"),
+        stderr.contains("`control.with_timeout`: missing required argument `fn`"),
         "expected 'missing closure' error:\n{stderr}"
     );
 }
@@ -412,7 +412,7 @@ run(A)
     let (ok, _stdout, stderr) = run_inline(src, false);
     assert!(!ok, "expected non-zero exit for missing datetime");
     assert!(
-        stderr.contains("control.with_deadline: missing argument at position 0"),
+        stderr.contains("`control.with_deadline`: missing required argument `deadline`"),
         "expected missing argument error:\n{stderr}"
     );
 }
@@ -452,7 +452,7 @@ run(A)
     let (ok, _stdout, stderr) = run_inline(src, false);
     assert!(!ok, "expected non-zero exit for missing closure");
     assert!(
-        stderr.contains("missing closure"),
+        stderr.contains("`control.with_deadline`: missing required argument `fn`"),
         "expected 'missing closure' error:\n{stderr}"
     );
 }
@@ -1061,7 +1061,7 @@ run(AsyncTest)
     let (ok, _stdout, stderr) = run_inline(src, false);
     assert!(!ok, "expected non-zero exit for spawn without closure");
     assert!(
-        stderr.contains("missing closure"),
+        stderr.contains("`async.spawn`: missing required argument `fn`"),
         "expected 'missing closure' error:\n{stderr}"
     );
 }


### PR DESCRIPTION
## Summary
- `keel check` never validated a `std/*` namespace call's arguments against the catalog's declared `BuiltinParam` list — only the runtime's own `expect_*`/`expect_*_named` helpers enforced arity, parameter names, and positional-vs-keyword-ness, with runtime-only error messages.
- `check_builtin_args` now validates each call against `BuiltinParam::binding` (`PositionalOnly`/`NamedOnly`/`Either`), mirroring the runtime's own `positional(args, idx)`/`find_arg(args, name)` lookup split exactly, and is wired into both call sites that resolve a namespace call's result type (`module_method_call` and the unqualified `use x from std/y` import path).
- `http.request`'s single-map-literal calling convention (`http.request({method: "GET", url: "..."})`) is recognized structurally and exempted, since no per-param binding can express "one map stands in for every named arg."
- A `TySpec::Float` param also accepts an `int` argument, matching `SPEC.md` §14's documented int-or-float contract for the `Math` namespace.
- Fixes two real bugs the new validation surfaced in the example corpus: `email_agent.keel`'s `memory.remember` call was missing its required `key` argument (#237), and both `email_agent.keel` and `multi_agent_inbox.keel` passed a nullable local to `ai.draft`'s non-nullable `guidance:` param without narrowing it first.

Closes #222, closes #237. Follow-up filed as #244 for an unrelated pre-existing gap this surfaced (`ai.decide`'s checker-inferred `as:` result type isn't honored by its runtime handler).

## Test plan
- [x] `cargo test --workspace` (all crates, `KEEL_LLM=mock`) — 0 failures
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [x] `mdbook build` over `docs/` — clean
- [x] `examples_all_parse` (every file in `examples/` passes `keel check`) — green, including the two example fixes above
- [x] New checker unit tests cover the issue's canonical repro (required arg passed by name, unknown keyword, the unqualified-import call site, and the int→float widening)