### PR TITLE
checker+interpreter: reject a closure call missing a required argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,18 @@ f(1)   # now a check error: task `f`: missing required argument `b`
 
   `keel check` now rejects the call directly, naming the missing parameter — covering plain task calls, `self.task(...)` agent-task calls, generic tasks, and calls through a local module binding. The interpreter's own param-binding fallback (silently reaching for `Value::None` when nothing else matched) is now a hard error too, as defense in depth for any call shape the checker can't see by name (a destructuring `{a, b}` parameter). A parameter with a declared default is unaffected — omitting it still uses the default, exactly as before.
 
+- **Same bug as above, for a lambda call — `keel check` never validated a closure call's arity at all.** `LambdaParam` has no default field, so every lambda parameter is unconditionally required, but a call through a closure-typed local (`Ty::Func`) had no arity check anywhere, and `call_closure_inner` bound a missing argument to `Value::None`:
+
+```keel
+task main() {
+  add = (a, b) => a + b
+  add(1)   # now a check error: closure call: expected 2 argument(s), got 1
+           # previously: keel check passed, keel run silently bound b = none
+}
+```
+
+  Only checked for a call through a local bound *directly* to a lambda literal (`add = (a, b) => a + b`) or an immediately-invoked one (`((a, b) => a + b)(1)`) — the one shape the checker can prove is exact. A function value obtained any other way is left unchecked: a named task used as a value (`g = my_task`) or a `(T, T) -> T`-annotated local, since neither can soundly rule out a hidden defaulted or variadic parameter; or an element pulled out of a list/`for` loop, since the checker doesn't track per-element provenance through those — even when every element happens to be a lambda. `call_closure_inner` also now raises rather than silently binding `none` for any closure call that still reaches it with too few args (a builtin callback, or a spread argument whose expanded length the checker can't know statically).
+
 - **A lambda reading an outer local variable passed `keel check` and then failed at `keel run`.** The interpreter's closures have never captured anything — `call_closure_inner` builds a fresh, disconnected environment for every call — but the checker type-checked a lambda body as a nested scope of the enclosing function, so it silently accepted a read of an outer local that would fail at runtime with `Undefined: <name>`. Lambdas are now formally non-capturing (SPEC §7): the checker rejects a lambda body that reads a name bound only in an enclosing local scope, with a diagnostic pointing at the identifier. `self.<field>` access inside a lambda is unaffected — it resolves through ambient per-call agent state, not lexical capture.
 
 ```keel

--- a/crates/keel-compiler/src/types/checker.rs
+++ b/crates/keel-compiler/src/types/checker.rs
@@ -1980,6 +1980,205 @@ agent A {
         );
     }
 
+    // Issue #238: a lambda call omitting a required parameter used to pass
+    // `keel check` silently — `LambdaParam` has no default field at all, so
+    // the checker's `Ty::Func` fallthrough for a closure-typed callee never
+    // validated arity, and the interpreter's own binding fallback quietly
+    // reached for `Value::None`. Checked here via `Scope::is_exact_lambda`:
+    // `add` is bound directly from a lambda literal with no annotation, so
+    // its arity is provably exact.
+    #[test]
+    fn error_closure_call_missing_arg() {
+        expect_error(
+            r#"
+task call_it() {
+  add = (a, b) => a + b
+  x = add(1)
+}
+"#,
+            "closure call: expected 2 argument(s), got 1",
+        );
+    }
+
+    #[test]
+    fn error_closure_call_too_many_args() {
+        expect_error(
+            r#"
+task call_it() {
+  add = (a, b) => a + b
+  x = add(1, 2, 3)
+}
+"#,
+            "closure call: expected 2 argument(s), got 3",
+        );
+    }
+
+    #[test]
+    fn valid_closure_call_with_exact_args() {
+        type_ok(
+            r#"
+task call_it() {
+  add = (a, b) => a + b
+  x = add(1, 2)
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn valid_closure_call_with_spread_arg_skips_arity_check() {
+        // A spread's expanded length isn't known statically — this must not
+        // be flagged even though a single syntactic arg is supplied for two
+        // params.
+        type_ok(
+            r#"
+task call_it() {
+  add = (a, b) => a + b
+  pair = [1, 2]
+  x = add(...pair)
+}
+"#,
+        );
+    }
+
+    // A task referenced as a value (`g = f`) is bound via the plain
+    // `bind_to_scope` path, not `define_exact_lambda` — so `g` is never
+    // marked exact, and `TaskSig`'s hidden default on `f`'s second param
+    // can't be falsely flagged (issue #238).
+    #[test]
+    fn valid_task_as_value_call_relying_on_default_not_flagged() {
+        type_ok(
+            r#"
+task f(a: int, b: int = 2) -> int {
+  return a + b
+}
+
+task call_it() {
+  g = f
+  x = g(1)
+}
+"#,
+        );
+    }
+
+    // Same reasoning through a `(T, T) -> T` annotation: `ty.is_some()`
+    // skips `define_exact_lambda` entirely, so a defaulted task assigned to
+    // an annotated local isn't flagged either (issue #238).
+    #[test]
+    fn valid_task_as_value_call_through_annotation_relying_on_default_not_flagged() {
+        type_ok(
+            r#"
+task f(a: int, b: int = 2) -> int {
+  return a + b
+}
+
+task call_it() {
+  g: (int, int) -> int = f
+  x = g(1)
+}
+"#,
+        );
+    }
+
+    // A list literal's element type is approximated by its *first*
+    // element's type (this checker doesn't unify per-element types) — so a
+    // heterogeneous `[lambda, task_with_a_default]` must not let indexing
+    // into the second element inherit the first's exactness. Embedding
+    // exactness in `Ty::Func` itself (an earlier version of this fix) broke
+    // exactly this case; `Scope::is_exact_lambda` doesn't, since nothing
+    // ever marks `fns[1]` as exact in the first place (issue #238).
+    #[test]
+    fn valid_indexed_task_as_value_from_mixed_list_relying_on_default_not_flagged() {
+        type_ok(
+            r#"
+task f(a: int, b: int = 2) -> int {
+  return a + b
+}
+
+task call_it() {
+  fns = [(a, b) => a + b, f]
+  x = fns[1](1)
+}
+"#,
+        );
+    }
+
+    // Same soundness requirement, reached through a `for` loop instead of
+    // indexing: the loop variable's type comes from the same approximated
+    // list-element type, and must not be treated as exact either.
+    #[test]
+    fn valid_task_as_value_from_mixed_list_for_loop_relying_on_default_not_flagged() {
+        type_ok(
+            r#"
+task f(a: int, b: int = 2) -> int {
+  return a + b
+}
+
+task call_it() {
+  fns = [(a, b) => a + b, f]
+  for g in fns {
+    x = g(1)
+  }
+}
+"#,
+        );
+    }
+
+    // An immediately-invoked lambda literal is exact straight from its own
+    // AST params — no `Scope` lookup needed, so no reassignment/laundering
+    // risk applies to it at all.
+    #[test]
+    fn error_iife_missing_arg() {
+        expect_error(
+            r#"
+task call_it() {
+  x = ((a, b) => a + b)(1)
+}
+"#,
+            "closure call: expected 2 argument(s), got 1",
+        );
+    }
+
+    // Reassigning a name away from a lambda literal must clear its exact
+    // mark — `x` ends up holding `f` (a task with a default), so `x(1)`
+    // must not be flagged.
+    #[test]
+    fn valid_reassignment_away_from_lambda_clears_exact_mark() {
+        type_ok(
+            r#"
+task f(a: int, b: int = 2) -> int {
+  return a + b
+}
+
+task call_it() {
+  x = (a, b) => a + b
+  x = f
+  y = x(1)
+}
+"#,
+        );
+    }
+
+    // The opposite direction: reassigning a name *to* a lambda literal must
+    // mark it exact even though its earlier binding wasn't.
+    #[test]
+    fn error_reassignment_to_lambda_sets_exact_mark() {
+        expect_error(
+            r#"
+task f(a: int, b: int = 2) -> int {
+  return a + b
+}
+
+task call_it() {
+  x = f
+  x = (a, b) => a + b
+  y = x(1)
+}
+"#,
+            "closure call: expected 2 argument(s), got 1",
+        );
+    }
+
     #[test]
     fn valid_out_of_order_named_args_use_matching_literal_types() {
         type_ok(

--- a/crates/keel-compiler/src/types/checker/call.rs
+++ b/crates/keel-compiler/src/types/checker/call.rs
@@ -122,6 +122,39 @@ impl Checker<'_, '_> {
         }
     }
 
+    /// Check a call whose callee resolved to a lambda literal's own
+    /// `Ty::Func` — a binding `Scope::is_exact_lambda` confirmed is exact,
+    /// or an immediately-invoked lambda literal (see both call sites).
+    /// Unlike a task, `LambdaParam` has no default, named, or
+    /// variadic/spread concept, so every parameter is required and matched
+    /// strictly by position — a call omitting one previously passed `keel
+    /// check` silently and let the interpreter's own param-binding
+    /// fallback bind it to `Value::None` (issue #238).
+    pub(crate) fn check_closure_call_arity(
+        &mut self,
+        expected: usize,
+        args: &[CallArg],
+        span: crate::lexer::Span,
+    ) {
+        // A spread arg's expanded length isn't known statically — e.g.
+        // `add(...pair)` is a valid call today when `pair` has exactly
+        // `expected` elements, since argument evaluation flattens it into
+        // positional runtime args before the closure ever binds them.
+        // Skip the check rather than reject an already-working call shape.
+        if args.iter().any(|a| a.spread) {
+            return;
+        }
+        if args.len() != expected {
+            self.err_at(
+                format!(
+                    "closure call: expected {expected} argument(s), got {}",
+                    args.len()
+                ),
+                span,
+            );
+        }
+    }
+
     /// Validate a `std/*` namespace call's arguments against its catalog
     /// entry's declared `params` (issue #222).
     ///

--- a/crates/keel-compiler/src/types/checker/expr.rs
+++ b/crates/keel-compiler/src/types/checker/expr.rs
@@ -772,7 +772,36 @@ impl Checker<'_, '_> {
                         _ => {}
                     }
                 }
-                let _ = self.infer_expr(callee, scope);
+                let callee_ty = self.infer_expr(callee, scope);
+                // A closure call (`add(1)` where `add`'s inferred type is
+                // `Ty::Func`) has no named-callee branch above to catch it —
+                // `NameKind::Local` falls straight through. `Ty::Func` alone
+                // can't tell a lambda from a task exposed as a value (which
+                // may hide a defaulted/variadic param), so trust
+                // `Scope::is_exact_lambda` instead of the type (issue #238)
+                // — it's only set for a name bound directly from a lambda
+                // literal, never laundered through a list/for-loop/etc.
+                // merge. An immediately-invoked lambda literal is exact too,
+                // straight from its own AST params, no lookup needed.
+                match &callee.as_ref().kind {
+                    Expr::Ident(name) if scope.is_exact_lambda(name) => {
+                        if let Ty::Func(param_tys, _) = &callee_ty {
+                            self.check_closure_call_arity(
+                                param_tys.len(),
+                                args,
+                                spanned.span.clone(),
+                            );
+                        }
+                    }
+                    Expr::Lambda { params, .. } => {
+                        self.check_closure_call_arity(params.len(), args, spanned.span.clone());
+                    }
+                    // Any other callee shape (a non-lambda-marked local, a
+                    // list/map index, a method call's result, …) has no
+                    // provable arity — skip rather than risk a false
+                    // positive.
+                    _ => {}
+                }
                 // Callee type not resolved — return type is also indeterminate.
                 Ty::Unknown(UnknownReason::InferenceLimitation)
             }

--- a/crates/keel-compiler/src/types/checker/stmt.rs
+++ b/crates/keel-compiler/src/types/checker/stmt.rs
@@ -611,7 +611,20 @@ impl Checker<'_, '_> {
                         inferred
                     }
                 };
-                self.bind_to_scope(binding, &bound, scope);
+                // A plain `x = (a, b) => a + b` (no annotation) binds `x`'s
+                // type straight from the lambda's own inferred `Ty::Func`,
+                // with no merge in between — the one place a call through
+                // `x` can be soundly arity-checked later (issue #238; see
+                // `Scope::is_exact_lambda`'s doc for why this can't just
+                // live on `Ty::Func` itself).
+                if ty.is_none()
+                    && let Binding::Ident(name) = binding
+                    && matches!(value.kind, Expr::Lambda { .. })
+                {
+                    scope.define_exact_lambda(name.clone(), bound);
+                } else {
+                    self.bind_to_scope(binding, &bound, scope);
+                }
             }
             Stmt::SelfAssign { field, value, .. } => {
                 // An `impl` receiver is passed by value, so a write to

--- a/crates/keel-compiler/src/types/scope.rs
+++ b/crates/keel-compiler/src/types/scope.rs
@@ -4,13 +4,31 @@
 //! vec) is pushed on block entry and popped on block exit.  Name lookup
 //! walks frames from back to front so inner bindings shadow outer ones.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::types::ty::Ty;
 
 /// Chained lexical scope: newer scopes on the back of the vec.
 pub(crate) struct Scope {
     pub(crate) frames: Vec<HashMap<String, Ty>>,
+    /// Parallel to `frames`: names whose *current* binding in that same
+    /// frame is known, with certainty, to be a lambda literal's own
+    /// inferred type — set only by [`Scope::define_exact_lambda`], cleared
+    /// for a name by every plain [`Scope::define`] (so `x = (a,b)=>a+b; x =
+    /// f` un-marks `x`).
+    ///
+    /// This can't be folded into `Ty::Func` itself (issue #238 originally
+    /// tried exactly that, via a trailing `bool`): several checker sites
+    /// approximate a merged type from just one of its sources — a list
+    /// literal's element type is its first element's type, a `for` loop's
+    /// element type is its iterable's — and any of them would silently
+    /// launder a non-exact `Ty::Func` (a named task exposed as a value,
+    /// which may hide a defaulted or variadic param) into one indistinguishable
+    /// from a real lambda's. Tracking exactness here instead, as a fact
+    /// about *this specific name's current binding* rather than data
+    /// carried on the type, means it only exists where it was explicitly
+    /// proven — nothing to launder.
+    exact_lambda: Vec<HashSet<String>>,
     /// `frames` indices at which a lambda body begins, innermost last.
     /// Lambdas are non-capturing (mirrors the HIR lowerer's identical
     /// restriction): [`Scope::get`] never looks below the innermost boundary.
@@ -21,17 +39,20 @@ impl Scope {
     pub(crate) fn new() -> Self {
         Scope {
             frames: vec![HashMap::new()],
+            exact_lambda: vec![HashSet::new()],
             lambda_boundaries: Vec::new(),
         }
     }
 
     pub(crate) fn push(&mut self) {
         self.frames.push(HashMap::new());
+        self.exact_lambda.push(HashSet::new());
     }
 
     pub(crate) fn pop(&mut self) {
         if self.frames.len() > 1 {
             self.frames.pop();
+            self.exact_lambda.pop();
         }
     }
 
@@ -49,8 +70,24 @@ impl Scope {
     }
 
     pub(crate) fn define(&mut self, name: String, ty: Ty) {
+        if let Some(s) = self.exact_lambda.last_mut() {
+            s.remove(&name);
+        }
         if let Some(f) = self.frames.last_mut() {
             f.insert(name, ty);
+        }
+    }
+
+    /// Like [`Scope::define`], but also marks `name` as exactly a lambda
+    /// literal's own type in the current frame — see `exact_lambda`'s doc.
+    /// Callers must only pass a `ty` that was itself inferred directly from
+    /// an `Expr::Lambda` node, with no intervening merge.
+    pub(crate) fn define_exact_lambda(&mut self, name: String, ty: Ty) {
+        if let Some(f) = self.frames.last_mut() {
+            f.insert(name.clone(), ty);
+        }
+        if let Some(s) = self.exact_lambda.last_mut() {
+            s.insert(name);
         }
     }
 
@@ -62,5 +99,20 @@ impl Scope {
             }
         }
         None
+    }
+
+    /// Whether `name`'s *current* binding is known to be exactly a lambda
+    /// literal's own type — see `exact_lambda`'s doc. Walks frames with the
+    /// same shadowing/lambda-boundary rules as [`Scope::get`], so a
+    /// non-lambda binding that shadows an outer lambda-marked one correctly
+    /// reads as not-exact.
+    pub(crate) fn is_exact_lambda(&self, name: &str) -> bool {
+        let boundary = self.lambda_boundaries.last().copied().unwrap_or(0);
+        for i in (boundary..self.frames.len()).rev() {
+            if self.frames[i].contains_key(name) {
+                return self.exact_lambda[i].contains(name);
+            }
+        }
+        false
     }
 }

--- a/crates/keel-compiler/src/types/ty.rs
+++ b/crates/keel-compiler/src/types/ty.rs
@@ -61,6 +61,13 @@ pub enum Ty {
         fields: Vec<(String, Ty)>,
     },
     Tuple(Vec<Ty>),
+    /// Function type. This alone can't tell a lambda from a named task
+    /// exposed as a value (`g = my_task`) — both flatten to the same
+    /// shape, but a task's `TaskSig` may hide a defaulted or variadic
+    /// param this type can't represent. A checker site that needs to know
+    /// a call's exact required arity (issue #238) can't get it from this
+    /// type; see `Scope::is_exact_lambda`, which tracks that fact
+    /// out-of-band, per-binding, instead.
     Func(Vec<Ty>, Box<Ty>),
     /// Enum type.  The second field carries resolved type arguments for
     /// generic enums (`Pair[str, int]` → `Enum("Pair", [Str, Int])`).
@@ -173,7 +180,7 @@ pub(crate) fn describe_ty(ty: &Ty) -> String {
             let s: Vec<String> = items.iter().map(describe_ty).collect();
             format!("({})", s.join(", "))
         }
-        Ty::Func(_, _) => "function".into(),
+        Ty::Func(..) => "function".into(),
         Ty::Enum(name, _) => name.clone(),
         Ty::DbConnection => "DbConnection".into(),
         Ty::Dynamic => "dynamic".into(),

--- a/crates/keel-kir/src/types.rs
+++ b/crates/keel-kir/src/types.rs
@@ -191,7 +191,7 @@ impl KirType {
             | Ty::Set(_)
             | Ty::Struct { .. }
             | Ty::Tuple(_)
-            | Ty::Func(_, _)
+            | Ty::Func(..)
             | Ty::Enum(_, _)
             | Ty::DbConnection
             | Ty::Dynamic

--- a/crates/keel-runtime/src/interpreter/call.rs
+++ b/crates/keel-runtime/src/interpreter/call.rs
@@ -49,6 +49,23 @@ impl Interpreter {
         body: &LambdaBody,
         args: Vec<CallArgValue>,
     ) -> Result<Value> {
+        // `LambdaParam` has no default value, so a missing arg is always a
+        // bug. `keel check` rejects this for a direct call expression
+        // (issue #238's checker fix), so this is defense-in-depth against
+        // reaching here at all — a callback dispatched from Rust (`map`,
+        // `reduce`, `control.retry`, …) with too few args, or a caller that
+        // skipped the checker. `<`, not `!=`: unlike a direct call
+        // expression, a builtin callback's arg count is fixed by the
+        // builtin, not the checker, and a closure may legitimately declare
+        // fewer params than it's handed — ignoring a trailing arg it
+        // doesn't need — so only a genuine shortfall is a bug.
+        if args.len() < params.len() {
+            return Err(miette::miette!(
+                "closure: expected {} argument(s), got {}",
+                params.len(),
+                args.len()
+            ));
+        }
         let mut env = Environment::new();
         for (i, p) in params.iter().enumerate() {
             let v = args.get(i).map(|a| a.value.clone()).unwrap_or(Value::None);

--- a/docs/src/release-notes.md
+++ b/docs/src/release-notes.md
@@ -24,6 +24,30 @@ Covers plain task calls, `self.task(...)` agent-task calls, generic tasks,
 and calls through a local module binding. A parameter with a declared
 default is unaffected — omitting it still uses the default.
 
+### A closure call missing a required argument is now a check-time error too
+
+Same bug as above, for a lambda call — a different code path with its own
+gap: `LambdaParam` has no default field at all, so every lambda parameter is
+unconditionally required, but `keel check` never validated a closure call's
+arity, and the interpreter's own binding fallback silently reached for
+`none`:
+
+```keel
+task main() {
+  add = (a, b) => a + b
+  add(1)   # now: closure call: expected 2 argument(s), got 1
+}
+```
+
+Only checked for a call through a local bound directly to a lambda literal,
+or an immediately-invoked one — the one shape the checker can prove is
+exact. A function value obtained any other way is left unchecked: a named
+task used as a value (`g = my_task`) or a function-typed annotation, since
+neither can rule out a hidden defaulted or variadic parameter; or an
+element pulled out of a list/`for` loop, since the checker doesn't track
+per-element provenance through those — even when every element happens to
+be a lambda.
+
 ### A named task now works everywhere a lambda does
 
 `results = emails.map(triage)` — SPEC §7's own documented "named function as

--- a/tests/integration/language/errors.rs
+++ b/tests/integration/language/errors.rs
@@ -96,6 +96,58 @@ run(A)
     );
 }
 
+// Issue #238: same bug class as #235 above, but for a lambda call — a
+// different code path (`Ty::Func`-typed callee, not a named task lookup)
+// with its own checker story, since `LambdaParam` has no default field at
+// all: every lambda parameter is unconditionally required.
+#[test]
+fn closure_call_missing_arg_is_a_check_error_not_a_silent_none() {
+    let src = r#"
+use std/io
+
+task main() {
+  add = (a, b) => a + b
+  io.show("{add(1)}")
+}
+main()
+"#;
+    let (ok, _stdout, stderr) = check_inline_output(src);
+    assert!(!ok, "expected a closure-call arity type error");
+    assert!(
+        stderr.contains("expected 2 argument(s), got 1"),
+        "error should report the expected/actual arg counts:\n{stderr}"
+    );
+}
+
+// A spread arg's expanded length isn't known at check time, so the checker
+// deliberately skips the arity check for `add(...pair)` — this reaches
+// `call_closure_inner` with too few args despite passing `keel check`,
+// exercising its own defense-in-depth guard (issue #238) rather than the
+// checker's.
+#[test]
+fn closure_call_missing_arg_via_undersized_spread_is_a_runtime_error() {
+    let src = r#"
+task main() {
+  add = (a, b) => a + b
+  pair = [1]
+  x = add(...pair)
+}
+main()
+"#;
+    let (ok, _stdout, stderr) = check_inline_output(src);
+    assert!(
+        ok,
+        "checker should not flag an undersized spread:\n{stderr}"
+    );
+
+    let (ok, _stdout, stderr) = run_inline(src, false);
+    assert!(!ok, "expected a runtime error, not a silent none binding");
+    assert!(
+        stderr.contains("expected 2 argument(s), got 1"),
+        "error should report the expected/actual arg counts:\n{stderr}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Regressions
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Same bug class as #235/#239, but for a lambda call instead of a task call: `add = (a, b) => a + b; add(1)` passed `keel check` silently, and the interpreter's own param-binding fallback quietly bound the missing argument to `none`.
- Only checked for a call whose callee is provably a lambda's own type — a local bound directly to a lambda literal, or an immediately-invoked one — via a new `Scope::is_exact_lambda` side-channel, cleared on reassignment.
- `call_closure_inner` now raises for any closure call that still reaches it with too few args (a builtin callback, or a spread argument whose expanded length the checker can't know statically) instead of silently binding `none`.

## Why `Scope::is_exact_lambda` instead of a flag on `Ty::Func`

An earlier version of this fix carried an "exact arity" bit directly on `Ty::Func`. That leaked: several checker sites approximate a merged type from just one of its sources — a list literal's element type is its first element's type, a `for` loop's element type is its iterable's — so a heterogeneous list mixing a lambda and a defaulted task,

```keel
task f(a: int, b: int = 2) -> int { return a + b }
fns = [(a, b) => a + b, f]
fns[1](1)   # legal — f's second param has a default
```

would go from silently valid to falsely rejected, because indexing `fns[1]` inherited the first element's "exact" bit regardless of which element was actually retrieved. Tracking exactness per-binding in `Scope` instead of on the type means nothing is ever exact unless explicitly proven at the one assignment site that can prove it (`x = <lambda literal>`, no annotation) — there's nothing left for an unrelated merge to launder.

```keel
task main() {
  add = (a, b) => a + b
  add(1)   # now a check error: closure call: expected 2 argument(s), got 1
}
```

## Follow-up filed separately

Named arguments to a closure call bind positionally, ignoring the name (`add(b: 2, a: 1)` silently computes as if called `add(2, 1)`) — a distinct, pre-existing bug found while investigating this one. Filed as #246, out of scope here.

## Test plan

- [x] `crates/keel-compiler/src/types/checker.rs`: unit tests for the missing/too-many-arg errors, the spread skip, task-as-value (direct and via annotation) not being falsely flagged, the mixed-list index/for-loop soundness cases, IIFE arity, and reassignment marking/unmarking exactness in both directions
- [x] `tests/integration/language/errors.rs`: end-to-end check-time test, plus a runtime-only test (undersized spread) that exercises `call_closure_inner`'s own defense-in-depth guard
- [x] Full workspace build, `cargo test --workspace`, and `cargo clippy --all-targets --features build-backend -- -D warnings` clean
- [x] `cargo test --test conformance --features build-backend` clean
- [x] Full `examples/` corpus passes `keel check`
- [x] `mdbook build` clean over updated `docs/src/release-notes.md`

Close #238